### PR TITLE
Fix OutOfBounds for return_data

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,7 +23,7 @@ lint:
         - output: rewrite
           success_codes: [0]
           formatter: true
-          run: poetry run cairo-format ${target}
+          run: cairo-format ${target}
           read_output_from: stdout
           run_linter_from: workspace
   enabled:

--- a/scripts/compile_kakarot.py
+++ b/scripts/compile_kakarot.py
@@ -1,9 +1,12 @@
 # %% Imports
 import logging
+import multiprocessing as mp
 from datetime import datetime
 
 from scripts.constants import COMPILED_CONTRACTS, NETWORK
 from scripts.utils.starknet import compile_contract
+
+mp.set_start_method("fork")
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -15,8 +18,8 @@ def main():
     # %% Compile
     logger.info(f"ℹ️  Compiling contracts for network {NETWORK['name']}")
     initial_time = datetime.now()
-    for contract in COMPILED_CONTRACTS:
-        compile_contract(contract)
+    with mp.Pool() as pool:
+        pool.map(compile_contract, COMPILED_CONTRACTS)
 
     logger.info(
         f"✅ Compiled all in {(datetime.now() - initial_time).total_seconds():.2f}s"

--- a/scripts/utils/starknet.py
+++ b/scripts/utils/starknet.py
@@ -300,7 +300,9 @@ def compile_contract(contract):
         indent=2,
     )
     elapsed = datetime.now() - start
-    logger.info(f"✅ Compiled in {elapsed.total_seconds():.2f}s")
+    logger.info(
+        f"✅ {contract['contract_name']} compiled in {elapsed.total_seconds():.2f}s"
+    )
 
 
 async def deploy_starknet_account(class_hash, private_key=None, amount=1):

