### PR TITLE
feat: remove nonce management, use starknet  nonce

### DIFF
--- a/src/kakarot/accounts/contract/contract_account.cairo
+++ b/src/kakarot/accounts/contract/contract_account.cairo
@@ -88,21 +88,3 @@ func is_initialized{
 }() -> (is_initialized: felt) {
     return ContractAccount.is_initialized();
 }
-
-// @notice This function is used to read the nonce from storage
-// @return nonce: The current nonce of the contract account
-@view
-func get_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (nonce: felt) {
-    return Accounts.get_nonce();
-}
-
-// @notice This function increases the contract accounts nonce by 1
-// @return nonce: The new nonce of the contract account
-@external
-func increment_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-    nonce: felt
-) {
-    Ownable.assert_only_owner();
-    Accounts.increment_nonce();
-    return Accounts.get_nonce();
-}

--- a/src/kakarot/accounts/eoa/externally_owned_account.cairo
+++ b/src/kakarot/accounts/eoa/externally_owned_account.cairo
@@ -136,25 +136,3 @@ func bytecode_len{
 }() -> (len: felt) {
     return (len=0);
 }
-
-// @notice This function is used to read the nonce from storage
-// @return nonce: The current nonce of the contract account
-@view
-func get_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (nonce: felt) {
-    return Accounts.get_nonce();
-}
-
-// @notice This function increases the contract accounts nonce by 1
-// @dev Currently external for testing purposes. Otherwise would not be needed.
-// @return nonce: The new nonce of the contract account
-@external
-func increment_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-    nonce: felt
-) {
-    let (caller) = get_caller_address();
-    with_attr error_message("ExternallyOwnedAccount: nonce can only be incremented by self") {
-        assert caller = 0;
-    }
-    Accounts.increment_nonce();
-    return Accounts.get_nonce();
-}

--- a/src/kakarot/accounts/eoa/library.cairo
+++ b/src/kakarot/accounts/eoa/library.cairo
@@ -1,7 +1,7 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.starknet.common.syscalls import CallContract
+from starkware.starknet.common.syscalls import CallContract, get_tx_info
 from starkware.cairo.common.uint256 import Uint256, uint256_not
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import TRUE, FALSE
@@ -91,9 +91,10 @@ namespace ExternallyOwnedAccount {
         }
 
         let (address) = evm_address.read();
-        let (nonce) = Accounts.get_nonce();
+        let (tx_info) = get_tx_info();
+
         EthTransaction.validate(
-            address, nonce, [call_array].data_len, calldata + [call_array].data_offset
+            address, tx_info.nonce, [call_array].data_len, calldata + [call_array].data_offset
         );
 
         return validate(
@@ -152,7 +153,6 @@ namespace ExternallyOwnedAccount {
             response + return_data_len,
         );
 
-        Accounts.increment_nonce();
         return (response_len=return_data_len + response_len);
     }
 }

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -97,14 +97,6 @@ namespace Accounts {
         return (account_address=account_address);
     }
 
-    // @notice This function is used to read the nonce from storage
-    // @return nonce: The current nonce of the contract account
-    func get_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-        nonce: felt
-    ) {
-        return nonce.read();
-    }
-
     // @notice This function increases the accounts nonce by 1
     // @return nonce: The incremented nonce of the contract account
     func increment_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -97,13 +97,4 @@ namespace Accounts {
         return (account_address=account_address);
     }
 
-    // @notice This function increases the accounts nonce by 1
-    // @return nonce: The incremented nonce of the contract account
-    func increment_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-        nonce: felt
-    ) {
-        let (current_nonce: felt) = nonce.read();
-        nonce.write(current_nonce + 1);
-        return (nonce=current_nonce + 1);
-    }
 }

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -20,7 +20,7 @@ from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.math_cmp import is_le, is_not_zero, is_nn
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.uint256 import Uint256
-from starkware.starknet.common.syscalls import deploy as deploy_syscall, get_contract_address
+from starkware.starknet.common.syscalls import deploy as deploy_syscall, get_contract_address, get_tx_info
 
 // Internal dependencies
 from kakarot.constants import contract_account_class_hash, native_token_address, Constants
