### PR TITLE
Add evm to starknet address mapping

### DIFF
--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -177,7 +177,7 @@ async def _contract_exists(address: int) -> bool:
 async def get_eoa(private_key=None, amount=0.1) -> Account:
     private_key = private_key or keys.PrivateKey(bytes.fromhex(EVM_PRIVATE_KEY[2:]))
 
-    starknet_address = await _get_starknet_address(
+    starknet_address = await _compute_starknet_address(
         private_key.public_key.to_checksum_address()
     )
     if not await _contract_exists(starknet_address):
@@ -230,7 +230,7 @@ async def eth_send_transaction(
     return await CLIENT.get_transaction_receipt(response.transaction_hash)
 
 
-async def _get_starknet_address(address: Union[str, int]):
+async def _compute_starknet_address(address: Union[str, int]):
     evm_address = int(address, 16) if isinstance(address, str) else address
     kakarot_contract = await _get_starknet_contract("kakarot")
     return (
@@ -257,7 +257,7 @@ async def deploy_and_fund_evm_address(evm_address: str, amount: float):
 
 
 async def fund_address(address: Union[str, int], amount: float):
-    starknet_address = await _get_starknet_address(address)
+    starknet_address = await _compute_starknet_address(address)
     logger.info(
         f"ℹ️  Funding EVM address {address} at Starknet address {hex(starknet_address)}"
     )

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -122,7 +122,8 @@ namespace Accounts {
             return (0, bytecode);
         }
 
-        return IAccount.bytecode(contract_address=starknet_address);
+        let (bytecode_len, bytecode) = IAccount.bytecode(contract_address=starknet_address);
+        return (bytecode_len, bytecode);
     }
 
     // @notice Returns the bytecode_len of a given EVM address
@@ -134,9 +135,10 @@ namespace Accounts {
         let (starknet_address) = get_starknet_address(evm_address);
 
         if (starknet_address == 0) {
-            return (0);
+            return (bytecode_len=0);
         }
 
-        return IAccount.bytecode_len(contract_address=starknet_address);
+        let (bytecode_len) = IAccount.bytecode_len(contract_address=starknet_address);
+        return (bytecode_len=bytecode_len);
     }
 }

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -2,8 +2,6 @@
 
 %lang starknet
 
-from openzeppelin.access.ownable.library import Ownable
-
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.bool import FALSE
@@ -29,7 +27,21 @@ func nonce() -> (nonce: felt) {
 func evm_contract_deployed(evm_contract_address: felt, starknet_contract_address: felt) {
 }
 
+@storage_var
+func evm_to_starknet_address(evm_address: felt) -> (starknet_address: felt) {
+}
+
 namespace Accounts {
+    // @dev Returns the registered starknet address for a given EVM address. Returns 0 if no contract is deployed for this
+    //      EVM address.
+    // @param evm_address The EVM address to transform to a starknet address
+    // @return starknet_address The Starknet Account Contract address or 0 if not already deployed
+    func get_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        evm_address: felt
+    ) -> (starknet_address: felt) {
+        return evm_to_starknet_address.read(evm_address);
+    }
+
     // @dev As contract addresses are deterministic we can know what will be the address of a starknet contract from its input EVM address
     // @dev Adapted code from: https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/starknet/core/os/contract_address/contract_address.cairo
     // @param evm_address The EVM address to transform to a starknet address
@@ -82,7 +94,7 @@ namespace Accounts {
         let (kakarot_address: felt) = get_contract_address();
         let (_account_proxy_class_hash: felt) = account_proxy_class_hash.read();
         let (constructor_calldata: felt*) = alloc();
-        let (account_address) = deploy_syscall(
+        let (starknet_address) = deploy_syscall(
             _account_proxy_class_hash,
             contract_address_salt=evm_address,
             constructor_calldata_size=0,
@@ -91,9 +103,40 @@ namespace Accounts {
         );
         assert constructor_calldata[0] = kakarot_address;
         assert constructor_calldata[1] = evm_address;
-        IAccount.initialize(account_address, class_hash, 2, constructor_calldata);
-        evm_contract_deployed.emit(evm_address, account_address);
+        IAccount.initialize(starknet_address, class_hash, 2, constructor_calldata);
+        evm_contract_deployed.emit(evm_address, starknet_address);
+        evm_to_starknet_address.write(evm_address, starknet_address);
+        return (account_address=starknet_address);
+    }
 
-        return (account_address=account_address);
+    // @notice Returns the bytecode of a given EVM address
+    // @dev Returns an empty bytecode if the corresponding Starknet contract is not deployed
+    //      as would eth_getCode do to any address
+    func get_bytecode{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        evm_address: felt
+    ) -> (bytecode_len: felt, bytecode: felt*) {
+        let (starknet_address) = get_starknet_address(evm_address);
+
+        if (starknet_address == 0) {
+            let (bytecode: felt*) = alloc();
+            return (0, bytecode);
+        }
+
+        return IAccount.bytecode(contract_address=starknet_address);
+    }
+
+    // @notice Returns the bytecode_len of a given EVM address
+    // @dev Returns 0 if the corresponding Starknet contract is not deployed
+    //      as would eth_getCode do to any address
+    func get_bytecode_len{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        evm_address: felt
+    ) -> (bytecode_len: felt) {
+        let (starknet_address) = get_starknet_address(evm_address);
+
+        if (starknet_address == 0) {
+            return (0);
+        }
+
+        return IAccount.bytecode_len(contract_address=starknet_address);
     }
 }

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -89,9 +89,9 @@ namespace EnvironmentalInformation {
         // Get the evm address.
         let (stack: model.Stack*, address: Uint256) = Stack.pop(ctx.stack);
 
-        let felt_address = Helpers.uint256_to_felt(address);
+        let address_felt = Helpers.uint256_to_felt(address);
         // Get the starknet account address from the evm account address
-        let (starknet_contract_address) = Accounts.compute_starknet_address(felt_address);
+        let (starknet_contract_address) = Accounts.compute_starknet_address(address_felt);
         // Get the number of native tokens owned by the given starknet account
         let (native_token_address_) = native_token_address.read();
         let (balance: Uint256) = IERC20.balanceOf(
@@ -447,15 +447,7 @@ namespace EnvironmentalInformation {
         // 0 - address: 20-byte address of the contract to query.
         let (stack, address_uint256) = Stack.pop(self=stack);
         let address_felt = Helpers.uint256_to_felt(address_uint256);
-
-        // Get the starknet address from the given evm address
-        let (starknet_contract_address) = Accounts.compute_starknet_address(address_felt);
-
-        local bytecode_len;
-        // TODO (https://github.com/sayajin-labs/kakarot/issues/474)
-        //      should be able to check that there is a deployed starknet contract at this address
-        // if not return bytecode_len 0
-        let (bytecode_len) = IAccount.bytecode_len(contract_address=starknet_contract_address);
+        let (bytecode_len) = Accounts.get_bytecode_len(address_felt);
 
         // bytecode_len cannot be greater than 24k in the EVM
         let stack = Stack.push(stack, Uint256(low=bytecode_len, high=0));
@@ -502,17 +494,7 @@ namespace EnvironmentalInformation {
         let size = popped[3];
 
         let address_felt = Helpers.uint256_to_felt(address_uint256);
-
-        // Get the starknet address from the given evm address
-
-        let (starknet_contract_address) = Accounts.compute_starknet_address(address_felt);
-
-        // TODO (https://github.com/sayajin-labs/kakarot/issues/474)
-        //      should be able to check that there is a deployed starknet contract at this address
-        // we get the bytecode from the Starknet_contract
-        let (bytecode_len, bytecode) = IAccount.bytecode(
-            contract_address=starknet_contract_address
-        );
+        let (bytecode_len, bytecode) = Accounts.get_bytecode(address_felt);
 
         // Get bytecode slice from offset to size
         // in the case were
@@ -655,15 +637,7 @@ namespace EnvironmentalInformation {
         // 0 - address: 20-byte address of the contract to query.
         let (stack, address_uint256) = Stack.pop(self=stack);
         let address_felt = Helpers.uint256_to_felt(address_uint256);
-
-        // Get the starknet address from the given evm address
-        let (starknet_contract_address) = Accounts.compute_starknet_address(address_felt);
-
-        // TODO (https://github.com/sayajin-labs/kakarot/issues/474)
-        //      should be able to check that there is a deployed starknet contract at this address
-        let (bytecode_len, bytecode) = IAccount.bytecode(
-            contract_address=starknet_contract_address
-        );
+        let (bytecode_len, bytecode) = Accounts.get_bytecode(address_felt);
 
         let (local dest: felt*) = alloc();
         // convert to little endian

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -515,6 +515,7 @@ namespace CallHelper {
                 calldata_len=call_args.args_size,
                 value=call_args.value,
             );
+            let (starknet_contract_address) = Accounts.compute_starknet_address(call_args.address);
             let sub_ctx = ExecutionContext.init(
                 call_context=call_context,
                 starknet_contract_address=starknet_contract_address,

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -507,19 +507,14 @@ namespace CallHelper {
         // Check if the called address is a precompiled contract
         let is_precompile = Precompiles.is_precompile(address=call_args.address);
         if (is_precompile == FALSE) {
-            let (starknet_contract_address) = Accounts.compute_starknet_address(
-                evm_address=call_args.address
-            );
-            let (bytecode_len, bytecode) = IAccount.bytecode(
-                contract_address=starknet_contract_address
-            );
+            let (bytecode_len, bytecode) = Accounts.get_bytecode(call_args.address);
             tempvar call_context = new model.CallContext(
                 bytecode=bytecode,
                 bytecode_len=bytecode_len,
                 calldata=call_args.calldata,
                 calldata_len=call_args.args_size,
                 value=call_args.value,
-            );
+                );
             let sub_ctx = ExecutionContext.init(
                 call_context=call_context,
                 starknet_contract_address=starknet_contract_address,
@@ -803,7 +798,7 @@ namespace CreateHelper {
             calldata=empty_array,
             calldata_len=0,
             value=value.low,
-        );
+            );
         let (local return_data: felt*) = alloc();
         let (empty_destroy_contracts: felt*) = alloc();
         let (empty_create_addresses: felt*) = alloc();
@@ -855,7 +850,7 @@ namespace CreateHelper {
                 revert_contract_state=revert_contract_state,
                 reverted=FALSE,
                 read_only=FALSE,
-            );
+                );
 
             return sub_ctx;
         } else {
@@ -900,7 +895,7 @@ namespace CreateHelper {
                 revert_contract_state=revert_contract_state,
                 reverted=FALSE,
                 read_only=FALSE,
-            );
+                );
 
             return sub_ctx;
         }
@@ -922,7 +917,7 @@ namespace CreateHelper {
         if (is_reverted != 0) {
             local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(
                 self=ctx.calling_context, sub_context=ctx
-            );
+                );
             // In the case of a reverted create context, the gas of the reverted context should be rolled back and not consumed
 
             // Append contracts to selfdestruct to the calling_context
@@ -952,7 +947,7 @@ namespace CreateHelper {
 
             local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(
                 self=ctx.calling_context, sub_context=ctx
-            );
+                );
             let ctx = ExecutionContext.increment_gas_used(ctx, ctx.sub_context.gas_used);
 
             // Append contracts to selfdestruct to the calling_context
@@ -993,7 +988,7 @@ namespace SelfDestructHelper {
         let (revert_contract_state_dict_start) = default_dict_new(0);
         tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
             revert_contract_state_dict_start, revert_contract_state_dict_start
-        );
+            );
 
         return new model.ExecutionContext(
             call_context=ctx.call_context,
@@ -1020,6 +1015,6 @@ namespace SelfDestructHelper {
             revert_contract_state=revert_contract_state,
             reverted=FALSE,
             read_only=FALSE,
-        );
+            );
     }
 }

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -514,7 +514,7 @@ namespace CallHelper {
                 calldata=call_args.calldata,
                 calldata_len=call_args.args_size,
                 value=call_args.value,
-                );
+            );
             let sub_ctx = ExecutionContext.init(
                 call_context=call_context,
                 starknet_contract_address=starknet_contract_address,
@@ -798,7 +798,7 @@ namespace CreateHelper {
             calldata=empty_array,
             calldata_len=0,
             value=value.low,
-            );
+        );
         let (local return_data: felt*) = alloc();
         let (empty_destroy_contracts: felt*) = alloc();
         let (empty_create_addresses: felt*) = alloc();
@@ -850,7 +850,7 @@ namespace CreateHelper {
                 revert_contract_state=revert_contract_state,
                 reverted=FALSE,
                 read_only=FALSE,
-                );
+            );
 
             return sub_ctx;
         } else {
@@ -895,7 +895,7 @@ namespace CreateHelper {
                 revert_contract_state=revert_contract_state,
                 reverted=FALSE,
                 read_only=FALSE,
-                );
+            );
 
             return sub_ctx;
         }
@@ -917,7 +917,7 @@ namespace CreateHelper {
         if (is_reverted != 0) {
             local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(
                 self=ctx.calling_context, sub_context=ctx
-                );
+            );
             // In the case of a reverted create context, the gas of the reverted context should be rolled back and not consumed
 
             // Append contracts to selfdestruct to the calling_context
@@ -947,7 +947,7 @@ namespace CreateHelper {
 
             local ctx: model.ExecutionContext* = ExecutionContext.update_sub_context(
                 self=ctx.calling_context, sub_context=ctx
-                );
+            );
             let ctx = ExecutionContext.increment_gas_used(ctx, ctx.sub_context.gas_used);
 
             // Append contracts to selfdestruct to the calling_context
@@ -988,7 +988,7 @@ namespace SelfDestructHelper {
         let (revert_contract_state_dict_start) = default_dict_new(0);
         tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
             revert_contract_state_dict_start, revert_contract_state_dict_start
-            );
+        );
 
         return new model.ExecutionContext(
             call_context=ctx.call_context,
@@ -1015,6 +1015,6 @@ namespace SelfDestructHelper {
             revert_contract_state=revert_contract_state,
             reverted=FALSE,
             read_only=FALSE,
-            );
+        );
     }
 }

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -90,6 +90,9 @@ namespace IKakarot {
     func compute_starknet_address(evm_address: felt) -> (contract_address: felt) {
     }
 
+    func get_starknet_address(evm_address: felt) -> (starknet_address: felt) {
+    }
+
     func eth_call(
         origin: felt,
         to: felt,
@@ -102,12 +105,7 @@ namespace IKakarot {
     }
 
     func eth_send_transaction(
-        to: felt,
-        gas_limit: felt,
-        gas_price: felt,
-        value: felt,
-        data_len: felt,
-        data: felt*,
+        to: felt, gas_limit: felt, gas_price: felt, value: felt, data_len: felt, data: felt*
     ) -> (return_data_len: felt, return_data: felt*) {
     }
 }

--- a/src/kakarot/kakarot.cairo
+++ b/src/kakarot/kakarot.cairo
@@ -105,6 +105,17 @@ func compute_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
     return Accounts.compute_starknet_address(evm_address);
 }
 
