### PR TITLE
Do not qualify madara as devnet

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -63,7 +63,7 @@ NETWORKS = {
         "name": "madara",
         "explorer_url": "",
         "rpc_url": os.getenv("MADARA_RPC_URL"),
-        "devnet": True,
+        "devnet": False,
         "check_interval": 6,
         "max_wait": 30,
     },


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Madara is qualified as `devnet: True` in the networks config.
However, it seems that madara declare doesn't accept `debug_info` that the compile
script leaves when targeting a `devnet` network.

## What is the new behavior?

madara is not a devnet, and:

```bash
STARKNET_NETWORK=madara make deploy
```

works again.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
