### PR TITLE
Add test case for issue 683 & 684

### DIFF
--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -135,7 +135,7 @@ async def deploy(
         max_fee=max_fee,
         value=value,
     )
-    contract.address = Web3.to_checksum_address(evm_address)
+    contract.address = Web3.to_checksum_address(f"0x{evm_address:040x}")
     contract.starknet_address = starknet_address
     logger.info(f"✅ {contract_name} deployed at address {contract.address}")
 

--- a/solidity_contracts/src/PlainOpcodes/Counter.sol
+++ b/solidity_contracts/src/PlainOpcodes/Counter.sol
@@ -17,7 +17,7 @@ contract Counter {
         count += 1;
     }
 
-    function decUnchecked() public greaterThanZero {
+    function decUnchecked() public {
         unchecked {
             count -= 1;
         }

--- a/solidity_contracts/src/PlainOpcodes/Counter.sol
+++ b/solidity_contracts/src/PlainOpcodes/Counter.sol
@@ -34,4 +34,18 @@ contract Counter {
     function reset() public {
         count = 0;
     }
+
+    function incForLoop(uint256 iterations) public {
+        count = 0;
+        for (uint256 i = 0; i < iterations; i++) {
+            count++;
+        }
+    }
+
+    function incWhileLoop(uint256 iterations) public {
+        count = 0;
+        while (count < iterations) {
+            count++;
+        }
+    }
 }

--- a/tests/end_to_end/PlainOpcodes/test_counter.py
+++ b/tests/end_to_end/PlainOpcodes/test_counter.py
@@ -75,3 +75,18 @@ class TestCounter:
         ):
             with kakarot_error():
                 await deploy_solidity_contract("PlainOpcodes", "Counter", value=1)
+
+    class TestLoops:
+        @pytest.mark.parametrize("iterations", [0, 50, 100])
+        async def test_should_set_counter_to_iterations_with_for_loop(
+            self, counter, owner, iterations
+        ):
+            await counter.incForLoop(iterations, caller_eoa=owner)
+            assert await counter.count() == iterations
+
+        @pytest.mark.parametrize("iterations", [0, 50, 200])
+        async def test_should_set_counter_to_iterations_with_while_loop(
+            self, counter, owner, iterations
+        ):
+            await counter.incWhileLoop(iterations, caller_eoa=owner)
+            assert await counter.count() == iterations

--- a/tests/end_to_end/PlainOpcodes/test_counter.py
+++ b/tests/end_to_end/PlainOpcodes/test_counter.py
@@ -21,47 +21,45 @@ class TestCounter:
 
     class TestInc:
         async def test_should_increase_count(self, counter, owner):
-            count_before = await counter.count()
+            await counter.reset(caller_eoa=owner)
             await counter.inc(caller_eoa=owner)
-            count_after = await counter.count()
-            assert count_after - count_before == 1
+            assert await counter.count() == 1
 
     class TestDec:
         @pytest.mark.xfail(
             os.environ.get("STARKNET_NETWORK", "katana") == "katana",
             reason="https://github.com/dojoengine/dojo/issues/864",
         )
-        async def test_should_raise_when_count_is_0_from_modifier(self, counter, owner):
+        async def test_should_raise_from_modifier_when_count_is_0(self, counter, owner):
+            await counter.reset(caller_eoa=owner)
             with kakarot_error("count should be strictly greater than 0"):
                 await counter.dec(caller_eoa=owner)
 
         @pytest.mark.xfail(
             reason="https://github.com/kkrt-labs/kakarot/issues/683",
         )
-        async def test_should_raise_when_count_is_0_from_vm(self, counter, owner):
+        async def test_should_raise_from_vm_when_count_is_0(self, counter, owner):
+            await counter.reset(caller_eoa=owner)
             with kakarot_error():
                 await counter.decUnchecked(caller_eoa=owner)
 
         async def test_should_decrease_count(self, counter, owner):
-            count_before = await counter.count()
+            await counter.reset(caller_eoa=owner)
             await counter.inc(caller_eoa=owner)
             await counter.dec(caller_eoa=owner)
-            count_after = await counter.count()
-            assert count_after == count_before
+            assert await counter.count() == 0
 
         async def test_should_decrease_count_unchecked(self, counter, owner):
-            count_before = await counter.count()
+            await counter.reset(caller_eoa=owner)
             await counter.inc(caller_eoa=owner)
             await counter.decUnchecked(caller_eoa=owner)
-            count_after = await counter.count()
-            assert count_after == count_before
+            assert await counter.count() == 0
 
         async def test_should_decrease_count_in_place(self, counter, owner):
-            count_before = await counter.count()
+            await counter.reset(caller_eoa=owner)
             await counter.inc(caller_eoa=owner)
             await counter.decInPlace(caller_eoa=owner)
-            count_after = await counter.count()
-            assert count_after == count_before
+            assert await counter.count() == 0
 
     class TestReset:
         async def test_should_set_count_to_0(self, counter, owner):

--- a/tests/end_to_end/PlainOpcodes/test_counter.py
+++ b/tests/end_to_end/PlainOpcodes/test_counter.py
@@ -31,9 +31,16 @@ class TestCounter:
             os.environ.get("STARKNET_NETWORK", "katana") == "katana",
             reason="https://github.com/dojoengine/dojo/issues/864",
         )
-        async def test_should_raise_when_count_is_0(self, counter, owner):
+        async def test_should_raise_when_count_is_0_from_modifier(self, counter, owner):
             with kakarot_error("count should be strictly greater than 0"):
                 await counter.dec(caller_eoa=owner)
+
+        @pytest.mark.xfail(
+            reason="https://github.com/kkrt-labs/kakarot/issues/683",
+        )
+        async def test_should_raise_when_count_is_0_from_vm(self, counter, owner):
+            with kakarot_error():
+                await counter.decUnchecked(caller_eoa=owner)
 
         async def test_should_decrease_count(self, counter, owner):
             count_before = await counter.count()


### PR DESCRIPTION
Time spent on this PR: 0.05

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

Kakarot doesn't revert when doing `0 - 1` for `uint256`.

There was already an issue, I just added a test.

## What is the new behavior?

Still not passing
