### PR TITLE
fix: allow transfer of `value` during contract creation

### DIFF
--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -252,9 +252,9 @@ namespace Kakarot {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(origin: felt, evm_contract_address: felt, bytecode_len: felt, bytecode: felt*) -> (
-        starknet_contract_address: felt
-    ) {
+    }(
+        origin: felt, evm_contract_address: felt, value: felt, bytecode_len: felt, bytecode: felt*
+    ) -> (starknet_contract_address: felt) {
         alloc_locals;
 
         let (class_hash) = contract_account_class_hash.read();
@@ -281,7 +281,7 @@ namespace Kakarot {
             bytecode=bytecode,
             calldata_len=0,
             calldata=empty_array,
-            value=0,
+            value=value,
             gas_limit=0,
             gas_price=0,
         );
@@ -367,6 +367,7 @@ namespace Kakarot {
             let (starknet_contract_address) = deploy_contract_account(
                 origin=origin,
                 evm_contract_address=evm_contract_address,
+                value=value,
                 bytecode_len=data_len,
                 bytecode=data,
             );

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -243,10 +243,12 @@ namespace Kakarot {
     // @notice Deploy contract account.
     // @dev First deploy a contract_account with no bytecode, then run the calldata as bytecode with the new address,
     //      then set the bytecode with the result of the initial run.
+    // @param origin The origin for the transaction
+    // @param evm_contract_address The evm address of the contract to be deployed
+    // @param value The value to be transferred as part of this deploy call
     // @param bytecode_len The deploy bytecode length.
     // @param bytecode The deploy bytecode.
     // @return starknet_contract_address The newly deployed starknet contract address.
-    // @return evm_contract_address The evm address that is mapped to the newly deployed starknet contract address.
     func deploy_contract_account{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -292,6 +292,8 @@ namespace Kakarot {
             bytecode_len=return_data_len,
             bytecode=return_data,
         );
+        // Increment nonce
+        IContractAccount.increment_nonce(contract_address=starknet_contract_address);
         return (starknet_contract_address=starknet_contract_address);
     }
 

--- a/tests/integration/solidity_contracts/PlainOpcodes/RevertTestCases.sol
+++ b/tests/integration/solidity_contracts/PlainOpcodes/RevertTestCases.sol
@@ -23,3 +23,4 @@ contract ContractRevertsOnConstruction {
         revert("FAIL");
     }
 }
+

--- a/tests/integration/solidity_contracts/PlainOpcodes/RevertTestCases.sol
+++ b/tests/integration/solidity_contracts/PlainOpcodes/RevertTestCases.sol
@@ -23,4 +23,3 @@ contract ContractRevertsOnConstruction {
         revert("FAIL");
     }
 }
-

--- a/tests/integration/solidity_contracts/PlainOpcodes/Safe.sol
+++ b/tests/integration/solidity_contracts/PlainOpcodes/Safe.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.13;
 
 contract Safe {
+    constructor() payable {}
+
     receive() external payable {}
 
     function withdrawTransfer() external {

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_counter.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_counter.py
@@ -41,3 +41,10 @@ class TestCounter:
             await counter.inc(caller_address=counter_deployer)
             await counter.reset(caller_address=counter_deployer)
             assert await counter.count() == 0
+
+    class TestDeploymentWithValue:
+        async def test_deployment_with_value_should_fail(
+            self, deploy_solidity_contract
+        ):
+            with kakarot_error():
+                await deploy_solidity_contract("PlainOpcodes", "Counter", value=1)

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
@@ -31,10 +31,6 @@ class TestSafe:
             ).result.balance.low == ACCOUNT_BALANCE
 
     class TestDeploySafeWithValue:
-        async def test_deploy_safe_with_value(
-            self, safe, deploy_solidity_contract
-        ):
-            safe = await deploy_solidity_contract(
-                "PlainOpcodes", "Safe", value=1
-            )
+        async def test_deploy_safe_with_value(self, safe, deploy_solidity_contract):
+            safe = await deploy_solidity_contract("PlainOpcodes", "Safe", value=1)
             assert await safe.balance() == 1

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
@@ -29,3 +29,12 @@ class TestSafe:
             assert (
                 await eth.balanceOf(owner.starknet_address).call()
             ).result.balance.low == ACCOUNT_BALANCE
+
+    class TestDeploySafeWithValue:
+        async def test_deploy_safe_with_value(
+            self, safe, safe_deployer, deploy_solidity_contract
+        ):
+            safe = await deploy_solidity_contract(
+                "PlainOpcodes", "Safe", value=int("1", 16)
+            )
+            assert await safe.balance() == 1

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
@@ -35,6 +35,6 @@ class TestSafe:
             self, safe, safe_deployer, deploy_solidity_contract
         ):
             safe = await deploy_solidity_contract(
-                "PlainOpcodes", "Safe", value=int("1", 16)
+                "PlainOpcodes", "Safe", value=1
             )
             assert await safe.balance() == 1

--- a/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
+++ b/tests/integration/solidity_contracts/PlainOpcodes/test_safe.py
@@ -32,7 +32,7 @@ class TestSafe:
 
     class TestDeploySafeWithValue:
         async def test_deploy_safe_with_value(
-            self, safe, safe_deployer, deploy_solidity_contract
+            self, safe, deploy_solidity_contract
         ):
             safe = await deploy_solidity_contract(
                 "PlainOpcodes", "Safe", value=1

--- a/tests/integration/solidity_contracts/conftest.py
+++ b/tests/integration/solidity_contracts/conftest.py
@@ -71,7 +71,7 @@ def deploy_bytecode(kakarot, deploy_eoa):
     the corresponding starknet address and the starknet transaction.
     """
 
-    async def _factory(bytecode: str, caller_eoa=None):
+    async def _factory(bytecode: str, value=0, caller_eoa=None):
         """
         This factory is what is actually returned by pytest when requesting the `deploy_bytecode`
         fixture.
@@ -85,7 +85,7 @@ def deploy_bytecode(kakarot, deploy_eoa):
             to=0,
             gas_limit=1_000_000,
             gas_price=0,
-            value=0,
+            value=value,
             data=hex_string_to_bytes_array(bytecode),
         ).execute(caller_address=caller_eoa.starknet_address)
 
@@ -124,10 +124,10 @@ def deploy_solidity_contract(deploy_bytecode, get_solidity_contract):
         is required and filtered out before calling the constructor.
         """
         contract = get_contract(contract_app, contract_name)
+        value = kwargs.pop("value", 0)
         caller_eoa = kwargs.pop("caller_eoa", None)
         evm_contract_address, starknet_contract_address, tx = await deploy_bytecode(
-            contract.constructor(*args, **kwargs).data_in_transaction,
-            caller_eoa,
+            contract.constructor(*args, **kwargs).data_in_transaction, value, caller_eoa
         )
         return get_solidity_contract(
             contract_app,
@@ -153,7 +153,7 @@ def create_account_with_bytecode_and_storage(
     """
 
     async def _factory(
-        bytecode: str = "", storage: Optional[Dict[str, str]] = None, caller_eoa=None
+        bytecode: str = "", storage: Optional[Dict[str, str]] = None, value=0, caller_eoa=None
     ):
         """
         This factory is what is actually returned by pytest when requesting the `create_account_with_bytecode_and_storage`
@@ -166,6 +166,7 @@ def create_account_with_bytecode_and_storage(
 
         evm_contract_address, starknet_contract_address, _ = await deploy_bytecode(
             "",
+            value,
             caller_eoa,
         )
 

--- a/tests/integration/solidity_contracts/conftest.py
+++ b/tests/integration/solidity_contracts/conftest.py
@@ -153,7 +153,10 @@ def create_account_with_bytecode_and_storage(
     """
 
     async def _factory(
-        bytecode: str = "", storage: Optional[Dict[str, str]] = None, value=0, caller_eoa=None
+        bytecode: str = "",
+        storage: Optional[Dict[str, str]] = None,
+        value=0,
+        caller_eoa=None,
     ):
         """
         This factory is what is actually returned by pytest when requesting the `create_account_with_bytecode_and_storage`


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- As of now we cannot transfer `value` when making a transaction `to`: "", i.e during an account creation.

Resolves #682 

## What is the new behavior?

- The value transfer during contract deployment is allowed.