### PR TITLE
Add condition for zero return_data_len in finalization if-statement

### DIFF
--- a/src/kakarot/instructions.cairo
+++ b/src/kakarot/instructions.cairo
@@ -639,7 +639,7 @@ namespace EVMInstructions {
                 // If the starknet contract of the execution context has
                 // no bytecode,
                 // is not an EOA,
-                // and has an empty return data
+                // and has return data
                 // then we treat it as at the end of a CREATE/CREATE2 opcode.
                 if (bytecode_len + is_eao + has_empty_return_data == 0) {
                     let ctx = CreateHelper.finalize_calling_context(ctx);

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -291,10 +291,6 @@ class TestPlainOpcodes:
             assert await plain_opcodes.loopValue() == steps
 
     class TestTransfer:
-        @pytest.mark.skip(
-            "EOA execution flow incorrectly dispatches to `CreateHelper.finalize_calling_context`"
-            "See issue https://github.com/kkrt-labs/kakarot/issues/696"
-        )
         async def test_send_some_should_send(
             self, plain_opcodes, plain_opcodes_deployer, addresses
         ):

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_plain_opcodes.py
@@ -292,8 +292,34 @@ class TestPlainOpcodes:
 
     class TestTransfer:
         async def test_send_some_should_send(
-            self, plain_opcodes, plain_opcodes_deployer, addresses
+            self, eth, plain_opcodes, fund_evm_address, other
         ):
+            send_amount = 1
+
+            plain_opcodes_address = int(plain_opcodes.address, 16)
+            await fund_evm_address(plain_opcodes_address)
+
+            receiver_balance_before = (
+                await eth.balanceOf(other.starknet_address).call()
+            ).result.balance.low
+            sender_balance_before = (
+                await eth.balanceOf(
+                    plain_opcodes.contract_account.contract_address
+                ).call()
+            ).result.balance.low
+
             await plain_opcodes.sendSome(
-                addresses[2].address, 0, caller_address=plain_opcodes_deployer
+                other.address, send_amount, caller_address=other
             )
+
+            receiver_balance_after = (
+                await eth.balanceOf(other.starknet_address).call()
+            ).result.balance.low
+            sender_balance_after = (
+                await eth.balanceOf(
+                    plain_opcodes.contract_account.contract_address
+                ).call()
+            ).result.balance.low
+
+            assert receiver_balance_after - receiver_balance_before == send_amount
+            assert sender_balance_before - sender_balance_after == send_amount


### PR DESCRIPTION
Ensure that the finalization logic accounts for cases where return_data_len is zero, to correctly branch into 'create' or 'call' operations.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #696 

## What is the new behavior?

per this suggestion: https://github.com/kkrt-labs/kakarot/issues/696#issuecomment-1693405166

we add a check if the return data length is zero to decide whether the execution context should be handed as create/call.

-
-
-
