### PR TITLE
Fix finalize_context breaking when caller is EOA

### DIFF
--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -12,8 +12,8 @@ from starkware.cairo.common.math import assert_le, assert_nn
 from starkware.cairo.common.math_cmp import is_le, is_not_zero, is_nn
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.registers import get_label_location
-from starkware.starknet.common.syscalls import emit_event
 from starkware.cairo.common.uint256 import Uint256
+from starkware.starknet.common.syscalls import emit_event, get_caller_address
 
 // Internal dependencies
 from utils.utils import Helpers
@@ -949,5 +949,23 @@ namespace ExecutionContext {
         }
 
         return ();
+    }
+
+    // @notice Check if starknet contract address is an EOA
+    // @dev use syscall to get caller address and compare it to the starknet contract address
+    // @param self The pointer to the execution context
+    // @return felt 1 if starknet contract address is an EOA, 0 otherwise
+    func is_caller_eoa{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(self: model.ExecutionContext*) -> felt {
+        let (address) = get_caller_address();
+        if (address == self.starknet_contract_address) {
+            return TRUE;
+        } else {
+            return FALSE;
+        }
     }
 }

--- a/src/kakarot/instructions.cairo
+++ b/src/kakarot/instructions.cairo
@@ -14,6 +14,7 @@ from starkware.cairo.common.registers import get_ap
 from starkware.cairo.common.registers import get_label_location
 from starkware.cairo.common.uint256 import Uint256
 
+
 // Internal dependencies
 from kakarot.execution_context import ExecutionContext
 from kakarot.instructions.block_information import BlockInformation
@@ -630,7 +631,10 @@ namespace EVMInstructions {
                 let (bytecode_len) = IAccount.bytecode_len(
                     contract_address=ctx.starknet_contract_address
                 );
-                if (bytecode_len == 0) {
+                let is_eao = ExecutionContext.is_caller_eoa(self=ctx);
+                // If the starknet contract of the execution context has no bytecode and is not an EOA,
+                // then it means we are at the end of a CREATE/CREATE2 opcode.
+                if (bytecode_len + is_eao == 0) {
                     let ctx = CreateHelper.finalize_calling_context(ctx);
                     return run(ctx=ctx);
                 } else {
@@ -673,4 +677,5 @@ namespace EVMInstructions {
         }
         return ();
     }
+
 }

--- a/tests/integration/solidity_contracts/PlainOpcodes/Safe.sol
+++ b/tests/integration/solidity_contracts/PlainOpcodes/Safe.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.13;
+
+contract Safe {
+    receive() external payable {}
+
+    function withdrawTransfer() external {
+        payable(msg.sender).transfer(address(this).balance);
+    }
+
+    function withdrawCall() external {
+        (bool success,) = msg.sender.call{value: address(this).balance}("");
+        require(success, "Withdrawal failed");
+    }
+
+    function balance() public view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function deposit() public payable {}
+}

--- a/tests/integration/solidity_contracts/PlainOpcodes/conftest.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/conftest.py
@@ -23,3 +23,12 @@ async def plain_opcodes(deploy_solidity_contract, owner, counter):
         counter.evm_contract_address,
         caller_eoa=owner,
     )
+
+
+@pytest_asyncio.fixture(scope="module")
+async def safe(deploy_solidity_contract, owner):
+    return await deploy_solidity_contract(
+        "PlainOpcodes",
+        "Safe",
+        caller_eoa=owner,
+    )

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
@@ -6,12 +6,23 @@ import pytest
 @pytest.mark.usefixtures("starknet_snapshot")
 class TestSafe:
     class TestReceive:
-        async def test_should_receive_eth(self, safe, owner):
-            await safe.deposit(value=1e9, caller_address=owner.starknet_address)
+        async def test_should_receive_eth(self, safe, owner, eth):
+            await eth.mint(owner.starknet_address, (int(1e9), 0)).execute(caller_address=owner.starknet_address)
+            await safe.deposit(value=int(1e9), caller_address=owner.starknet_address)
             assert await safe.balance() == 1e9
 
-    class TestWithdraw:
-        async def test_should_withdraw_eth(self, safe, owner):
-            await safe.receive(value=1e9)
-            await safe.withdraw(caller_address=owner.starknet_address)
+    class TestWithdrawTransfer:
+        async def test_should_withdraw_transfer_eth(self, safe, owner, eth):
+            await eth.mint(owner.starknet_address, (int(1e9), 0)).execute(caller_address=owner.starknet_address)
+            await safe.deposit(value=int(1e9), caller_address=owner.starknet_address)
+            await safe.withdrawTransfer(caller_address=owner.starknet_address)
             assert await safe.balance() == 0
+            assert (await eth.balanceOf(owner.starknet_address).call()).result.balance.low == 1e9
+
+    class TestWithdrawCall:
+        async def test_should_withdraw_call_eth(self, safe, owner, eth):
+            await eth.mint(owner.starknet_address, (int(1e9), 0)).execute(caller_address=owner.starknet_address)
+            await safe.deposit(value=int(1e9), caller_address=owner.starknet_address)
+            await safe.withdrawCall(caller_address=owner.starknet_address)
+            assert await safe.balance() == 0
+            assert (await eth.balanceOf(owner.starknet_address).call()).result.balance.low == 1e9

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.Counter
+@pytest.mark.usefixtures("starknet_snapshot")
+class TestSafe:
+    class TestReceive:
+        async def test_should_receive_eth(self, safe, owner):
+            await safe.deposit(value=1e9, caller_address=owner.starknet_address)
+            assert await safe.balance() == 1e9
+
+    class TestWithdraw:
+        async def test_should_withdraw_eth(self, safe, owner):
+            await safe.receive(value=1e9)
+            await safe.withdraw(caller_address=owner.starknet_address)
+            assert await safe.balance() == 0


### PR DESCRIPTION
Time spent on this PR:

Hacker house :)

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

Breaks when EOA calls `withdraw()` because it thinks it's the end of a CREATE opcode. 

## What is the new behavior?

The `func run()` checks if the starknet contract address has 0 bytecode length and is not an EAO, then it follows the CREATE opcode if/else branch. Otherwise, it finalizes the call. 