--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -518,8 +518,8 @@ namespace ExecutionContext {
     // @notice Update the return data of the current execution context.
     // @dev The memory is updated with the given memory.
     // @param self The pointer to the execution context.
-    // @param new_return_data_len The length of the return data array.
-    // @param new_return_data The return data array.
+    // @param return_data_len The length of the return data array.
+    // @param return_data The return data array.
     // @return ExecutionContext The pointer to the updated execution context.
     func update_return_data{
         syscall_ptr: felt*,
@@ -527,14 +527,14 @@ namespace ExecutionContext {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(
-        self: model.ExecutionContext*, new_return_data_len: felt, new_return_data: felt*
+        self: model.ExecutionContext*, return_data_len: felt, return_data: felt*
     ) -> model.ExecutionContext* {
         return new model.ExecutionContext(
             call_context=self.call_context,
             program_counter=self.program_counter,
             stopped=self.stopped,
-            return_data=new_return_data,
-            return_data_len=new_return_data_len,
+            return_data=return_data,
+            return_data_len=return_data_len,
             stack=self.stack,
             memory=self.memory,
             gas_used=self.gas_used,

--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -60,7 +60,6 @@ namespace ExecutionContext {
         dw 0;  // evm_contract_address
         dw 0;  // origin
         dw 0;  // calling_context
-        dw 0;  // sub_context
         dw 0;  // destroy_contracts_len
         dw 0;  // destroy_contracts
         dw 0;  // events_len
@@ -113,7 +112,6 @@ namespace ExecutionContext {
 
         let stack: model.Stack* = Stack.init();
         let memory: model.Memory* = Memory.init();
-        let sub_context = init_empty();
 
         return new model.ExecutionContext(
             call_context=call_context,
@@ -130,7 +128,6 @@ namespace ExecutionContext {
             evm_contract_address=evm_contract_address,
             origin=origin,
             calling_context=calling_context,
-            sub_context=sub_context,
             destroy_contracts_len=0,
             destroy_contracts=empty_destroy_contracts,
             events_len=0,
@@ -197,17 +194,6 @@ namespace ExecutionContext {
         return FALSE;
     }
 
-    // @notice Return whether the current execution context is a leaf.
-    // @dev A leaf context is a context without sub context.
-    // @param self The pointer to the execution context.
-    // @return is_leaf TRUE if the execution context is a leaf, FALSE otherwise.
-    func is_leaf(self: model.ExecutionContext*) -> felt {
-        if (cast(self.sub_context.call_context, felt) == 0) {
-            return TRUE;
-        }
-        return FALSE;
-    }
-
     // @notice Stop the current execution context.
     // @dev When the execution context is stopped, no more instructions can be executed.
     // @param self The pointer to the execution context.
@@ -228,7 +214,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -258,12 +243,11 @@ namespace ExecutionContext {
     func revert(
         self: model.ExecutionContext*, revert_reason: felt*, size: felt
     ) -> model.ExecutionContext* {
-        memcpy(self.return_data, revert_reason, size);
         return new model.ExecutionContext(
             call_context=self.call_context,
             program_counter=self.program_counter,
             stopped=TRUE,
-            return_data=self.return_data,
+            return_data=revert_reason,
             return_data_len=size,
             stack=self.stack,
             memory=self.memory,
@@ -274,7 +258,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -466,7 +449,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -502,7 +484,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -544,7 +525,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -580,7 +560,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -616,43 +595,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
-            destroy_contracts_len=self.destroy_contracts_len,
-            destroy_contracts=self.destroy_contracts,
-            events_len=self.events_len,
-            events=self.events,
-            create_addresses_len=self.create_addresses_len,
-            create_addresses=self.create_addresses,
-            revert_contract_state=self.revert_contract_state,
-            reverted=self.reverted,
-            read_only=self.read_only,
-        );
-    }
-
-    // @notice Update the child context of the current execution context.
-    // @dev The sub_context is updated with the given context.
-    // @param self The pointer to the execution context.
-    // @param sub_context The pointer to the child context.
-    // @return ExecutionContext The pointer to the updated execution context.
-    func update_sub_context(
-        self: model.ExecutionContext*, sub_context: model.ExecutionContext*
-    ) -> model.ExecutionContext* {
-        return new model.ExecutionContext(
-            call_context=self.call_context,
-            program_counter=self.program_counter,
-            stopped=self.stopped,
-            return_data=self.return_data,
-            return_data_len=self.return_data_len,
-            stack=self.stack,
-            memory=self.memory,
-            gas_used=self.gas_used,
-            gas_limit=self.gas_limit,
-            gas_price=self.gas_price,
-            starknet_contract_address=self.starknet_contract_address,
-            evm_contract_address=self.evm_contract_address,
-            origin=self.origin,
-            calling_context=self.calling_context,
-            sub_context=sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -689,7 +631,6 @@ namespace ExecutionContext {
             evm_contract_address=evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -730,7 +671,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len + destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -773,7 +713,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len + 1,
@@ -808,7 +747,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -844,7 +782,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len + 1,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -881,7 +818,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,
@@ -937,7 +873,6 @@ namespace ExecutionContext {
             evm_contract_address=self.evm_contract_address,
             origin=self.origin,
             calling_context=self.calling_context,
-            sub_context=self.sub_context,
             destroy_contracts_len=self.destroy_contracts_len,
             destroy_contracts=self.destroy_contracts,
             events_len=self.events_len,

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -549,7 +549,7 @@ namespace EnvironmentalInformation {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         // Get return data size.
-        let return_data_size = Helpers.to_uint256(ctx.sub_context.return_data_len);
+        let return_data_size = Helpers.to_uint256(ctx.return_data_len);
         let stack: model.Stack* = Stack.push(self=ctx.stack, element=return_data_size);
 
         // Update the execution context.
@@ -588,12 +588,9 @@ namespace EnvironmentalInformation {
         let return_data_offset = popped[1];
         let element_len = popped[2];
 
-        let return_data_len: felt = ctx.sub_context.return_data_len;
-        let return_data: felt* = ctx.sub_context.return_data;
-
         let sliced_return_data: felt* = Helpers.slice_data(
-            data_len=return_data_len,
-            data=return_data,
+            data_len=ctx.return_data_len,
+            data=ctx.return_data,
             data_offset=return_data_offset.low,
             slice_len=element_len.low,
         );

--- a/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
@@ -52,7 +52,7 @@ namespace StopAndArithmeticOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        // Clear latest sub_context's return data
+        // Clear data from the last executed sub context
         let (return_data: felt*) = alloc();
         let ctx = ExecutionContext.update_return_data(
             ctx, return_data_len=0, return_data=return_data

--- a/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
@@ -16,6 +16,7 @@ from starkware.cairo.common.uint256 import (
     uint256_mul_div_mod,
 )
 from starkware.cairo.common.bool import FALSE, TRUE
+from starkware.cairo.common.alloc import alloc
 
 // Internal dependencies
 from kakarot.model import model
@@ -50,8 +51,13 @@ namespace StopAndArithmeticOperations {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(ctx_ptr: model.ExecutionContext*) -> model.ExecutionContext* {
-        let ctx = ExecutionContext.stop(ctx_ptr);
+    }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
+        // Clear latest sub_context's return data
+        let (return_data: felt*) = alloc();
+        let ctx = ExecutionContext.update_return_data(
+            ctx, return_data_len=0, return_data=return_data
+        );
+        let ctx = ExecutionContext.stop(ctx);
         return ctx;
     }
 

--- a/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
@@ -52,7 +52,10 @@ namespace StopAndArithmeticOperations {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        // Clear data from the last executed sub context
+        // return_data stored the return_data for the last executed sub context
+        // see CALLs opcodes. When we run the STOP opcode, we stop the current
+        // execution context with *no* return data (unlike RETURN and REVERT).
+        // hence we just clear the return_data and stop.
         let (return_data: felt*) = alloc();
         let ctx = ExecutionContext.update_return_data(
             ctx, return_data_len=0, return_data=return_data

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -585,11 +585,6 @@ namespace CallHelper {
         let memory = Memory.store_n(ctx.memory, ret_size, return_data, ret_offset);
         let ctx = ExecutionContext.update_memory(ctx, memory);
 
-        // Clear sub_context's return_data args
-        let (local return_data: felt*) = alloc();
-        let ctx = ExecutionContext.update_return_data(
-            ctx, return_data_len=0, return_data=return_data
-        );
         return ctx;
     }
 }

--- a/src/kakarot/model.cairo
+++ b/src/kakarot/model.cairo
@@ -90,7 +90,6 @@ namespace model {
     // @param evm_contract_address The evm address of the contract interacted with.
     // @param calling_context The parent context of the current execution context, can be empty when context
     //                        is root context | see ExecutionContext.is_root(ctx).
-    // @param sub_context The child context of the current execution context, can be empty.
     // @param destroy_contracts_len The destroy_contract length.
     // @param destroy_contracts The array of contracts to destroy at the end of the transaction.
     // @param events_len The events length.
@@ -114,7 +113,6 @@ namespace model {
         evm_contract_address: felt,
         origin: felt,
         calling_context: ExecutionContext*,
-        sub_context: ExecutionContext*,
         destroy_contracts_len: felt,
         destroy_contracts: felt*,
         events_len: felt,

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -71,7 +71,6 @@ namespace Precompiles {
             evm_contract_address=address,
             origin=calling_context.origin,
             calling_context=calling_context,
-            sub_context=cast(0, model.ExecutionContext*),
             destroy_contracts_len=0,
             destroy_contracts=cast(0, felt*),
             events_len=0,

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -33,8 +33,6 @@ namespace Precompiles {
     // @param calldata The calldata.
     // @param value The value.
     // @param calling_context The calling context.
-    // @param return_data_len The length of the return data array.
-    // @param return_data The return data array.
     // @return ExecutionContext The initialized execution context.
     func run{
         syscall_ptr: felt*,
@@ -47,16 +45,11 @@ namespace Precompiles {
         calldata: felt*,
         value: felt,
         calling_context: model.ExecutionContext*,
-        return_data_len: felt,
-        return_data: felt*,
     ) -> model.ExecutionContext* {
         alloc_locals;
 
         // Execute the precompile at a given address
         let (output_len, output, gas_used) = _exec_precompile(address, calldata_len, calldata);
-
-        // Copy results of precompile to return data
-        memcpy(return_data, output, output_len);
 
         let (local revert_contract_state_dict_start) = default_dict_new(0);
         tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
@@ -67,8 +60,8 @@ namespace Precompiles {
             call_context=cast(0, model.CallContext*),
             program_counter=0,
             stopped=TRUE,
-            return_data=return_data,
-            return_data_len=return_data_len,
+            return_data=output,
+            return_data_len=output_len,
             stack=cast(0, model.Stack*),
             memory=cast(0, model.Memory*),
             gas_used=gas_used,

--- a/tests/src/kakarot/instructions/test_stop_and_arithmetic_operations.cairo
+++ b/tests/src/kakarot/instructions/test_stop_and_arithmetic_operations.cairo
@@ -328,6 +328,7 @@ func test__exec_stop{
     let stopped_ctx = StopAndArithmeticOperations.exec_stop(ctx);
 
     assert stopped_ctx.stopped = TRUE;
+    assert stopped_ctx.return_data_len = 0;
 
     return ();
 }

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -213,9 +213,6 @@ func test__exec_call__should_return_a_new_context_based_on_calling_ctx_stack{
     let sub_ctx = SystemOperations.exec_call(ctx);
 
     // Then
-    // assert than calling_context stores the CALL args for RETURN_DATA
-    assert sub_ctx.calling_context.return_data_len = ret_size.low;
-    assert [sub_ctx.calling_context.return_data] = ret_offset.low;
 
     // assert than sub_context is well initialized
     assert sub_ctx.call_context.bytecode_len = 0;
@@ -382,8 +379,6 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
     assert sub_ctx.call_context.value = value.low;
     assert sub_ctx.program_counter = 0;
     assert sub_ctx.stopped = 0;
-    assert sub_ctx.calling_context.return_data_len = ret_size.low;
-    assert [sub_ctx.calling_context.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
     let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
     assert_le(sub_ctx.gas_limit, gas_felt);
@@ -528,8 +523,6 @@ func test__exec_staticcall__should_return_a_new_context_based_on_calling_ctx_sta
     assert sub_ctx.call_context.value = 0;
     assert sub_ctx.program_counter = 0;
     assert sub_ctx.stopped = 0;
-    assert sub_ctx.calling_context.return_data_len = ret_size.low;
-    assert [sub_ctx.calling_context.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
     let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
     assert_le(sub_ctx.gas_limit, gas_felt);
@@ -605,8 +598,6 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
     assert sub_ctx.call_context.value = 0;
     assert sub_ctx.program_counter = 0;
     assert sub_ctx.stopped = 0;
-    assert sub_ctx.calling_context.return_data_len = ret_size.low;
-    assert [sub_ctx.calling_context.return_data] = ret_offset.low;
     assert sub_ctx.gas_used = 0;
     let (gas_felt, _) = Helpers.div_rem(Constants.TRANSACTION_GAS_LIMIT, 64);
     assert_le(sub_ctx.gas_limit, gas_felt);

--- a/tests/src/kakarot/precompiles/test_precompiles.cairo
+++ b/tests/src/kakarot/precompiles/test_precompiles.cairo
@@ -30,8 +30,6 @@ func test__precompiles_should_throw_on_out_of_bounds{
         calldata=cast(0, felt*),
         value=0,
         calling_context=cast(0, model.ExecutionContext*),
-        return_data_len=0,
-        return_data=cast(0, felt*),
     );
 
     return ();
@@ -66,8 +64,6 @@ func test__run_should_return_a_stopped_execution_context{
         calldata=cast(0, felt*),
         value=0,
         calling_context=calling_context,
-        return_data_len=0,
-        return_data=cast(0, felt*),
     );
 
     assert result.stopped = 1;

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -114,32 +114,6 @@ namespace TestHelpers {
         return init_context(bytecode_count, bytecode);
     }
 
-    func init_context_with_stack_and_sub_ctx{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-    }(
-        bytecode_len: felt, bytecode: felt*, stack: model.Stack*, sub_ctx: model.ExecutionContext*
-    ) -> model.ExecutionContext* {
-        let ctx: model.ExecutionContext* = init_context_with_stack(bytecode_len, bytecode, stack);
-        let ctx = ExecutionContext.update_sub_context(ctx, sub_ctx);
-        return ctx;
-    }
-
-    func init_context_with_sub_ctx{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-    }(sub_ctx: model.ExecutionContext*) -> model.ExecutionContext* {
-        let (bytecode) = alloc();
-        let stack: model.Stack* = Stack.init();
-        let ctx: model.ExecutionContext* = init_context_with_stack(0, bytecode, stack);
-        let ctx = ExecutionContext.update_sub_context(ctx, sub_ctx);
-        return ctx;
-    }
-
     func init_context_with_return_data{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,


### PR DESCRIPTION
Time spent on this PR: 0.4

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Fails to finalize a calling context when `ret_size` is greater than `return_data_len`.

Resolves #718 

## What is the new behavior?

Use `Helpers.slice` to make sure that the stored `return_data` is big enough.

Note: we previously stored the `ret_offset` in the `sub_context.return_data[0]`. I have put both `ret_offset` and `ret_size` in the calling_context return data, as:

- this is more logical: they belong to the calling context and not the sub context
- it is safe because return_data is only written in RETURN, which stops the context, so no data could have been put before a call
- actually I've seen that geth and the execution spec reads RETURNDATASIZE and RETURNDATACOPY directly from the execution context and don't keep a ref to the previous sub_context. Might be an idea for a future refacto