### PR TITLE
Improve logging of starknet utils

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,5 @@ ACCOUNT_ADDRESS=
 PRIVATE_KEY=
 
 # An EVM private to define a default EOA for EVM related scripts
-EVM_PRIVATE_KEY=0x7f109a9e3b0d8ecfba9cc23a3614433ce0fa7ddcc80f2a8f10b222179a5a80d6
+# This default value is Anvil first account private key
+EVM_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -232,4 +232,7 @@ async def deploy_and_fund_evm_address(evm_address: str, amount: float):
 
 async def fund_address(address: Union[str, int], amount: float):
     starknet_address = await _get_starknet_address(address)
+    logger.info(
+        f"ℹ️  Funding EVM address {address} at Starknet address {hex(starknet_address)}"
+    )
     await _fund_starknet_address(starknet_address, amount)


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The invoke/deploy/declare functions always log with a ✅ even though the tx didn't succeed.
This "regression" has been introduced when the `wait_for_transaction` has been updated to handle
"Transaction not found" by introducing a timeout.

Currently, at the end of the timeout, even if the tx is not `ACCEPTED_ON_L2`, the logs show a misleading ✅.

## What is the new behavior?

Show ❌ when status is not ACCEPTED_ON_L2

## Other information

Usually, clients raise when a tx is not eventually `ACCEPTED_ON_L2`, while we currently don't.
I added the emoji to make the logging more accurate without changing the behavior. Actually I don't
know if we should raise, the problem coming from the fact that REJECTED tx are not found neither in
RPCs. Say it differently, NOT_RECEIVED/PENDING/REJECTED return the same "Transaction not found".
