### PR TITLE
event key is appended w/ `evm_contract_address`

### DIFF
--- a/src/kakarot/model.cairo
+++ b/src/kakarot/model.cairo
@@ -96,7 +96,7 @@ namespace model {
     // @param events_len The events length.
     // @param events The events to be emitted upon a non-reverted stopped execution context.
     // @param create_addresses_len The create_addresses length.
-    // @param events The addresses of contracts initialized by the create(2) opcodes that are deleted if the creating context is reverted.
+    // @param create_addresses The addresses of contracts initialized by the create(2) opcodes that are deleted if the creating context is reverted.
     // @param revert_contract_state A dictionary that keeps track of the prior-to-first-write value of a contract storage key so it can be reverted to if the writing execution context reverts.
     // @param read_only if set to true, context cannot do any state modifying instructions or send ETH in the sub context.
     struct ExecutionContext {

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -98,6 +98,11 @@ class TestPlainOpcodes:
 
         async def test_should_emit_log0_with_no_data(self, plain_opcodes, addresses):
             await plain_opcodes.opcodeLog0(caller_address=addresses[0].starknet_address)
+            # the contract address is set at deploy time, we verify that event address is
+            # getting correctly set by asserting equality
+            expected_address = plain_opcodes.address
+            for log_receipt in plain_opcodes.raw_log_receipts:
+                assert log_receipt["address"] == expected_address
             assert plain_opcodes.events.Log0 == [{}]
 
         async def test_should_emit_log0_with_data(
@@ -106,23 +111,48 @@ class TestPlainOpcodes:
             await plain_opcodes.opcodeLog0Value(
                 caller_address=addresses[0].starknet_address
             )
+            # the contract address is set at deploy time, we verify that event address is
+            # getting correctly set by asserting equality
+            expected_address = plain_opcodes.address
+            for log_receipt in plain_opcodes.raw_log_receipts:
+                assert log_receipt["address"] == expected_address
             assert plain_opcodes.events.Log0Value == [{"value": event["value"]}]
 
         async def test_should_emit_log1(self, plain_opcodes, addresses, event):
             await plain_opcodes.opcodeLog1(caller_address=addresses[0].starknet_address)
+            # the contract address is set at deploy time, we verify that event address is
+            # getting correctly set by asserting equality
+            expected_address = plain_opcodes.address
+            for log_receipt in plain_opcodes.raw_log_receipts:
+                assert log_receipt["address"] == expected_address
             assert plain_opcodes.events.Log1 == [{"value": event["value"]}]
 
         async def test_should_emit_log2(self, plain_opcodes, addresses, event):
             await plain_opcodes.opcodeLog2(caller_address=addresses[0].starknet_address)
             del event["spender"]
+            # the contract address is set at deploy time, we verify that event address is
+            # getting correctly set by asserting equality
+            expected_address = plain_opcodes.address
+            for log_receipt in plain_opcodes.raw_log_receipts:
+                assert log_receipt["address"] == expected_address
             assert plain_opcodes.events.Log2 == [event]
 
         async def test_should_emit_log3(self, plain_opcodes, addresses, event):
             await plain_opcodes.opcodeLog3(caller_address=addresses[0].starknet_address)
+            # the contract address is set at deploy time, we verify that event address is
+            # getting correctly set by asserting equality
+            expected_address = plain_opcodes.address
+            for log_receipt in plain_opcodes.raw_log_receipts:
+                assert log_receipt["address"] == expected_address
             assert plain_opcodes.events.Log3 == [event]
 
         async def test_should_emit_log4(self, plain_opcodes, addresses, event):
             await plain_opcodes.opcodeLog4(caller_address=addresses[0].starknet_address)
+            # the contract address is set at deploy time, we verify that event address is
+            # getting correctly set by asserting equality
+            expected_address = plain_opcodes.address
+            for log_receipt in plain_opcodes.raw_log_receipts:
+                assert log_receipt["address"] == expected_address
             assert plain_opcodes.events.Log4 == [event]
 
     class TestCreate2:

--- a/tests/integration/test_kakarot.py
+++ b/tests/integration/test_kakarot.py
@@ -90,7 +90,8 @@ class TestKakarot:
         if events:
             assert [
                 [
-                    event.keys,
+                    # we remove the key that is used to convey the emitting kkrt evm contract
+                    event.keys[:-1],
                     event.data,
                 ]
                 for event in sorted(res.call_info.events, key=lambda x: x.order)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: .5

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Event emission is consolidated in the kkrt contract. This gives us an ability to filter out kkrt events, but we also want to be able to associate the kkrt event w/ kkrt contract.

Resolves #600 

## What is the new behavior?

- the `evm_contract_address` is appended to the event keys of every emitted event
- we test that each event log's address is equal to the address that a contract is mutated w/ at deploy time

## Other information


