### PR TITLE
Minor devX improvements

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -24,6 +24,7 @@ NETWORKS = {
         "rpc_url": f"https://starknet-mainnet.infura.io/v3/{os.getenv('INFURA_KEY')}",
         "gateway": "mainnet",
         "devnet": False,
+        "chain_id": 0x534E5F4D41494E,
     },
     "testnet": {
         "name": "testnet",
@@ -31,6 +32,7 @@ NETWORKS = {
         "rpc_url": f"https://starknet-goerli.infura.io/v3/{os.getenv('INFURA_KEY')}",
         "gateway": "testnet",
         "devnet": False,
+        "chain_id": 0x534E5F474F45524C49,
     },
     "testnet2": {
         "name": "testnet2",
@@ -38,6 +40,7 @@ NETWORKS = {
         "rpc_url": f"https://starknet-goerli2.infura.io/v3/{os.getenv('INFURA_KEY')}",
         "gateway": "testnet2",
         "devnet": False,
+        "chain_id": 0x534E5F474F45524C4932,
     },
     "starknet-devnet": {
         "name": "starknet-devnet",

--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -37,7 +37,10 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 if not NETWORK["devnet"]:
-    fetch_deployments()
+    try:
+        fetch_deployments()
+    except Exception as e:
+        logger.warn(f"Using network {NETWORK}, couldn't fetch deployment, error:\n{e}")
 KAKAROT_ADDRESS = get_deployments()["kakarot"]["address"]
 FOUNDRY_FILE = toml.loads((Path(__file__).parents[2] / "foundry.toml").read_text())
 SOLIDITY_CONTRACTS_DIR = Path(FOUNDRY_FILE["profile"]["default"]["src"])


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`chain_id` is fetch from the given RPC endpoint. Even though we now use the Gateway for mainnet/testnet/testnet2,
we then still need an RPC endpoint just for this.

`fetch_deployments` is called when network is not `devnet` and raises if no deployment is found. This is not
really necessary and was done so when we used only devnet/testnet/mainnet.

## What is the new behavior?

`chain_id` is prefilled for testnet/testnet2/mainnet
`try/catch` around `fetch_deployments`
