### PR TITLE
Make wait_for_transaction handle v4 RPC

### DIFF
--- a/scripts/utils/starknet.py
+++ b/scripts/utils/starknet.py
@@ -557,7 +557,9 @@ async def wait_for_transaction(*args, **kwargs):
                     f"tx {transaction_hash:x} error: {json.dumps(payload['error'])}"
                 )
                 break
-        status = payload.get("result", {}).get("status")
+        status = payload.get("result", {}).get("status") or payload.get(
+            "result", {}
+        ).get("finality_status")
         if status is not None:
             status = TransactionStatus(status)
         else:

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -154,7 +154,19 @@ def compute_starknet_address(kakarot: Contract):
 
 
 @pytest.fixture(scope="session")
-def deploy_externally_owned_account(kakarot: Contract, max_fee: int):
+def wait_for_transaction():
+    from scripts.utils.starknet import wait_for_transaction
+
+    async def _factory(*args, **kwargs):
+        return await wait_for_transaction(*args, **kwargs)
+
+    return _factory
+
+
+@pytest.fixture(scope="session")
+def deploy_externally_owned_account(
+    kakarot: Contract, max_fee: int, wait_for_transaction
+):
     """
     Isolate the starknet-py logic and make the test agnostic of the backend.
     """
@@ -165,7 +177,7 @@ def deploy_externally_owned_account(kakarot: Contract, max_fee: int):
         tx = await kakarot.functions["deploy_externally_owned_account"].invoke(
             evm_address, max_fee=max_fee
         )
-        await tx.wait_for_acceptance()
+        await wait_for_transaction(tx.hash)
         return tx
 
     return _factory

--- a/tests/end_to_end/test_kakarot.py
+++ b/tests/end_to_end/test_kakarot.py
@@ -38,6 +38,7 @@ class TestKakarot:
         self,
         starknet: FullNodeClient,
         eth: Contract,
+        wait_for_transaction,
         params: dict,
         request,
         evm: Contract,
@@ -75,9 +76,9 @@ class TestKakarot:
         if events:
             # Events only show up in a transaction, thus we run the same call, but in a tx
             tx = await call.invoke(max_fee=max_fee)
-            await tx.wait_for_acceptance()
+            status = await wait_for_transaction(tx.hash)
+            assert status == TransactionStatus.ACCEPTED_ON_L2
             receipt = await starknet.get_transaction_receipt(tx.hash)
-            assert receipt.status == TransactionStatus.ACCEPTED_ON_L2
             assert [
                 [
                     # we remove the key that is used to convey the emitting kakarot evm contract


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Neither Starknet.py wait_for_acceptance not our `wait_for_transaction` util accept
RPC v4 response, with the `status` field replaced by `execution_status` and `finality_status`.

## What is the new behavior?

Also search for `finality_status` key in the receipt.
