### PR TITLE
Minor updates to deploy scripts after latest sharingan release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ SHARINGAN_RPC_URL=
 
 # Account used by default in all scripts
 # Prefixed accounts {NETWORK}_ will take precedeance over the default one
-MADARA_ACCOUNT_ADDRESS=0x1
+MADARA_ACCOUNT_ADDRESS=0x3
 MADARA_PRIVATE_KEY=0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d
 
 SHARINGAN_ACCOUNT_ADDRESS=

--- a/scripts/deploy_kakarot.py
+++ b/scripts/deploy_kakarot.py
@@ -6,12 +6,10 @@ from scripts.constants import (
     COMPILED_CONTRACTS,
     ETH_TOKEN_ADDRESS,
     EVM_ADDRESS,
-    NETWORK,
 )
 from scripts.utils.starknet import (
     declare,
     deploy,
-    deploy_starknet_account,
     dump_declarations,
     dump_deployments,
     get_declarations,
@@ -27,8 +25,6 @@ logger.setLevel(logging.INFO)
 # %% Main
 async def main():
     # %% Declarations
-    if NETWORK["name"] in ["madara", "sharingan"]:
-        await deploy_starknet_account(amount=100)
     account = await get_starknet_account()
     logger.info(f"ℹ️  Using account {hex(account.address)} as deployer")
 


### PR DESCRIPTION
Time spent on this PR: 0.25

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Two unrelated topics:

1. the chain_id enum has some hard-coded values that needs to be maintained
1. the deploy scripts first deploy an OZ account in madara and sharingan. This was done because no standard account was available on these networks

## What is the new behavior?

Two unrelated updates:

1. the chain_id is now taken from the network itself so it's always the right one
1. no more initial deployment of an account in madara and sharingan because an OZ account has been added in the genesis state. The util is not removed though because it is useful to have it ready in case we need to create on the fly several accounts.

## Other information
