### PR TITLE
Remove wrong assert in Account.set_code

### DIFF
--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -289,7 +289,6 @@ namespace Account {
     // @param code_len The len of the code
     // @param code The code array
     func set_code(self: model.Account*, code_len: felt, code: felt*) -> model.Account* {
-        assert self.code_len = 0;
         return new model.Account(
             address=self.address,
             code_len=code_len,


### PR DESCRIPTION

Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`Account.set_code` assert that the account has no code.
This cause `evm.finalize` to break, even though the tx is reverted.

## What is the new behavior?

No assertion, this is not the role of the `Account` to make sure that it's allowed to actually write code.