@@ -811,13 +811,11 @@ namespace CreateHelper {
         // so we use popped_len to derive the way we should handle
         // the creation of evm addresses
         if (popped_len != 4) {
-            let (nonce) = IContractAccount.get_nonce(ctx.starknet_contract_address);
+            let (tx_info) = get_tx_info();
 
             let (evm_contract_address) = CreateHelper.get_create_address(
-                ctx.evm_contract_address, nonce
+                ctx.evm_contract_address, tx_info.nonce
             );
-
-            let (nonce) = IContractAccount.increment_nonce(ctx.starknet_contract_address);
 
             let (contract_account_class_hash_) = contract_account_class_hash.read();
             let (starknet_contract_address) = Accounts.create(

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -57,11 +57,6 @@ namespace IAccount {
     func bytecode() -> (bytecode_len: felt, bytecode: felt*) {
     }
 
-    func get_nonce() -> (nonce: felt) {
-    }
-
-    func increment_nonce() -> (nonce: felt) {
-    }
 }
 
 @contract_interface
@@ -75,11 +70,6 @@ namespace IContractAccount {
     func write_storage(key: Uint256, value: Uint256) {
     }
 
-    func get_nonce() -> (nonce: felt) {
-    }
-
-    func increment_nonce() -> (nonce: felt) {
-    }
 }
 
 @contract_interface

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -232,8 +232,8 @@ namespace Kakarot {
         alloc_locals;
         let (caller_address) = get_caller_address();
         let (sender_evm_address) = IAccount.get_evm_address(caller_address);
-        let (nonce) = IAccount.get_nonce(caller_address);
-        let (evm_contract_address) = CreateHelper.get_create_address(sender_evm_address, nonce);
+        let (tx_info) = get_tx_info();
+        let (evm_contract_address) = CreateHelper.get_create_address(sender_evm_address, tx_info.nonce);
         let (class_hash) = contract_account_class_hash.read();
         let (starknet_contract_address) = Accounts.create(class_hash, evm_contract_address);
         let (empty_array: felt*) = alloc();

--- a/tests/integration/accounts/test_contract_account.py
+++ b/tests/integration/accounts/test_contract_account.py
@@ -91,27 +91,3 @@ class TestContractAccount:
                 )
                 == "Uint256(low=340282366920938463463374607431768211455, high=340282366920938463463374607431768211455)"
             )
-
-    class TestNonce:
-        async def test_should_increment_nonce(
-            self, contract_account: StarknetContract, kakarot
-        ):
-            # Get current contract account nonce
-            initial_nonce = (await contract_account.get_nonce().call()).result.nonce
-
-            # Increment nonce
-            await contract_account.increment_nonce().execute(
-                caller_address=kakarot.contract_address
-            )
-
-            # Get new nonce
-            assert (
-                initial_nonce + 1
-                == (await contract_account.get_nonce().call()).result.nonce
-            )
-
-        async def test_should_raise_when_caller_is_not_kakarot(
-            self, contract_account: StarknetContract
-        ):
-            with kakarot_error():
-                await contract_account.increment_nonce().execute(caller_address=1)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,7 +60,7 @@ async def addresses(starknet, kakarot, externally_owned_account_class) -> List[W
 
     # Randomly generated private keys
     private_keys = [predefined_private_key] + [
-        generate_random_private_key(seed=i) for i in range(3)
+        generate_random_private_key(seed=i) for i in range(15)
     ]
 
     wallets = []

--- a/tests/integration/solidity_contracts/PlainOpcodes/conftest.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/conftest.py
@@ -1,34 +1,51 @@
 import pytest_asyncio
 
 
-@pytest_asyncio.fixture(scope="module")
-async def counter(deploy_solidity_contract, owner):
-    return await deploy_solidity_contract("PlainOpcodes", "Counter", caller_eoa=owner)
+@pytest_asyncio.fixture(scope="session")
+def counter_deployer(addresses):
+    return addresses[1]
+
+@pytest_asyncio.fixture(scope="session")
+def caller_deployer(addresses):
+    return addresses[2]
+
+@pytest_asyncio.fixture(scope="session")
+def plain_opcodes_deployer(addresses):
+    return addresses[3]
+
+@pytest_asyncio.fixture(scope="session")
+def safe_deployer(addresses):
+    return addresses[4]
 
 
-@pytest_asyncio.fixture(scope="module")
-async def caller(deploy_solidity_contract, owner):
+@pytest_asyncio.fixture(scope="package")
+async def counter(deploy_solidity_contract, counter_deployer):
+    return await deploy_solidity_contract("PlainOpcodes", "Counter", caller_eoa=counter_deployer)
+
+
+@pytest_asyncio.fixture(scope="package")
+async def caller(deploy_solidity_contract, caller_deployer):
     return await deploy_solidity_contract(
         "PlainOpcodes",
         "Caller",
-        caller_eoa=owner,
+        caller_eoa=caller_deployer,
     )
 
 
-@pytest_asyncio.fixture(scope="module")
-async def plain_opcodes(deploy_solidity_contract, owner, counter):
+@pytest_asyncio.fixture(scope="package")
+async def plain_opcodes(deploy_solidity_contract, plain_opcodes_deployer, counter):
     return await deploy_solidity_contract(
         "PlainOpcodes",
         "PlainOpcodes",
         counter.evm_contract_address,
-        caller_eoa=owner,
+        caller_eoa=plain_opcodes_deployer,
     )
 
 
-@pytest_asyncio.fixture(scope="module")
-async def safe(deploy_solidity_contract, owner):
+@pytest_asyncio.fixture(scope="package")
+async def safe(deploy_solidity_contract, safe_deployer):
     return await deploy_solidity_contract(
         "PlainOpcodes",
         "Safe",
-        caller_eoa=owner,
+        caller_eoa=safe_deployer
     )

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_counter.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_counter.py
@@ -12,32 +12,32 @@ class TestCounter:
             assert await counter.count() == 0
 
     class TestInc:
-        async def test_should_increase_count(self, counter, addresses):
-            await counter.inc(caller_address=addresses[1].starknet_address)
+        async def test_should_increase_count(self, counter, counter_deployer):
+            await counter.inc(caller_address=counter_deployer.starknet_address)
             assert await counter.count() == 1
 
     class TestDec:
-        async def test_should_raise_when_count_is_0(self, counter, addresses):
+        async def test_should_raise_when_count_is_0(self, counter, counter_deployer):
             with kakarot_error("count should be strictly greater than 0"):
-                await counter.dec(caller_address=addresses[1].starknet_address)
+                await counter.dec(caller_address=counter_deployer.starknet_address)
 
-        async def test_should_decrease_count(self, counter, addresses):
-            await counter.inc(caller_address=addresses[1].starknet_address)
-            await counter.dec(caller_address=addresses[1].starknet_address)
+        async def test_should_decrease_count(self, counter, counter_deployer):
+            await counter.inc(caller_address=counter_deployer.starknet_address)
+            await counter.dec(caller_address=counter_deployer.starknet_address)
             assert await counter.count() == 0
 
-        async def test_should_decrease_count_unchecked(self, counter, addresses):
-            await counter.inc(caller_address=addresses[1].starknet_address)
-            await counter.decUnchecked(caller_address=addresses[1].starknet_address)
+        async def test_should_decrease_count_unchecked(self, counter, counter_deployer):
+            await counter.inc(caller_address=counter_deployer.starknet_address)
+            await counter.decUnchecked(caller_address=counter_deployer.starknet_address)
             assert await counter.count() == 0
 
-        async def test_should_decrease_count_in_place(self, counter, addresses):
-            await counter.inc(caller_address=addresses[1].starknet_address)
-            await counter.decInPlace(caller_address=addresses[1].starknet_address)
+        async def test_should_decrease_count_in_place(self, counter, counter_deployer):
+            await counter.inc(caller_address=counter_deployer.starknet_address)
+            await counter.decInPlace(caller_address=counter_deployer.starknet_address)
             assert await counter.count() == 0
 
     class TestReset:
-        async def test_should_set_count_to_0(self, counter, addresses):
-            await counter.inc(caller_address=addresses[1].starknet_address)
-            await counter.reset(caller_address=addresses[1].starknet_address)
+        async def test_should_set_count_to_0(self, counter, counter_deployer):
+            await counter.inc(caller_address=counter_deployer.starknet_address)
+            await counter.reset(caller_address=counter_deployer.starknet_address)
             assert await counter.count() == 0

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -26,9 +26,9 @@ class TestPlainOpcodes:
             self,
             counter,
             plain_opcodes,
-            addresses,
+            counter_deployer,
         ):
-            await plain_opcodes.opcodeCall(caller_address=addresses[1].starknet_address)
+            await plain_opcodes.opcodeCall(caller_address=counter_deployer.starknet_address)
             assert await counter.count() == 1
 
     class TestBlockhash:
@@ -146,8 +146,8 @@ class TestPlainOpcodes:
                 assert log_receipt["address"] == expected_address
             assert plain_opcodes.events.Log3 == [event]
 
-        async def test_should_emit_log4(self, plain_opcodes, addresses, event):
-            await plain_opcodes.opcodeLog4(caller_address=addresses[0].starknet_address)
+        async def test_should_emit_log4(self, plain_opcodes, plain_opcodes_deployer, event):
+            await plain_opcodes.opcodeLog4(caller_address=plain_opcodes_deployer.starknet_address)
             # the contract address is set at deploy time, we verify that event address is
             # getting correctly set by asserting equality
             expected_address = plain_opcodes.address
@@ -160,7 +160,7 @@ class TestPlainOpcodes:
             self,
             plain_opcodes,
             counter,
-            addresses,
+            plain_opcodes_deployer,
             get_starknet_address,
             get_solidity_contract,
         ):
@@ -168,7 +168,7 @@ class TestPlainOpcodes:
             evm_address = await plain_opcodes.create2(
                 bytecode=counter.constructor().data_in_transaction,
                 salt=salt,
-                caller_address=addresses[0].starknet_address,
+                caller_address=plain_opcodes_deployer.starknet_address,
             )
             starknet_address = get_starknet_address(salt)
             deployed_counter = get_solidity_contract(
@@ -259,6 +259,6 @@ class TestPlainOpcodes:
 
     class TestLoop:
         @pytest.mark.parametrize("steps", [0, 1, 2, 10])
-        async def test_loop_should_write_to_storage(self, plain_opcodes, owner, steps):
-            await plain_opcodes.testLoop(steps, caller_address=owner.starknet_address)
+        async def test_loop_should_write_to_storage(self, plain_opcodes, plain_opcodes_deployer, steps):
+            await plain_opcodes.testLoop(steps, caller_address=plain_opcodes_deployer.starknet_address)
             assert await plain_opcodes.loopValue() == steps

--- a/tests/integration/solidity_contracts/Solmate/test_erc20.py
+++ b/tests/integration/solidity_contracts/Solmate/test_erc20.py
@@ -8,16 +8,19 @@ from tests.utils.helpers import ec_sign, get_approval_digest
 TEST_SUPPLY = 10**18
 TEST_AMOUNT = int(0.9 * 10**18)
 
+@pytest_asyncio.fixture(scope="session")
+def erc_20_deployer(addresses):
+    return addresses[5]
 
 @pytest_asyncio.fixture(scope="module")
-async def erc_20(deploy_solidity_contract, owner):
+async def erc_20(deploy_solidity_contract, erc_20_deployer):
     return await deploy_solidity_contract(
         "Solmate",
         "ERC20",
         "Kakarot Token",
         "KKT",
         18,
-        caller_eoa=owner,
+        caller_eoa=erc_20_deployer,
     )
 
 

--- a/tests/integration/solidity_contracts/Solmate/test_erc721.py
+++ b/tests/integration/solidity_contracts/Solmate/test_erc721.py
@@ -5,51 +5,70 @@ from eth_utils import keccak
 from tests.utils.constants import ZERO_ADDRESS
 from tests.utils.errors import kakarot_error
 
+@pytest_asyncio.fixture(scope="session")
+def erc_721_deployer(addresses):
+    return addresses[6]
+
+@pytest_asyncio.fixture(scope="session")
+def erc_721_recepient_deployer(addresses):
+    return addresses[7]
+
+@pytest_asyncio.fixture(scope="session")
+def erc_721_reverting_recipient_deployer(addresses):
+    return addresses[8]
+
+@pytest_asyncio.fixture(scope="session")
+def erc_721_recipient_with_wrong_return_data_deployer(addresses):
+    return addresses[9]
+
+@pytest_asyncio.fixture(scope="session")
+def erc_721_non_recipient_deployer(addresses):
+    return addresses[10]
 
 @pytest_asyncio.fixture(scope="module")
-async def erc_721(deploy_solidity_contract, owner):
+async def erc_721(deploy_solidity_contract, erc_721_deployer):
     return await deploy_solidity_contract(
         "Solmate",
         "MockERC721",
         "Kakarot NFT",
         "KKNFT",
-        caller_eoa=owner,
+        caller_eoa=erc_721_deployer,
     )
 
 
 @pytest_asyncio.fixture(scope="module")
-async def erc_721_recipient(deploy_solidity_contract, owner):
+async def erc_721_recipient(deploy_solidity_contract, erc_721_recepient_deployer):
     return await deploy_solidity_contract(
         "Solmate",
         "ERC721Recipient",
-        caller_eoa=owner,
+        caller_eoa=erc_721_recepient_deployer,
     )
 
 
 @pytest_asyncio.fixture(scope="module")
-async def erc_721_reverting_recipient(deploy_solidity_contract, owner):
+async def erc_721_reverting_recipient(deploy_solidity_contract, erc_721_reverting_recipient_deployer):
     return await deploy_solidity_contract(
         "Solmate",
         "RevertingERC721Recipient",
-        caller_eoa=owner,
+        caller_eoa=erc_721_reverting_recipient_deployer,
     )
 
 
 @pytest_asyncio.fixture(scope="module")
-async def erc_721_recipient_with_wrong_return_data(deploy_solidity_contract, owner):
+async def erc_721_recipient_with_wrong_return_data(deploy_solidity_contract, erc_721_recipient_with_wrong_return_data_deployer):
     return await deploy_solidity_contract(
         "Solmate",
         "WrongReturnDataERC721Recipient",
-        caller_eoa=owner,
+        caller_eoa=erc_721_recipient_with_wrong_return_data_deployer,
     )
 
 
 @pytest_asyncio.fixture(scope="module")
-async def erc_721_non_recipient(deploy_solidity_contract, owner):
+async def erc_721_non_recipient(deploy_solidity_contract, erc_721_non_recipient_deployer):
     return await deploy_solidity_contract(
         "Solmate",
         "NonERC721Recipient",
-        caller_eoa=owner,
+        caller_eoa=erc_721_non_recipient_deployer,
     )
 
 

--- a/tests/integration/solidity_contracts/UniswapV2/conftest.py
+++ b/tests/integration/solidity_contracts/UniswapV2/conftest.py
@@ -5,42 +5,58 @@ import pytest_asyncio
 TOTAL_SUPPLY = 10000 * 10**18
 
 
+@pytest_asyncio.fixture(scope="session")
+async def token_a_deployer(addresses):
+    return addresses[11]
+
+@pytest_asyncio.fixture(scope="session")
+async def token_b_deployer(addresses):
+    return addresses[12]
+
+@pytest_asyncio.fixture(scope="session")
+async def uniswap_factory_deployer(addresses):
+    return addresses[13]
+
+@pytest_asyncio.fixture(scope="session")
+async def uniswap_pair_deployer(addresses):
+    return addresses[14]
+
 @pytest_asyncio.fixture(scope="module")
 async def token_a(
     deploy_solidity_contract: Callable,
-    owner,
+    token_a_deployer,
 ):
     return await deploy_solidity_contract(
         "UniswapV2",
         "ERC20",
         TOTAL_SUPPLY,
-        caller_eoa=owner,
+        caller_eoa=token_a_deployer,
     )
 
 
 @pytest_asyncio.fixture(scope="module")
 async def token_b(
     deploy_solidity_contract: Callable,
-    owner,
+    token_b_deployer,
 ):
     return await deploy_solidity_contract(
         "UniswapV2",
         "ERC20",
         TOTAL_SUPPLY,
-        caller_eoa=owner,
+        caller_eoa=token_b_deployer,
     )
 
 
 @pytest_asyncio.fixture(scope="module")
 async def factory(
     deploy_solidity_contract: Callable,
-    owner,
+    uniswap_factory_deployer,
 ):
     return await deploy_solidity_contract(
         "UniswapV2",
         "UniswapV2Factory",
-        owner.address,
-        caller_eoa=owner,
+        uniswap_factory_deployer.address,
+        caller_eoa=uniswap_factory_deployer,
     )
 
 
@@ -50,7 +66,7 @@ async def pair(
     token_a,
     token_b,
     factory,
-    owner,
+    uniswap_pair_deployer,
 ):
     # TODO: the fixture should use factory.createPair but this currently fails
     # TODO: with OUT_OF_RESOURCES so we do it via an EOA for the sake of running
@@ -58,7 +74,7 @@ async def pair(
     _pair = await deploy_solidity_contract(
         "UniswapV2",
         "UniswapV2Pair",
-        caller_eoa=owner,
+        caller_eoa=uniswap_pair_deployer,
     )
     token_0, token_1 = (
         (token_a, token_b)

--- a/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_erc20.py
+++ b/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_erc20.py
@@ -18,20 +18,21 @@ TEST_AMOUNT = 10 * 10**18
 @pytest.mark.usefixtures("starknet_snapshot")
 class TestUniswapV2ERC20:
     class TestDeploy:
-        async def test_should_set_constants(self, token_a, owner):
+        async def test_should_set_constants(self, token_a, token_a_deployer):
             name = await token_a.name()
             assert name == "Uniswap V2"
             assert await token_a.symbol() == "UNI-V2"
             assert await token_a.decimals() == 18
             assert await token_a.totalSupply() == TOTAL_SUPPLY
-            assert await token_a.balanceOf(owner.address) == TOTAL_SUPPLY
+            assert await token_a.balanceOf(token_a_deployer.address) == TOTAL_SUPPLY
             assert await token_a.DOMAIN_SEPARATOR() == get_domain_separator(
                 name, token_a.evm_contract_address
             )
             assert await token_a.PERMIT_TYPEHASH() == PERMIT_TYPEHASH
 
     class TestApprove:
-        async def test_should_set_allowance(self, token_a, owner, other):
+        async def test_should_set_allowance(self, token_a, token_a_deployer, other):
+            owner = token_a_deployer
             await token_a.approve(
                 other.address,
                 TEST_AMOUNT,
@@ -49,8 +50,9 @@ class TestUniswapV2ERC20:
 
     class TestTransfer:
         async def test_should_transfer_token_when_signer_is_owner(
-            self, token_a, owner, other
+            self, token_a, token_a_deployer, other
         ):
+            owner = token_a_deployer
             await token_a.transfer(
                 other.address,
                 TEST_AMOUNT,
@@ -67,13 +69,13 @@ class TestUniswapV2ERC20:
             assert await token_a.balanceOf(other.address) == TEST_AMOUNT
 
         async def test_should_fail_when_amount_is_greater_than_balance_and_balance_not_zero(
-            self, token_a, owner, other
+            self, token_a, token_a_deployer, other
         ):
             with kakarot_error():
                 await token_a.transfer(
                     other.address,
                     TOTAL_SUPPLY + 1,
-                    caller_address=owner.starknet_address,
+                    caller_address=token_a_deployer.starknet_address,
                 )
 
         async def test_should_fail_when_amount_is_greater_than_balance_and_balance_zero(
@@ -88,8 +90,9 @@ class TestUniswapV2ERC20:
 
     class TestTransferFrom:
         async def test_should_transfer_token_when_signer_is_approved(
-            self, token_a, owner, other
+            self, token_a, token_a_deployer, other
         ):
+            owner = token_a_deployer
             await token_a.approve(
                 other.address,
                 TEST_AMOUNT,
@@ -110,8 +113,9 @@ class TestUniswapV2ERC20:
             assert await token_a.balanceOf(other.address) == TEST_AMOUNT
 
         async def test_should_transfer_token_when_signer_is_approved_max_uint(
-            self, token_a, owner, other
+            self, token_a, token_a_deployer, other
         ):
+            owner = token_a_deployer
             await token_a.approve(
                 other.address,
                 MAX_INT,

--- a/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_factory.py
+++ b/tests/integration/solidity_contracts/UniswapV2/test_uniswap_v2_factory.py
@@ -13,7 +13,8 @@ TEST_ADDRESSES = [
 @pytest.mark.usefixtures("starknet_snapshot")
 class TestUniswapV2Factory:
     class TestDeploy:
-        async def test_should_set_constants(self, factory, owner):
+        async def test_should_set_constants(self, factory, uniswap_factory_deployer):
+            owner = uniswap_factory_deployer
             assert await factory.feeTo() == f"0x{0:040x}"
             assert await factory.feeToSetter() == owner.address
             assert await factory.allPairsLength() == 0
@@ -84,7 +85,8 @@ class TestUniswapV2Factory:
                     other.address, caller_address=other.starknet_address
                 )
 
-        async def test_should_set_fee_to_owner(self, factory, owner):
+        async def test_should_set_fee_to_owner(self, factory, uniswap_factory_deployer):
+            owner = uniswap_factory_deployer
             await factory.setFeeTo(owner.address, caller_address=owner.starknet_address)
             assert await factory.feeTo() == owner.address
 
@@ -96,8 +98,9 @@ class TestUniswapV2Factory:
                 )
 
         async def test_should_set_fee_setter_to_other_and_transfer_permission(
-            self, factory, owner, other
+            self, factory, uniswap_factory_deployer, other
         ):
+            owner = uniswap_factory_deployer
             await factory.setFeeToSetter(
                 other.address, caller_address=owner.starknet_address
             )

--- a/tests/integration/solidity_contracts/conftest.py
+++ b/tests/integration/solidity_contracts/conftest.py
@@ -93,7 +93,6 @@ def deploy_solidity_contract(kakarot, get_solidity_contract):
             contract.constructor(*args, **kwargs).data_in_transaction
         )
         with traceit.context(contract_name):
-            await caller_eoa.starknet_contract.increment_nonce().execute()
             tx = await kakarot.eth_send_transaction(
                 to=0, gas_limit=1_000_000, gas_price=0, value=0, data=deploy_bytecode
             ).execute(caller_address=caller_eoa.starknet_address)

--- a/tests/src/kakarot/accounts/eoa/mock_externally_owned_account.cairo
+++ b/tests/src/kakarot/accounts/eoa/mock_externally_owned_account.cairo
@@ -34,9 +34,3 @@ func execute{
     return (response_len, response);
 }
 
-// @notice This function is used to read the nonce from storage
-// @return nonce: The current nonce of the contract account
-@view
-func get_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (nonce: felt) {
-    return Accounts.get_nonce();
-}

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -79,12 +79,6 @@ func compute_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
 // Contract Account
 //
 
-// @dev We are using a storage var, so that we can set custom nonces whilst still being able to increment them during the create execution.
-@storage_var
-func mock_nonce() -> (nonce: felt) {
-}
-
-
 // ///////////////////
 //    Test Cases    //
 // ///////////////////
@@ -642,9 +636,6 @@ func test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at
     );
 
     let ctx = MemoryOperations.exec_mstore(ctx);
-
-    // We set the nonce of the mocked contract account
-    mock_nonce.write(nonce_);
 
     // When
     let sub_ctx = SystemOperations.exec_create(ctx);

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -84,16 +84,6 @@ func compute_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
 func mock_nonce() -> (nonce: felt) {
 }
 
-// @notice This function increases the accounts nonce by 1
-// @return nonce: The incremented nonce of the contract account
-@external
-func increment_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-    nonce: felt
-) {
-    let (current_nonce: felt) = mock_nonce.read();
-    mock_nonce.write(current_nonce + 1);
-    return (nonce=current_nonce + 1);
-}
 
 // ///////////////////
 //    Test Cases    //

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -84,12 +84,6 @@ func compute_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
 func mock_nonce() -> (nonce: felt) {
 }
 
-// @notice the current nonce of the mocked contract account
-@view
-func get_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (nonce: felt) {
-    return mock_nonce.read();
-}
-
 // @notice This function increases the accounts nonce by 1
 // @return nonce: The incremented nonce of the contract account
 @external

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -87,8 +87,8 @@ class TestSystemOperations:
             system_operations.contract_address
         )
 
-    @pytest.mark.parametrize("salt", [0, 127, 256, 2**55 - 1])
-    async def test_create(self, system_operations, salt):
+    async def test_create(self, system_operations):
+        salt = 0
         # given we start with the first anvil test account
         evm_caller_address_int = 0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266
         evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")


### PR DESCRIPTION
This pr removes nonce management and uses starknet nonce wherever nonce is required.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We currently manage nonce ourselves which causes multiple issues, migrating to starknet nonce is a better solution and the PR implements the required changes for that.

Resolves #648 

## What is the new behavior?

- nonce management has been removed
- we now use starknet nonce wherever required

## Other information

- The rpc is already [using starknet nonce](https://github.com/kkrt-labs/kakarot-rpc/blob/d6e3676de6fc9e804dc751aa3493810c95957bba/crates/core/src/client/mod.rs#L338), which means that the current transactions by tools like metamask are already being signed with starknet nonce and not our own nonce when RPC is being used.