+// @notice Returns the registered starknet address for a given EVM address.
+// @dev Returns 0 if no contract is deployed for this EVM address.
+// @param evm_address The EVM address to transform to a starknet address
+// @return starknet_address The Starknet Account Contract address or 0 if not already deployed
+@view
+func get_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    evm_address: felt
+) -> (starknet_address: felt) {
+    return Accounts.get_starknet_address(evm_address);
+}
+
 // @notice Deploy a new externally owned account.
 // @param evm_address The evm address that is mapped to the newly deployed starknet contract address.
 // @return starknet_contract_address The newly deployed starknet contract address.
@@ -157,16 +168,11 @@ func eth_call{
 @external
 func eth_send_transaction{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(
-    to: felt,
-    gas_limit: felt,
-    gas_price: felt,
-    value: felt,
-    data_len: felt,
-    data: felt*,
-) -> (return_data_len: felt, return_data: felt*) {
+}(to: felt, gas_limit: felt, gas_price: felt, value: felt, data_len: felt, data: felt*) -> (
+    return_data_len: felt, return_data: felt*
+) {
     alloc_locals;
     let (local starknet_caller_address) = get_caller_address();
-    let (local origin) =  Kakarot.safe_get_evm_address(starknet_caller_address);
+    let (local origin) = Kakarot.safe_get_evm_address(starknet_caller_address);
     return Kakarot.eth_call(origin, to, gas_limit, gas_price, value, data_len, data);
 }

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -354,6 +354,7 @@ namespace Kakarot {
         data_len: felt,
         data: felt*,
     ) -> (return_data_len: felt, return_data: felt*) {
+        alloc_locals;
         let (success) = transfer(origin, to, value);
         with_attr error_message("Kakarot: eth_call: failed to transfer {value} tokens to {to}") {
             assert success = TRUE;
@@ -371,6 +372,7 @@ namespace Kakarot {
             assert [return_data + 1] = starknet_contract_address;
             return (2, return_data);
         } else {
+            let (local starknet_contract_address) = Accounts.compute_starknet_address(to);
             let (bytecode_len, bytecode) = Accounts.get_bytecode(to);
             let summary = execute(
                 starknet_contract_address,

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -112,7 +112,7 @@ namespace Kakarot {
             calldata=calldata,
             calldata_len=calldata_len,
             value=value,
-            );
+        );
 
         let ctx = ExecutionContext.init(
             call_context=call_context,

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -58,9 +58,8 @@ namespace Kakarot {
     // @notice Run the given bytecode with the given calldata and parameters
     // @dev starknet_contract_address and evm_contract_address can be set to 0 if
     //      there is no notion of deployed contract in the bytecode. Otherwise,
-    //      they should match (ie. that
-    //      compute_starknet_address(IAccount.get_evm_address(starknet_contract_address))
-    //      shou equal starknet_contract_address. In a future version, either one or the
+    //      they should match (ie. that compute_starknet_address(IAccount.get_evm_address(starknet_contract_address))
+    //      should equal starknet_contract_address. In a future version, either one or the
     //      other will be removed
     // @param starknet_contract_address The starknet contract address of the called contract
     // @param evm_contract_address The corresponding EVM contract address of the called contract
@@ -113,7 +112,7 @@ namespace Kakarot {
             calldata=calldata,
             calldata_len=calldata_len,
             value=value,
-        );
+            );
 
         let ctx = ExecutionContext.init(
             call_context=call_context,
@@ -372,10 +371,7 @@ namespace Kakarot {
             assert [return_data + 1] = starknet_contract_address;
             return (2, return_data);
         } else {
-            let (starknet_contract_address) = Accounts.compute_starknet_address(to);
-            let (bytecode_len, bytecode) = IAccount.bytecode(
-                contract_address=starknet_contract_address
-            );
+            let (bytecode_len, bytecode) = Accounts.get_bytecode(to);
             let summary = execute(
                 starknet_contract_address,
                 to,
@@ -392,8 +388,8 @@ namespace Kakarot {
         }
     }
 
-    // @notice returns the EVM address associated to a Starknet account deployed by kakarot. 
-    //         Prevents cases where some Starknet account has an entrypoint get_evm_address() 
+    // @notice returns the EVM address associated to a Starknet account deployed by kakarot.
+    //         Prevents cases where some Starknet account has an entrypoint get_evm_address()
     //         but isn't part of Kakarot system
     // @dev Raise if the declared corresponding evm address (retrieved with get_evm_address)
     //      does not recomputes into to the actual caller address
@@ -405,9 +401,7 @@ namespace Kakarot {
     }(starknet_address: felt) -> (evm_address: felt) {
         alloc_locals;
         let (local evm_address) = IAccount.get_evm_address(starknet_address);
-        let (local computed_starknet_address) = Accounts.compute_starknet_address(
-            evm_address
-        );
+        let (local computed_starknet_address) = Accounts.compute_starknet_address(evm_address);
 
         with_attr error_message("Kakarot: caller contract is not a Kakarot Account") {
             assert computed_starknet_address = starknet_address;
@@ -415,7 +409,6 @@ namespace Kakarot {
 
         return (evm_address=evm_address);
     }
-
 
     // @notice Since it's possible in starknet to send a transcation to a @view entrypoint, this
     //         ensures that there is no ongoing transaction (so it's really a view call).

--- a/tests/src/kakarot/accounts/eoa/mock_kakarot.cairo
+++ b/tests/src/kakarot/accounts/eoa/mock_kakarot.cairo
@@ -42,6 +42,14 @@ func compute_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
     return (contract_address=contract_address_);
 }
 
+// @dev mock function that returns the registered starknet address from an evm address or 0
+@view
+func get_starknet_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    evm_address: felt
+) -> (starknet_address: felt) {
+    return Accounts.get_starknet_address(evm_address);
+}
+
 // @notice Deploy a new externally owned account.
 // @param evm_address The evm address that is mapped to the newly deployed starknet contract address.
 // @return starknet_contract_address The newly deployed starknet contract address.
@@ -83,16 +91,11 @@ func eth_call{
 @external
 func eth_send_transaction{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(
-    to: felt,
-    gas_limit: felt,
-    gas_price: felt,
-    value: felt,
-    data_len: felt,
-    data: felt*,
-) -> (return_data_len: felt, return_data: felt*) {
+}(to: felt, gas_limit: felt, gas_price: felt, value: felt, data_len: felt, data: felt*) -> (
+    return_data_len: felt, return_data: felt*
+) {
     alloc_locals;
     let (local starknet_caller_address) = get_caller_address();
-    let (local origin) =  IAccount.get_evm_address(starknet_caller_address);
+    let (local origin) = IAccount.get_evm_address(starknet_caller_address);
     return eth_call(origin, to, gas_limit, gas_price, value, data_len, data);
 }


### PR DESCRIPTION
Time spent on this PR: 0.3

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The Kakarot contract cannot know whether a starknet address is deployed or not.

Resolves #719 #474

## What is the new behavior?

A mapping evm_address -> starknet_address has been added:

- returns the starknet_address when it's deployed
- returns 0 otherwise

## Note

I didn't replace all the `compute_starknet_address`, and did actually the minimal changes,
since it is still possible in some case (e.g. transfer) to send ETH to a non deployed account.

However, now that we have introduced a mapping, we could move away from this deterministic mapping
to allow any starknet contract to claim ownership of an EVM address.

This is let to further dev, probably in cairo1.
