### PR TITLE
Add a docker image to act as a Kakarot deployer

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -138,3 +138,4 @@ jobs:
           tags: ghcr.io/kkrt-labs/kakarot/deployer:latest
           context: .
           file: ./docker/deployer/Dockerfile
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -61,7 +61,7 @@ jobs:
           path: ./deployments/
           name: deployments
 
-  build_and_push:
+  build_and_push_devnet:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
@@ -115,3 +115,26 @@ jobs:
           context: .
           file: ./docker/katana/Dockerfile
           platforms: linux/amd64,linux/arm64
+
+  build_and_push_deployer:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ghcr.io/kkrt-labs/kakarot/deployer:latest
+          context: .
+          file: ./docker/deployer/Dockerfile

--- a/docker/deployer/Dockerfile
+++ b/docker/deployer/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.9.13
+
+# install poetry
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="$PATH:/root/.local/bin"
+RUN poetry config virtualenvs.create false
+
+# install madara swap
+WORKDIR /app/kakarot
+COPY poetry.lock .
+COPY pyproject.toml .
+COPY scripts ./scripts
+COPY README.md .
+RUN poetry install
+# split install in two steps to leverage docker cache
+COPY . .
+RUN poetry install
+
+# Build contracts
+ENV STARKNET_NETWORK=sharingan
+RUN python scripts/compile_kakarot.py
+
+# Deploy kakarot
+CMD ["python", "scripts/deploy_kakarot.py"]

--- a/docker/deployer/Dockerfile
+++ b/docker/deployer/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="$PATH:/root/.local/bin"
 RUN poetry config virtualenvs.create false
 
-# install madara swap
+# install dependencies
 WORKDIR /app/kakarot
 COPY poetry.lock .
 COPY pyproject.toml .

--- a/docker/deployer/Dockerfile
+++ b/docker/deployer/Dockerfile
@@ -17,7 +17,6 @@ COPY . .
 RUN poetry install
 
 # Build contracts
-ENV STARKNET_NETWORK=sharingan
 RUN python scripts/compile_kakarot.py
 
 # Deploy kakarot

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -73,7 +73,23 @@ NETWORKS = {
     },
 }
 
-NETWORK = NETWORKS[os.getenv("STARKNET_NETWORK", "starknet-devnet")]
+if os.getenv("STARKNET_NETWORK") is not None:
+    if NETWORKS.get(os.environ["STARKNET_NETWORK"]) is not None:
+        NETWORK = NETWORKS[os.environ["STARKNET_NETWORK"]]
+    else:
+        raise ValueError(
+            f"STARKNET_NETWORK {os.environ['STARKNET_NETWORK']} given in env variable unknown"
+        )
+else:
+    NETWORK = {
+        "name": "",
+        "rpc_url": os.getenv("RPC_URL"),
+        "explorer_url": "",
+        "devnet": False,
+        "check_interval": 6,
+        "max_wait": 30,
+    }
+
 NETWORK["account_address"] = os.environ.get(
     f"{NETWORK['name'].upper()}_ACCOUNT_ADDRESS"
 )


### PR DESCRIPTION
Time spent on this PR: 0.2

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No Docker image for just deploying the kakarot contracts to a given network.

## What is the new behavior?

Added a deployer image such that

```bash
docker run -e SHARINGAN_ACCOUNT_ADDRESS= -e SHARINGAN_PRIVATE_KEY= -e SHARINGAN_RPC_URL= deployer
```

will deploy Kakarot to the given `SHARINGAN_RPC_URL` network, using as deployer `SHARINGAN_ACCOUNT_ADDRESS` with private key `SHARINGAN_PRIVATE_KEY`.

## Other information
