### PR TITLE
feat: update deploy script to fund and deploy deployer accounts, Make OpenzeppelingAccount.cairo part of compilation script

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -150,6 +150,7 @@ COMPILED_CONTRACTS = [
     {"contract_name": "externally_owned_account", "is_account_contract": True},
     {"contract_name": "proxy", "is_account_contract": False},
     {"contract_name": "EVM", "is_account_contract": False},
+    {"contract_name": "OpenzeppelinAccount", "is_account_contract": True},
 ]
 
 KAKAROT_CHAIN_ID = 1263227476  # KKRT (0x4b4b5254) in ASCII
@@ -166,3 +167,9 @@ if NETWORK.get("chain_id"):
         f"ℹ️  Connected to CHAIN_ID {NETWORK['chain_id'].value.to_bytes(ceil(log(NETWORK['chain_id'].value, 256)), 'big')} "
         f"with {f'Gateway {GATEWAY_CLIENT.net}' if GATEWAY_CLIENT is not None else f'RPC {RPC_CLIENT.url}'}"
     )
+
+# private key for the deployer account for Madara and Katana, generated via starkli
+# the account will be used at RPC for deploying EOA and will be deployed and funded via ./scripts/deploy_kakarot.py
+DEPLOYER_ACCOUNT_PRIVATE_KEY = (
+    "0x0288a51c164874bb6a1ca7bd1cb71823c234a86d0f7b150d70fa8f06de645396"
+)

--- a/scripts/deploy_kakarot.py
+++ b/scripts/deploy_kakarot.py
@@ -5,12 +5,15 @@ from asyncio import run
 from scripts.constants import (
     COMPILED_CONTRACTS,
     DEPLOY_FEE,
+    DEPLOYER_ACCOUNT_PRIVATE_KEY,
     ETH_TOKEN_ADDRESS,
     EVM_ADDRESS,
+    NETWORK,
 )
 from scripts.utils.starknet import (
     declare,
     deploy,
+    deploy_starknet_account,
     dump_declarations,
     dump_deployments,
     get_declarations,
@@ -60,6 +63,11 @@ async def main():
         class_hash["proxy"],  # account_proxy_class_hash
         deployments["blockhash_registry"]["address"],  # blockhash_registry address
     )
+
+    if NETWORK["name"] in ["madara", "katana"]:
+        deployments["deployer_account"] = await deploy_starknet_account(
+            class_hash["OpenzeppelinAccount"], private_key=DEPLOYER_ACCOUNT_PRIVATE_KEY
+        )
 
     dump_deployments(deployments)
 

--- a/scripts/utils/starknet.py
+++ b/scripts/utils/starknet.py
@@ -286,11 +286,8 @@ def compile_contract(contract):
     )
 
 
-async def deploy_starknet_account(private_key=None, amount=1) -> Account:
-    compile_contract(
-        {"contract_name": "OpenzeppelinAccount", "is_account_contract": True}
-    )
-    class_hash = await declare("OpenzeppelinAccount")
+async def deploy_starknet_account(class_hash, private_key=None, amount=1) -> Account:
+
     salt = random.randint(0, 2**251)
     private_key = private_key or NETWORK["private_key"]
     if private_key is None:
@@ -322,9 +319,11 @@ async def deploy_starknet_account(private_key=None, amount=1) -> Account:
     status = "✅" if status == TransactionStatus.ACCEPTED_ON_L2 else "❌"
     logger.info(f"{status} Account deployed at address {hex(res.account.address)}")
 
-    NETWORK["account_address"] = hex(res.account.address)
-    NETWORK["private_key"] = hex(key_pair.private_key)
-    return res.account
+    return {
+        "address": res.account.address,
+        "tx": res.hash,
+        "artifact": get_artifact("OpenzeppelinAccount"),
+    }
 
 
 async def declare(contract_name):

--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -339,10 +339,7 @@ namespace ExecutionContext {
         let updated_event_len = event.keys_len + 1;
 
         emit_event(
-            keys_len=updated_event_len,
-            keys=event_keys,
-            data_len=event.data_len,
-            data=event.data,
+            keys_len=updated_event_len, keys=event_keys, data_len=event.data_len, data=event.data
         );
         // we maintain the semantics of one event struct involves iterating a full event struct size recursively
         emit_events(evm_contract_address, events_len - 1, events + 1 * model.Event.SIZE);


### PR DESCRIPTION
This PR updates the deploy script to deploy a pre-funded account to be used at the RPC for deploying EOAs for only Madara and Katana. 

It also updates the compilation script to compile [OpenzeppelinAccount.cairo](https://github.com/kkrt-labs/kakarot/blob/main/src/utils/OpenzeppelinAccount.cairo) the build of which will be required for a future feature PR to the RPC for deploying accounts if they don't exist. 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- We would have to manually fund these accounts when we run Madara { you can read the linked issue to understand why we we are not using the default accounts provided by Madara }
- [OpenzeppelinAccount.cairo](https://github.com/kkrt-labs/kakarot/blob/main/src/utils/OpenzeppelinAccount.cairo) is not part of compilation

Resolves #673 

## What is the new behavior?

- Account deployment for test environments have been automated
- [OpenzeppelinAccount.cairo](https://github.com/kkrt-labs/kakarot/blob/main/src/utils/OpenzeppelinAccount.cairo) is not part of compilation
