### PR TITLE
fix: fix broken asset links for katna image

### DIFF
--- a/docker/katana/scripts/download_katana.sh
+++ b/docker/katana/scripts/download_katana.sh
@@ -1,9 +1,9 @@
 # Conditionally download different binaries based on architecture
 if [ "$(uname -m)" = "x86_64" ]; then \
-      wget https://github.com/dojoengine/dojo/releases/download/nightly-efb3cf6841b679fd94204ace10147a8e84c5fc8a/dojo_nightly_linux_amd64.tar.gz
+      wget https://github.com/dojoengine/dojo/releases/download/nightly-e7abee5/dojo_nightly_linux_amd64.tar.gz
       tar -xvf dojo_nightly_linux_amd64.tar.gz -C /app/
     elif [ "$(uname -m)" = "aarch64" ]; then \
-      wget https://github.com/dojoengine/dojo/releases/download/nightly-efb3cf6841b679fd94204ace10147a8e84c5fc8a/dojo_nightly_linux_arm64.tar.gz
+      wget https://github.com/dojoengine/dojo/releases/download/nightly-e7abee5/dojo_nightly_linux_arm64.tar.gz
       tar -xvf dojo_nightly_linux_arm64.tar.gz -C /app/
     else \
       echo "Unsupported architecture: $BUILDARCH"; \


### PR DESCRIPTION
The link to the dojo assets that we are using got broken, so updating to the latest link so that the Katana image build works.

Also, will look into a better of way of permanently storing these assets.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The Katana image should be breaking because of links not working.

Resolves #615 

## What is the new behavior?

- The Katana image should be building.