### PR TITLE
fix: update events emissions logic

### DIFF
--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -330,15 +330,17 @@ namespace ExecutionContext {
         let event: model.Event = [events];
         let event_keys_felt = cast(event.keys, felt*);
         // we add the operating evm_contract_address of an execution context
-        // as the final key of an event
+        // as the first key of an event
         // we track kakarot events as those emitted from the kkrt contract
         // and map it to the kkrt contract via this convention
-        assert [event_keys_felt + events.keys_len] = evm_contract_address;
+        let (event_keys: felt*) = alloc();
+        memcpy(dst=event_keys + 1, src=event_keys_felt, len=event.keys_len);
+        assert [event_keys] = evm_contract_address;
         let updated_event_len = event.keys_len + 1;
 
         emit_event(
             keys_len=updated_event_len,
-            keys=event_keys_felt,
+            keys=event_keys,
             data_len=event.data_len,
             data=event.data,
         );

--- a/tests/integration/test_kakarot.py
+++ b/tests/integration/test_kakarot.py
@@ -101,7 +101,7 @@ class TestKakarot:
             assert [
                 [
                     # we remove the key that is used to convey the emitting kkrt evm contract
-                    event.keys[:-1],
+                    event.keys[1:],
                     event.data,
                 ]
                 for event in sorted(res.call_info.events, key=lambda x: x.order)

--- a/tests/utils/contracts.py
+++ b/tests/utils/contracts.py
@@ -119,8 +119,8 @@ def use_kakarot_backend(contract: Contract, kakarot: StarknetContract):
             for log_index, event in enumerate(res.raw_events):
                 # Using try/except as some events are emitted by cairo code and not LOG opcode
                 try:
-                    # every kkrt evm event emission appends the emitting contract as the final value of the event key (as felt)
-                    address = hex(event.keys[-1])
+                    # every kkrt evm event emission appends the emitting contract as the first value of the event key (as felt)
+                    address = hex(event.keys[0])
                     log_receipts.append(
                         LogReceipt(
                             address=to_checksum_address(address),
@@ -137,8 +137,8 @@ def use_kakarot_backend(contract: Contract, kakarot: StarknetContract):
                                     # of the bytes32 topics. This recomputes the original topic
                                     f"{(event.keys[i] + 2**128 * event.keys[i + 1]):064x}"
                                 )
-                                # every kkrt evm event emission appends the emitting contract as the final value of the event key (as felt), we skip those here
-                                for i in range(0, len(event.keys) - 1, 2)
+                                # every kkrt evm event emission appends the emitting contract as the first value of the event key (as felt), we skip those here
+                                for i in range(1, len(event.keys), 2)
                             ],
                             transactionHash=bytes(),
                             transactionIndex=0,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Currently we emit the evm address linked to the log as the last key of the Starknet event. This causes issues when indexing events on Starknet, as the evm address can be located as different places the in key array depending on the amount of topics included in the log.

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.1 day

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Evm address is emitted as last key of the Starknet event, after all topics.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Evm address emitted as first key of the Starknet event, before any topics
