### PR TITLE
Fix testnet deploy adding gateway_client calls in kakarot.py

### DIFF
--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -24,6 +24,7 @@ from scripts.constants import (
     KAKAROT_CHAIN_ID,
     NETWORK,
     RPC_CLIENT,
+    GATEWAY_CLIENT
 )
 from scripts.utils.starknet import call as _call_starknet
 from scripts.utils.starknet import fund_address as _fund_starknet_address
@@ -157,7 +158,10 @@ def _wrap_kakarot(fun: str):
 
 async def _contract_exists(address: int) -> bool:
     try:
-        await RPC_CLIENT.get_class_hash_at(address)
+        if GATEWAY_CLIENT is not None:
+            await GATEWAY_CLIENT.get_class_hash_at(address)
+        else:
+            await RPC_CLIENT.get_class_hash_at(address)
         return True
     except ClientError:
         return False
@@ -173,10 +177,10 @@ async def get_eoa(
     starknet_address = await _get_starknet_address(address)
     if not await _contract_exists(starknet_address):
         await deploy_and_fund_evm_address(hex(address), 0.1)
-
+    
     return Account(
         address=starknet_address,
-        client=RPC_CLIENT,
+        client=GATEWAY_CLIENT if GATEWAY_CLIENT is not None else RPC_CLIENT,
         chain=NETWORK["chain_id"],
         key_pair=KeyPair(private_key, address),
     )
@@ -213,8 +217,10 @@ async def eth_send_transaction(
         max_fee=int(5e17),
     )
     await wait_for_transaction(tx_hash=response.transaction_hash)
-    return await RPC_CLIENT.get_transaction_receipt(response.transaction_hash)
-
+    if GATEWAY_CLIENT is not None:
+        return await GATEWAY_CLIENT.get_transaction_receipt(response.transaction_hash)
+    else:
+        return await RPC_CLIENT.get_transaction_receipt(response.transaction_hash)
 
 async def _get_starknet_address(address: Union[str, int]):
     evm_address = int(address, 16) if isinstance(address, str) else address


### PR DESCRIPTION
Time spent on this PR: 0.5 days

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Deploy on testnet fails.

Resolves #666 

## What is the new behavior?

- Add gateway_client conditions

## Other information

Fix tested in devnet and testnet:

DEVNET:
(py39) kali:~/kakarot$ make deploy
poetry lock --check
poetry.lock is consistent with pyproject.toml.
make clean
make[1]: Entering directory '/home/kali/kakarot'
rm -rf build
mkdir build
make[1]: Leaving directory '/home/kali/kakarot'
poetry run python ./scripts/compile_kakarot.py
INFO:scripts.constants:ℹ️  Connected to CHAIN_ID b'SN_GOERLI' with RPC http://127.0.0.1:5050/rpc
INFO:__main__:ℹ️  Compiling contracts for network starknet-devnet
INFO:__main__:⏳ Compiling {'contract_name': 'kakarot', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 45.90s
INFO:__main__:⏳ Compiling {'contract_name': 'blockhash_registry', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 4.13s
INFO:__main__:⏳ Compiling {'contract_name': 'contract_account', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 7.16s
INFO:__main__:⏳ Compiling {'contract_name': 'externally_owned_account', 'is_account_contract': True}
INFO:__main__:✅ Compiled in 16.14s
INFO:__main__:⏳ Compiling {'contract_name': 'proxy', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 3.49s
INFO:__main__:⏳ Compiling {'contract_name': 'EVM', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 44.72s
INFO:__main__:✅ Compiled all in 121.55s
poetry run python ./scripts/deploy_kakarot.py
INFO:scripts.constants:ℹ️  Connected to CHAIN_ID b'SN_GOERLI' with RPC http://127.0.0.1:5050/rpc
INFO:__main__:ℹ️  Using account 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a as deployer
INFO:scripts.utils.starknet:ℹ️  Declaring kakarot
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x0091a6bc98f13bd8164f4b496427fe9586a6d75a4bc74a95bc0fcb553f44a3de
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ kakarot class hash: 0x284c9954ec913534bbe7747fb3d7c2a813a8eaf28b0d9f5f601f98d7f9bc6a9
INFO:scripts.utils.starknet:ℹ️  Declaring blockhash_registry
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x017951b4598c92c879df2a0c92ab6cebbe19e0e97ca939f18a89ca9f0df62a6a
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ blockhash_registry class hash: 0x5277c32a95832978dc85642c2a99e57a04c224e1f9546c672ec7e2673ea8177
INFO:scripts.utils.starknet:ℹ️  Declaring contract_account
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x0039c6f6ac4e8f8af619a3c08a3864d16357aa58749b2b30338f7cc6500c6611
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ contract_account class hash: 0x2a8a4106311b93d77f27010f58827e02a5214bdcd92697b78e627771995899a
INFO:scripts.utils.starknet:ℹ️  Declaring externally_owned_account
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x0724c0c02fd2c0ab22385b0adedbe98e07ed4f30ef096b6068a9579695357ce7
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ externally_owned_account class hash: 0x23c39e1e3afc8845ca48d0af070825fd83d3e848f7fed5c721d5c32ba990c3f
INFO:scripts.utils.starknet:ℹ️  Declaring proxy
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x01dacae09d8814e17a2c89b08ffdfaf885a81f6d2a27c96bac25e2e957ac23a2
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ proxy class hash: 0x4b9eef81a3f0a582dfed69be93196cedbff063e0fa206b34b4c2f06ac505f0c
INFO:scripts.utils.starknet:ℹ️  Declaring EVM
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x03445d50ce841beff5e672715b1f498659e02707281ac78aa3c756f3befea633
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ EVM class hash: 0x4484d175b6a04c376a9ea1b4e21e7923f213526d334a1591c75c91e651bac89
INFO:scripts.utils.starknet:ℹ️  Deploying kakarot
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x0547453538dea1e0047448d13f376e71704bc5333cbf44a46299bcf51e3a917d
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ kakarot deployed at: 0x9aeb7e72c36edd0d2d895e9c0c0c39fdd11c470b6427bcdf1a5b713515a083
INFO:scripts.utils.starknet:ℹ️  Deploying blockhash_registry
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x05985b051976f5539b4a4f798f66235e52b890e55b75bd8aff4ea34b1cd9f4ec
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ blockhash_registry deployed at: 0x516b4ed5c1bb6b2ce67a20f3dadeefe8fbe65825f8f83464f07e5a0b3efa05b
INFO:scripts.utils.starknet:ℹ️  Deploying EVM
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x07385d4f7246b0547ccb26308c5cf51ae2fa1381eb346527e370d94c73bf0ab6
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ EVM deployed at: 0x659d6ce89385e37111c8703bf300fd0fe359fc547880f99376a48d866657830
INFO:__main__:⏳ Configuring Contracts...
INFO:scripts.utils.starknet:ℹ️  Invoking kakarot.set_blockhash_registry([2301683591891370387679197666566243653723162538194641458280194845189516271707])
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x03da9ede6f0773390163faf6368ee9e8920a5fda78214ccc1c8946b75807d275
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x03da9ede6f0773390163faf6368ee9e8920a5fda78214ccc1c8946b75807d275
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ kakarot.set_blockhash_registry invoked at tx: 0x3da9ede6f0773390163faf6368ee9e8920a5fda78214ccc1c8946b75807d275
INFO:__main__:✅ Configuration Complete
INFO:__main__:ℹ️  Found default EVM address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to deploy an EOA for
INFO:scripts.utils.starknet:ℹ️  Invoking kakarot.deploy_externally_owned_account([1390849295786071768276380950238675083608645509734])
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x04c54567fe2793425cce1761314c65890719972b4986e27adf78fb79e3bfadc7
INFO:scripts.utils.starknet:⏳ Waiting for tx /tx/0x04c54567fe2793425cce1761314c65890719972b4986e27adf78fb79e3bfadc7
INFO:scripts.utils.starknet:ℹ️  Sleeping for 0.1s
INFO:scripts.utils.starknet:✅ kakarot.deploy_externally_owned_account invoked at tx: 0x4c54567fe2793425cce1761314c65890719972b4986e27adf78fb79e3bfadc7
INFO:scripts.utils.kakarot:ℹ️  Funding EVM address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 at Starknet address 0x4427094e72838c8a85df1cbeb002df494f34432fa26512b5795f7062a979db
INFO:scripts.utils.starknet:1.0 ETH minted to 0x4427094e72838c8a85df1cbeb002df494f34432fa26512b5795f7062a979db
(py39) kali:~/kakarot$ 

TESTNET:
(py39) kali:~/kakarot$ STARKNET_NETWORK=testnet make deploy
poetry lock --check
poetry.lock is consistent with pyproject.toml.
make clean
make[1]: Entering directory '/home/kali/kakarot'
rm -rf build
mkdir build
make[1]: Leaving directory '/home/kali/kakarot'
poetry run python ./scripts/compile_kakarot.py
WARNING:scripts.constants:⚠️  TESTNET_ACCOUNT_ADDRESS not set, defaulting to ACCOUNT_ADDRESS
WARNING:scripts.constants:⚠️  TESTNET_PRIVATE_KEY not set, defaulting to PRIVATE_KEY
INFO:scripts.constants:ℹ️  Connected to CHAIN_ID b'SN_GOERLI' with Gateway testnet
INFO:__main__:ℹ️  Compiling contracts for network testnet
INFO:__main__:⏳ Compiling {'contract_name': 'kakarot', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 41.37s
INFO:__main__:⏳ Compiling {'contract_name': 'blockhash_registry', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 4.04s
INFO:__main__:⏳ Compiling {'contract_name': 'contract_account', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 6.29s
INFO:__main__:⏳ Compiling {'contract_name': 'externally_owned_account', 'is_account_contract': True}
INFO:__main__:✅ Compiled in 13.78s
INFO:__main__:⏳ Compiling {'contract_name': 'proxy', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 3.19s
INFO:__main__:⏳ Compiling {'contract_name': 'EVM', 'is_account_contract': False}
INFO:__main__:✅ Compiled in 39.19s
INFO:__main__:✅ Compiled all in 107.86s
poetry run python ./scripts/deploy_kakarot.py
WARNING:scripts.constants:⚠️  TESTNET_ACCOUNT_ADDRESS not set, defaulting to ACCOUNT_ADDRESS
WARNING:scripts.constants:⚠️  TESTNET_PRIVATE_KEY not set, defaulting to PRIVATE_KEY
INFO:scripts.constants:ℹ️  Connected to CHAIN_ID b'SN_GOERLI' with Gateway testnet
INFO:__main__:ℹ️  Using account 0x1726957d348b60814e2ceda5a91b5595757733cfbef16a7a9ed5fb430e49aaa as deployer
INFO:scripts.utils.starknet:ℹ️  Declaring kakarot
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring blockhash_registry
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring contract_account
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring externally_owned_account
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring proxy
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Declaring EVM
INFO:scripts.utils.starknet:✅ Class already declared, skipping
INFO:scripts.utils.starknet:ℹ️  Deploying kakarot
INFO:scripts.utils.starknet:✅ kakarot deployed at: 0x4ffd04bebeee04b29d24b8add5f6dc06b41a155cdf63cc7e97cb3b34edba07e
INFO:scripts.utils.starknet:ℹ️  Deploying blockhash_registry
INFO:scripts.utils.starknet:✅ blockhash_registry deployed at: 0x738b1a9a65a2140c83adf9fdd4b4ac329d11595411f6f628541035a44d6ccce
INFO:scripts.utils.starknet:ℹ️  Deploying EVM
INFO:scripts.utils.starknet:✅ EVM deployed at: 0x364343a32be24c274e20ecc29b259f7e96f0641aa945e83643302bdc85abc6d
INFO:__main__:⏳ Configuring Contracts...
INFO:scripts.utils.starknet:ℹ️  Invoking kakarot.set_blockhash_registry([3266359558563740624438251466069708834427641135605644377330958081879147203790])
INFO:scripts.utils.starknet:⏳ Waiting for tx https://testnet.starkscan.co/tx/0x07589a0c8f3079ab722b48dd48fd849b18af2c853884f42d9aee95435a9a110e
INFO:scripts.utils.starknet:✅ kakarot.set_blockhash_registry invoked at tx: 0x7589a0c8f3079ab722b48dd48fd849b18af2c853884f42d9aee95435a9a110e
INFO:__main__:✅ Configuration Complete
INFO:__main__:ℹ️  Found default EVM address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to deploy an EOA for
INFO:scripts.utils.kakarot:ℹ️  Funding EVM address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 at Starknet address 0x470e0c7c1f139cf906afaee2cd4bd05e71d32be1cef8ce90af8f9bc36665958
INFO:scripts.utils.starknet:✅ 1.0 ETH sent from 0x1726957d348b60814e2ceda5a91b5595757733cfbef16a7a9ed5fb430e49aaa to 0x470e0c7c1f139cf906afaee2cd4bd05e71d32be1cef8ce90af8f9bc36665958
INFO:scripts.utils.starknet:💰 Balance of 0x470e0c7c1f139cf906afaee2cd4bd05e71d32be1cef8ce90af8f9bc36665958: 2.099359531435221
(py39) kali:~/kakarot$
