### PR TITLE
test_create_has_determistic_address tests address w/o state

### DIFF
--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -715,6 +715,17 @@ func test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at
 }
 
 @external
+func test__get_create_address_should_construct_address_deterministically{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(evm_caller_address: felt, nonce: felt, expected_create_address: felt) {
+    let (evm_contract_address) = CreateHelper.get_create_address(evm_caller_address, nonce);
+
+    assert evm_contract_address = expected_create_address;
+
+    return ();
+}
+
+@external
 func test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_at_expected_address{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -108,9 +108,7 @@ class TestSystemOperations:
         expected_create_addr = get_create_address(evm_caller_address, nonce)
 
         await system_operations.test__get_create_address_should_construct_address_deterministically(
-            int(evm_caller_address, 16),
-            nonce,
-            int(expected_create_addr, 16)
+            int(evm_caller_address, 16), nonce, int(expected_create_addr, 16)
         ).call()
 
     async def test_create2(self, system_operations):
@@ -138,7 +136,7 @@ class TestSystemOperations:
             (size, 0),
             (salt, 0),
             (0, memory_word),
-            int(expected_create_addr, 16)
+            int(expected_create_addr, 16),
         ).call()
 
     async def test_selfdestruct(self, system_operations):

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -108,9 +108,9 @@ class TestSystemOperations:
         expected_create_addr = get_create_address(evm_caller_address, nonce)
 
         await system_operations.test__get_create_address_should_construct_address_deterministically(
-            int(evm_caller_address[2:], 16),
+            int(evm_caller_address, 16),
             nonce,
-            from_bytes(decode_hex(expected_create_addr)),
+            int(expected_create_addr, 16)
         ).call()
 
     async def test_create2(self, system_operations):
@@ -138,7 +138,7 @@ class TestSystemOperations:
             (size, 0),
             (salt, 0),
             (0, memory_word),
-            from_bytes(decode_hex(expected_create2_addr)),
+            int(expected_create_addr, 16)
         ).call()
 
     async def test_selfdestruct(self, system_operations):

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -87,7 +87,7 @@ class TestSystemOperations:
             system_operations.contract_address
         )
 
-    @pytest.mark.parametrize("salt", [0])
+    @pytest.mark.parametrize("salt", [0, 127, 256, 2**55 - 1])
     async def test_create(self, system_operations, salt):
         # given we start with the first anvil test account
         evm_caller_address_int = 0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -87,17 +87,29 @@ class TestSystemOperations:
             system_operations.contract_address
         )
 
-    @pytest.mark.parametrize("salt", [0, 127, 256, 2**55 - 1])
-    async def test_create(self, system_operations, salt):
+    @pytest.mark.parametrize("salt", [0])
+    async def test_create(self, system_operations, nonce):
         # given we start with the first anvil test account
         evm_caller_address_int = 0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266
         evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")
         evm_caller_address = to_checksum_address(evm_caller_address_bytes)
         expected_create_addr = get_create_address(evm_caller_address, salt)
 
-        await system_operations.test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at_expected_address(
+        await system_operations.test__get_create_address_should_construct_address_deterministically(
+            evm_caller_address_int, salt, from_bytes(decode_hex(expected_create_addr))
+        ).call()
+
+    @pytest.mark.parametrize("salt", [0, 127, 256, 2**55 - 1])
+    async def test_create_has_deterministic_address(self, system_operations, nonce):
+        # given we start with the first anvil test account
+        evm_caller_address_int = 0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266
+        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")
+        evm_caller_address = to_checksum_address(evm_caller_address_bytes)
+        expected_create_addr = get_create_address(evm_caller_address, salt)
+
+        await system_operations.test__get_create_address_should_construct_address_deterministically(
             evm_caller_address_int,
-            salt,
+            nonce,
             from_bytes(decode_hex(expected_create_addr)),
         ).call()
 

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -88,27 +88,25 @@ class TestSystemOperations:
         )
 
     @pytest.mark.parametrize("salt", [0])
-    async def test_create(self, system_operations, nonce):
+    async def test_create(self, system_operations, salt):
         # given we start with the first anvil test account
         evm_caller_address_int = 0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266
-        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")
+        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")                
         evm_caller_address = to_checksum_address(evm_caller_address_bytes)
         expected_create_addr = get_create_address(evm_caller_address, salt)
 
-        await system_operations.test__get_create_address_should_construct_address_deterministically(
+        await system_operations.test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at_expected_address(
             evm_caller_address_int, salt, from_bytes(decode_hex(expected_create_addr))
         ).call()
 
-    @pytest.mark.parametrize("salt", [0, 127, 256, 2**55 - 1])
+    @pytest.mark.parametrize("nonce", [0, 127, 256, 2**55 - 1])
     async def test_create_has_deterministic_address(self, system_operations, nonce):
         # given we start with the first anvil test account
-        evm_caller_address_int = 0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266
-        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")
-        evm_caller_address = to_checksum_address(evm_caller_address_bytes)
-        expected_create_addr = get_create_address(evm_caller_address, salt)
+        evm_caller_address = to_checksum_address(0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266)
+        expected_create_addr = get_create_address(evm_caller_address, nonce)
 
         await system_operations.test__get_create_address_should_construct_address_deterministically(
-            evm_caller_address_int,
+            int(evm_caller_address[2:], 16),
             nonce,
             from_bytes(decode_hex(expected_create_addr)),
         ).call()

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -136,7 +136,7 @@ class TestSystemOperations:
             (size, 0),
             (salt, 0),
             (0, memory_word),
-            int(expected_create_addr, 16),
+            int(expected_create2_addr, 16),
         ).call()
 
     async def test_selfdestruct(self, system_operations):

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -91,7 +91,7 @@ class TestSystemOperations:
     async def test_create(self, system_operations, salt):
         # given we start with the first anvil test account
         evm_caller_address_int = 0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266
-        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")                
+        evm_caller_address_bytes = evm_caller_address_int.to_bytes(20, byteorder="big")
         evm_caller_address = to_checksum_address(evm_caller_address_bytes)
         expected_create_addr = get_create_address(evm_caller_address, salt)
 
@@ -102,7 +102,9 @@ class TestSystemOperations:
     @pytest.mark.parametrize("nonce", [0, 127, 256, 2**55 - 1])
     async def test_create_has_deterministic_address(self, system_operations, nonce):
         # given we start with the first anvil test account
-        evm_caller_address = to_checksum_address(0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266)
+        evm_caller_address = to_checksum_address(
+            0xF39FD6E51AAD88F6F4CE6AB8827279CFFFB92266
+        )
         expected_create_addr = get_create_address(evm_caller_address, nonce)
 
         await system_operations.test__get_create_address_should_construct_address_deterministically(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.01

## Pull request type



- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

#649 changes the ability for testing to mock a nonce as a precondition for an assert.

Resolves #654 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- We separate the further testing of deterministic addresses by a range of nonces to be done directly on `CreateHelper.get_create_address`, instead of the previous way which depended on the ability to establish a mock nonce value before running `SystemOperations.exec_create`

-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Currently there is a redundancy of only testing the zero case of nonce for the `test_create`, we can factor out all nonce/address assertions in `test_create` and have them done in a separate test, `test_create_has_deterministic_address`
