### PR TITLE
Write custom declare to fix RPC types mismatch

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -17,7 +17,8 @@ EVM_ADDRESS = (
         bytes.fromhex(EVM_PRIVATE_KEY[2:])
     ).public_key.to_checksum_address()
 )
-NETWORK = os.getenv("STARKNET_NETWORK", "starknet-devnet")
+
+NETWORK = os.getenv("STARKNET_NETWORK", "katana")
 NETWORK = (
     "testnet"
     if re.match(r".*(testnet|goerli)$", NETWORK, flags=re.I)
@@ -27,6 +28,10 @@ NETWORK = (
     if re.match(r".*(mainnet).*", NETWORK, flags=re.I)
     else "sharingan"
     if re.match(r".*(sharingan).*", NETWORK, flags=re.I)
+    else "katana"
+    if re.match(r".*(katana).*", NETWORK, flags=re.I)
+    else "madara"
+    if re.match(r".*(madara).*", NETWORK, flags=re.I)
     else "devnet"
 )
 STARKSCAN_URLS = {
@@ -35,6 +40,8 @@ STARKSCAN_URLS = {
     "testnet2": "https://testnet-2.starkscan.co",
     "devnet": "https://devnet.starkscan.co",
     "sharingan": "https://starknet-madara.netlify.app/#/explorer/query",
+    "katana": "",
+    "madara": "",
 }
 STARKSCAN_URL = STARKSCAN_URLS[NETWORK]
 
@@ -46,6 +53,8 @@ RPC_URLS = {
     "testnet2": f"https://starknet-goerli2.infura.io/v3/{os.getenv('RPC_KEY')}",
     "devnet": "http://127.0.0.1:5050/rpc",
     "sharingan": os.getenv("SHARINGAN_RPC_URL"),
+    "katana": "http://127.0.0.1:5050",
+    "madara": "http://127.0.0.1:9944",
 }
 RPC_CLIENT = FullNodeClient(node_url=RPC_URLS[NETWORK])
 
@@ -56,6 +65,8 @@ class ChainId(Enum):
     testnet2 = int.from_bytes(b"SN_GOERLI2", "big")
     devnet = int.from_bytes(b"SN_GOERLI", "big")
     sharingan = int.from_bytes(b"SN_GOERLI", "big")
+    katana = int.from_bytes(b"KATANA", "big")
+    madara = int.from_bytes(b"SN_GOERLI", "big")
 
 
 BUILD_DIR = Path("build")

--- a/scripts/deploy_kakarot.py
+++ b/scripts/deploy_kakarot.py
@@ -3,7 +3,13 @@ import logging
 from asyncio import run
 from math import ceil, log
 
-from scripts.constants import CHAIN_ID, COMPILED_CONTRACTS, EVM_ADDRESS, RPC_CLIENT
+from scripts.constants import (
+    CHAIN_ID,
+    COMPILED_CONTRACTS,
+    ETH_TOKEN_ADDRESS,
+    EVM_ADDRESS,
+    RPC_CLIENT,
+)
 from scripts.utils.starknet import (
     declare,
     deploy,
@@ -11,7 +17,6 @@ from scripts.utils.starknet import (
     dump_declarations,
     dump_deployments,
     get_declarations,
-    get_eth_contract,
     get_starknet_account,
     invoke,
 )
@@ -39,13 +44,12 @@ async def main():
 
     # %% Deployments
     class_hash = get_declarations()
-    eth = await get_eth_contract()
 
     deployments = {}
     deployments["kakarot"] = await deploy(
         "kakarot",
         account.address,  # owner
-        eth.address,  # native_token_address_
+        ETH_TOKEN_ADDRESS,  # native_token_address_
         class_hash["contract_account"],  # contract_account_class_hash_
         class_hash["externally_owned_account"],  # externally_owned_account_class_hash
         class_hash["proxy"],  # account_proxy_class_hash


### PR DESCRIPTION
Time spent on this PR: 3 days

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The deploy script relying on starknet-py doesn't work on katana (and on madara).

## What is the new behavior?

Works on katana (and most probably on all the RPC using starknet-rs).

## Other information

The blockers were:
- the `offset` type of the `entry_points_by_type` being output as `int` by `starknet-compile-deprecated` while expected as `hex` by the JSON RPC spec
- `starknet-py` mutating the `program` object while computing the class hash (adding `debug_info=None` and clearing `attributes`
- `starknet-rs` not able to handle declare as an object and not a list (should be fixed now however)