### PR TITLE
Fix gateway only deployment

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from eth_keys import keys
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.gateway_client import GatewayClient
+from starknet_py.net.models.chains import StarknetChainId
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ NETWORKS = {
         "rpc_url": f"https://starknet-mainnet.infura.io/v3/{os.getenv('INFURA_KEY')}",
         "gateway": "mainnet",
         "devnet": False,
-        "chain_id": 0x534E5F4D41494E,
+        "chain_id": StarknetChainId.MAINNET,
     },
     "testnet": {
         "name": "testnet",
@@ -32,7 +33,7 @@ NETWORKS = {
         "rpc_url": f"https://starknet-goerli.infura.io/v3/{os.getenv('INFURA_KEY')}",
         "gateway": "testnet",
         "devnet": False,
-        "chain_id": 0x534E5F474F45524C49,
+        "chain_id": StarknetChainId.TESTNET,
     },
     "testnet2": {
         "name": "testnet2",
@@ -40,7 +41,7 @@ NETWORKS = {
         "rpc_url": f"https://starknet-goerli2.infura.io/v3/{os.getenv('INFURA_KEY')}",
         "gateway": "testnet2",
         "devnet": False,
-        "chain_id": 0x534E5F474F45524C4932,
+        "chain_id": StarknetChainId.TESTNET2,
     },
     "starknet-devnet": {
         "name": "starknet-devnet",
@@ -82,7 +83,7 @@ NETWORK["account_address"] = os.environ.get(
 )
 if NETWORK["account_address"] is None:
     logger.warning(
-        f"⚠️ {NETWORK['name'].upper()}_ACCOUNT_ADDRESS not set, defaulting to ACCOUNT_ADDRESS"
+        f"⚠️  {NETWORK['name'].upper()}_ACCOUNT_ADDRESS not set, defaulting to ACCOUNT_ADDRESS"
     )
     NETWORK["account_address"] = os.getenv("ACCOUNT_ADDRESS")
 NETWORK["private_key"] = os.environ.get(f"{NETWORK['name'].upper()}_PRIVATE_KEY")
@@ -94,7 +95,7 @@ if NETWORK["private_key"] is None:
 
 RPC_CLIENT = FullNodeClient(node_url=NETWORK["rpc_url"])
 GATEWAY_CLIENT = GatewayClient(NETWORK["gateway"]) if NETWORK.get("gateway") else None
-CLIENT = GATEWAY_CLIENT if GATEWAY_CLIENT else RPC_CLIENT
+CLIENT = GATEWAY_CLIENT if GATEWAY_CLIENT is not None else RPC_CLIENT
 
 try:
     response = requests.post(


### PR DESCRIPTION
Time spent on this PR: 0.15

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When trying to deploy to testnet using the gateway and no RPC, the script raises.

## What is the new behavior?

Pass, see locally tested output:

```
STARKNET_NETWORK=testnet python scripts/deploy_kakarot.py
WARNING:scripts.constants:⚠️  TESTNET_ACCOUNT_ADDRESS not set, defaulting to ACCOUNT_ADDRESS
WARNING:scripts.constants:⚠️  TESTNET_PRIVATE_KEY not set, defaulting to PRIVATE_KEY
INFO:scripts.constants:ℹ️  Connected to CHAIN_ID b'SN_GOERLI' with Gateway testnet
INFO:__main__:ℹ️  Using account 0x2e2226d64eb35c27f72beb528221884046b2ee1ef96b659aeb1351c4daad971 as deployer
INFO:scripts.utils.starknet:ℹ️  Declaring kakarot
INFO:scripts.utils.starknet:✅ kakarot class hash: 0x71aabb944873364ad1cddf2ea849bc6796c1d7022db71ce942ddb3c09a8987f
INFO:scripts.utils.starknet:ℹ️  Declaring blockhash_registry
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring contract_account
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring externally_owned_account
INFO:scripts.utils.starknet:✅ externally_owned_account class hash: 0x5f855e35cbf845982b47a8dee1ba47a40eecf48b807cf8c36615111fc3885f5
INFO:scripts.utils.starknet:ℹ️  Declaring proxy
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring EVM
INFO:scripts.utils.starknet:✅ EVM class hash: 0xd75b64d46d88182e63a0a321ad839e84f8f0989874fed95591246ef65f167c
INFO:scripts.utils.starknet:ℹ️  Deploying kakarot
INFO:scripts.utils.starknet:✅ kakarot deployed at: 0x4d17fbd40eb6efecf534ba846f5e4175719c1ec710d1346154b9198fd8b8536
INFO:scripts.utils.starknet:ℹ️  Deploying blockhash_registry
INFO:scripts.utils.starknet:✅ blockhash_registry deployed at: 0x490659e82ed6e3f7695a4c7a27540a2c30ac5d2830d5e14cefa5a137415e952
INFO:scripts.utils.starknet:ℹ️  Deploying EVM
INFO:scripts.utils.starknet:✅ EVM deployed at: 0x1920a75ceb58d15c93868065166425f8e855499d3c4a7572e987df6e0e54713
INFO:__main__:⏳ Configuring Contracts...
INFO:scripts.utils.starknet:ℹ️  Invoking kakarot.set_blockhash_registry([2064378721502023377180588092946576422272224031199955676050778932035515181394])
INFO:scripts.utils.starknet:✅ kakarot.set_blockhash_registry invoked at tx: 0x44ffd0e62bbde3e9989e5865f70e78fccdb78919f38e882e09e674de3c915d4
INFO:__main__:✅ Configuration Complete
INFO:__main__:ℹ️  Found default EVM address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to deploy an EOA for
```

## Other information

Tested for testnet and testnet2 and ✅