### PR TITLE
Use Gateway provider in testnet

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -9,6 +9,7 @@ import requests
 from dotenv import load_dotenv
 from eth_keys import keys
 from starknet_py.net.full_node_client import FullNodeClient
+from starknet_py.net.gateway_client import GatewayClient
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -21,16 +22,19 @@ NETWORKS = {
         "name": "mainnet",
         "explorer_url": "https://starkscan.co",
         "rpc_url": f"https://starknet-mainnet.infura.io/v3/{os.getenv('INFURA_KEY')}",
+        "gateway": "mainnet",
     },
     "testnet": {
         "name": "testnet",
         "explorer_url": "https://testnet.starkscan.co",
         "rpc_url": f"https://starknet-goerli.infura.io/v3/{os.getenv('INFURA_KEY')}",
+        "gateway": "testnet",
     },
     "testnet2": {
         "name": "testnet2",
         "explorer_url": "https://testnet-2.starkscan.co",
         "rpc_url": f"https://starknet-goerli2.infura.io/v3/{os.getenv('INFURA_KEY')}",
+        "gateway": "testnet2",
     },
     "devnet": {
         "name": "devnet",
@@ -71,6 +75,9 @@ if NETWORK["private_key"] is None:
     NETWORK["private_key"] = os.getenv("PRIVATE_KEY")
 
 RPC_CLIENT = FullNodeClient(node_url=NETWORK["rpc_url"])
+GATEWAY_CLIENT = GatewayClient(NETWORK["gateway"]) if NETWORK.get("gateway") else None
+CLIENT = GATEWAY_CLIENT if GATEWAY_CLIENT else RPC_CLIENT
+
 try:
     response = requests.post(
         RPC_CLIENT.url,
@@ -118,5 +125,5 @@ EVM_ADDRESS = (
 if NETWORK.get("chain_id"):
     logger.info(
         f"ℹ️  Connected to CHAIN_ID {NETWORK['chain_id'].value.to_bytes(ceil(log(NETWORK['chain_id'].value, 256)), 'big')} "
-        f"with RPC {RPC_CLIENT.url}"
+        f"with {f'Gateway {GATEWAY_CLIENT.net}' if GATEWAY_CLIENT is not None else f'RPC {RPC_CLIENT.url}'}"
     )

--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -25,6 +25,7 @@ from scripts.constants import (
     NETWORK,
     RPC_CLIENT,
 )
+from scripts.utils.starknet import call as _call_starknet
 from scripts.utils.starknet import fund_address as _fund_starknet_address
 from scripts.utils.starknet import get_contract as _get_starknet_contract
 from scripts.utils.starknet import get_deployments
@@ -224,9 +225,15 @@ async def deploy_and_fund_evm_address(evm_address: str, amount: float):
     """
     Deploy an EOA linked to the given EVM address and fund it with amount ETH
     """
-    await _invoke_starknet(
-        "kakarot", "deploy_externally_owned_account", int(evm_address, 16)
-    )
+    starknet_address = (
+        await _call_starknet(
+            "kakarot", "compute_starknet_address", int(evm_address, 16)
+        )
+    ).contract_address
+    if not await _contract_exists(starknet_address):
+        await _invoke_starknet(
+            "kakarot", "deploy_externally_owned_account", int(evm_address, 16)
+        )
     await fund_address(evm_address, amount)
 
 


### PR DESCRIPTION
Time spent on this PR: 0.3

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We migrated to use only a RPC starknet provider. However, in the latest Starknet upgrade, the RPC doesn't return
the same data as the Gateway (espc. transaction status, nonce).
After spending a bit of time to hack the RPC data, I decided to just put the Gateway client for these networks where it is available.

## What is the new behavior?

Use Gateway for mainnet/testnet/testnet2

## Other information
