### PR TITLE
dev: set contract account nonce to 1 after CREATE/CREATE2

### DIFF
--- a/src/kakarot/accounts/contract/library.cairo
+++ b/src/kakarot/accounts/contract/library.cairo
@@ -57,6 +57,7 @@ namespace ContractAccount {
         is_initialized_.write(1);
         Ownable.initializer(kakarot_address);
         evm_address.write(_evm_address);
+        nonce.write(1);
         // Give infinite ETH transfer allowance to Kakarot
         let (native_token_address) = IKakarot.get_native_token(kakarot_address);
         let (infinite) = uint256_not(Uint256(0, 0));

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -865,6 +865,7 @@ namespace CreateHelper {
             );
 
             let (contract_account_class_hash_) = contract_account_class_hash.read();
+            IContractAccount.increment_nonce(ctx.starknet_contract_address);
             let (starknet_contract_address) = Accounts.create(
                 contract_account_class_hash_, evm_contract_address
             );

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -294,8 +294,6 @@ namespace Kakarot {
             bytecode_len=return_data_len,
             bytecode=return_data,
         );
-        // Increment nonce
-        IContractAccount.increment_nonce(contract_address=starknet_contract_address);
         return (starknet_contract_address=starknet_contract_address);
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.2

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Created contract account nonce is not set to 1 after creation

Resolves #715 

## What is the new behavior?
- Move setting of nonce to initialize
- Created contract account nonce is set to 1 after creation

<!-- Please describe the behavior or changes that are being added by this PR. -->
