### PR TITLE
Add fixtures for debugging EF tests, and sha3_d0g0v0_Shanghai test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ markers = [
     "UniswapV2Factory",
     "Utils",
     "Safe",
+    "EF_TEST",
 ]
 
 [tool.isort]

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -360,12 +360,6 @@ namespace Kakarot {
             assert success = TRUE;
         }
 
-        // TODO: add check that target contract does not exist or has empty bytecode
-        if (data_len == 0) {
-            let (return_data) = alloc();
-            return (0, return_data);
-        }
-
         if (to == 0) {
             with_attr error_message("Kakarot: value should be 0 when deploying a contract") {
                 assert value = 0;

--- a/tests/integration/solidity_contracts/EFTests/test_sha3.py
+++ b/tests/integration/solidity_contracts/EFTests/test_sha3.py
@@ -1,0 +1,42 @@
+import logging
+
+import pytest
+from starkware.starknet.testing.contract import StarknetContract
+
+from tests.utils.helpers import hex_string_to_bytes_array
+
+logger = logging.getLogger()
+
+
+@pytest.mark.asyncio
+@pytest.mark.EF_TEST
+class TestSha3:
+    @pytest.mark.skip(
+        "TODO: need to fix when return_data is shorter than retSize in CallHelper.finalize_calling_context"
+    )
+    async def test_sha3_d0g0v0_Shanghai(
+        self,
+        owner,
+        create_account_with_bytecode,
+        kakarot: StarknetContract,
+    ):
+        called_contract = await create_account_with_bytecode("0x600060002060005500")
+        caller_contract = await create_account_with_bytecode(
+            "0x604060206010600f6000600435610100016001600003f100"
+        )
+
+        res = await kakarot.eth_send_transaction(
+            origin=int(owner.address, 16),
+            to=int(caller_contract.evm_contract_address, 16),
+            gas_limit=1_000_000,
+            gas_price=0,
+            value=0,
+            data=hex_string_to_bytes_array(
+                # In the original EF test, the called contract is supposed to be set in genesis
+                # at address 0x000000000000000000000000000000000000010{i} while the payload of
+                # the tx uses {i}, hence we sub 0x100 to the real deployed called_address
+                f"0x693c6139{int(called_contract.evm_contract_address, 16) - 0x100:064x}"
+            ),
+        ).execute(caller_address=owner.starknet_address)
+        sha3 = called_contract.storage(0).call()
+        assert res == sha3

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -178,7 +178,7 @@ class TestPlainOpcodes:
             evm_addresses = await plain_opcodes.create(
                 bytecode=counter.constructor().data_in_transaction,
                 count=count,
-                caller_address=plain_opcodes_deployer.starknet_address,
+                caller_address=plain_opcodes_deployer,
             )
             assert len(evm_addresses) == count
             for evm_address in evm_addresses:


### PR DESCRIPTION
Time spent on this PR: 0.3

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No fixture available for deploying raw bytecode (not from compilation artifacts) or setting a bytecode (without running it as in deploy).

## What is the new behavior?

Added fixtures:

- `deploy_eoa(private_key)` to deploy an EOA
- `deploy_bytecode(bytecode)` to deploy a given raw bytecode
- `create_account_with_bytecode(bytecode)` to create a CA with the given bytecode

## Other information

Also added a first EF test (sha3_d0g0v0_Shanghai), currently failing due to the `return_data` shorted than the `retSize`.
