### PR TITLE
dev: remove `build-devnet` and `build-mac` make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,6 @@ build: check
 	$(MAKE) clean
 	poetry run python ./scripts/compile_kakarot.py
 
-build-mac: check
-	$(MAKE) clean
-	python ./scripts/compile_kakarot.py
-
-build-devnet:
-	docker build . --tag sayajin-labs/kakarot -f ./docker/devnet/Dockerfile
-
 check:
 	poetry lock --check
 


### PR DESCRIPTION
remove `build-devnet` and `build-mac` make commands as they are not used anywhere in the codebase.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`build-devnet` and `build-mac` make commands exist in Makefile.

Resolves #596 

## What is the new behavior?

`build-devnet` and `build-mac` make commands are removed from the Makefile.
