### PR TITLE
initialize return_data to its length in zeroes when initializing call context

### DIFF
--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -452,6 +452,7 @@ namespace CallHelper {
         // During teardown we update the memory using this offset
         let return_data: felt* = alloc();
         assert [return_data] = ret_offset;
+        Helpers.fill(ret_size, return_data+1, 0);
 
         // Load calldata from Memory
         let (calldata: felt*) = alloc();
@@ -584,12 +585,16 @@ namespace CallHelper {
 
         let stack = Stack.push(ctx.stack, status);
         let ctx = ExecutionContext.update_stack(ctx, stack);
+        // in the case that the return data is empty, we use `slice_data` 
+        // to give us a zero padded array
+        let return_data_len = ctx.sub_context.return_data_len;
+        let return_data = Helpers.slice_data(return_data_len, ctx.sub_context.return_data, 0, return_data_len);
 
         // ret_offset, see prepare_args
         let memory = Memory.store_n(
             ctx.memory,
-            ctx.sub_context.return_data_len,
-            ctx.sub_context.return_data,
+            return_data_len,
+            return_data,
             [ctx.sub_context.return_data - 1],
         );
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

`return_data` is prepped to be able to be finalized in the case where it is empty [here](https://gist.github.com/jobez/b21a84a35e7c97eb0de98424506cd4ef#file-resultant_traceback-txt-L132), where the finalized calling context attempts to write an empty return array to memory

-
-
-
