### PR TITLE
fix `evm_to_starknet_address` storage entry in `setup_test_state` and `is_account_eoa` predicate in `assert_post_state`

### DIFF
--- a/tests/integration/ef_tests/test_ef_blockchain_tests.py
+++ b/tests/integration/ef_tests/test_ef_blockchain_tests.py
@@ -99,7 +99,7 @@ class TestEFBlockchain:
             actual_nonce = (
                 # For EOA's, nonces are mapped to system level nonce.
                 await starknet.state.state.get_nonce_at(starknet_address)
-                if is_account_eoa(expected_post_state)
+                if is_account_eoa(account)
                 # For evm contracts, nonces are managed by Kakarot as contract state.
                 else await starknet.state.state.get_storage_at(
                     starknet_address, get_storage_var_address("nonce")

--- a/tests/integration/ef_tests/test_ef_blockchain_tests.py
+++ b/tests/integration/ef_tests/test_ef_blockchain_tests.py
@@ -41,7 +41,7 @@ class TestEFBlockchain:
             storage_entries = (
                 (("is_initialized",), 1),
                 (("evm_address",), evm_address),
-                (("evm_to_starknet_address", starknet_address), evm_address),
+                (("evm_to_starknet_address", evm_address), starknet_address),
             ) + (
                 (
                     (("kakarot_address",), kakarot.contract_address),

--- a/tests/integration/ef_tests/utils.py
+++ b/tests/integration/ef_tests/utils.py
@@ -1,2 +1,2 @@
-def is_account_eoa(state: dict) -> bool:
-    return state.get("code") in [None, "0x"] and not state.get("storage")
+def is_account_eoa(account: dict) -> bool:
+    return account.get("code") in [None, "0x"] and not account.get("storage")


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

https://github.com/kkrt-labs/kakarot/blob/5d0390e3f7fd55e08f7129c11373ada2aec5b955/tests/integration/ef_tests/test_ef_blockchain_tests.py#L44

Storage key argument and value are in the wrong order.

https://github.com/kkrt-labs/kakarot/blob/5d0390e3f7fd55e08f7129c11373ada2aec5b955/tests/integration/ef_tests/test_ef_blockchain_tests.py#L102

`is_account_eoa` is passed the wrong dict object in `assert_post_state`

Resolves #<Issue number>

## What is the new behavior?

- Corrected order of `evm_to_starknet_address
- `assert_post_state` determines `is_account_eoa` correctly


