### PR TITLE
Fix compile_contract never add debug_info

### DIFF
--- a/scripts/utils/starknet.py
+++ b/scripts/utils/starknet.py
@@ -221,7 +221,7 @@ def compile_contract(contract):
             BUILD_DIR / f"{contract['contract_name']}.json",
             "--cairo_path",
             str(SOURCE_DIR),
-            *(["--no_debug_info"] if NETWORK != "devnet" else []),
+            *(["--no_debug_info"] if NETWORK["name"] != "devnet" else []),
             *(["--account_contract"] if contract["is_account_contract"] else []),
             *(["--disable_hint_validation"] if NETWORK["name"] == "devnet" else []),
         ],


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `compile_contract` util should add the debug info when the target network is `devnet` but it currently doesn't as the whole `NETWORK` dict is
used instead of `NETWORK["name"]` (missed change during a previous refacto).

## What is the new behavior?

`"debug_info"` added in output program

## Other information

We may want ot activate this flags for other "devnet-like" (katana, madara) but I wasn't sure about the naming, and went just for the fix.
We could though rename `devnet` in `starknet-devnet`, and create a `is_devnet` attribute in the network config, to eventually filter on this and not on the name.
