### PR TITLE
Add deploy_bytecode utils and fix dict_ptr error in memory.finalize

### DIFF
--- a/solidity_contracts/src/PlainOpcodes/PlainOpcodes.sol
+++ b/solidity_contracts/src/PlainOpcodes/PlainOpcodes.sol
@@ -72,6 +72,10 @@ contract PlainOpcodes {
         return address(counter).staticcall(data);
     }
 
+    function opcodeStaticCallToAddress(address target, bytes memory data) public view returns (bool, bytes memory) {
+        return target.staticcall(data);
+    }
+
     function opcodeCall() public {
         counter.inc();
     }

--- a/solidity_contracts/tests/PlainOpcodes.t.sol
+++ b/solidity_contracts/tests/PlainOpcodes.t.sol
@@ -111,4 +111,10 @@ contract PlainOpcodesTest is Test {
         (bool success,) = plainOpcodes.opcodeStaticCall2();
         assert(!success);
     }
+
+    function testStaticCallToCallToInc() public view {
+        bytes memory data = abi.encodeWithSelector(bytes4(keccak256("opcodeCall()")));
+        (bool success,) = plainOpcodes.opcodeStaticCallToAddress(address(plainOpcodes), data);
+        assert(!success);
+    }
 }

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -230,8 +230,8 @@ namespace SystemOperations {
         );
         if (ctx.call_context.read_only * sub_ctx.call_context.value != FALSE) {
             let (revert_reason_len, revert_reason) = Errors.stateModificationError();
-            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
-            return ctx;
+            let sub_ctx = ExecutionContext.stop(sub_ctx, revert_reason_len, revert_reason, TRUE);
+            return sub_ctx;
         }
 
         let (value_high, value_low) = split_felt(sub_ctx.call_context.value);

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -230,8 +230,9 @@ namespace SystemOperations {
         );
         if (ctx.call_context.read_only * sub_ctx.call_context.value != FALSE) {
             let (revert_reason_len, revert_reason) = Errors.stateModificationError();
-            let sub_ctx = ExecutionContext.stop(sub_ctx, revert_reason_len, revert_reason, TRUE);
-            return sub_ctx;
+            let ctx = sub_ctx.call_context.calling_context;
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
         }
 
         let (value_high, value_low) = split_felt(sub_ctx.call_context.value);

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -772,18 +772,18 @@ namespace CreateHelper {
         let is_collision = Account.has_code_or_nonce(account);
         let account = Account.set_nonce(account, 1);
 
-        if (is_collision != 0) {
-            let (revert_reason_len, revert_reason) = Errors.addressCollision();
-            tempvar ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
-            return ctx;
-        }
-
         // Update calling context before creating sub context
         let ctx = ExecutionContext.update_memory(ctx, memory);
         let ctx = ExecutionContext.increment_gas_used(
             ctx, gas_cost + SystemOperations.GAS_COST_CREATE
         );
         let ctx = ExecutionContext.update_state(ctx, state);
+
+        if (is_collision != 0) {
+            let (revert_reason_len, revert_reason) = Errors.addressCollision();
+            tempvar ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         // Create sub context with copied state
         let state = State.copy(ctx.state);

--- a/tests/end_to_end/PlainOpcodes/test_counter.py
+++ b/tests/end_to_end/PlainOpcodes/test_counter.py
@@ -19,46 +19,46 @@ class TestCounter:
 
     class TestInc:
         async def test_should_increase_count(self, counter, owner):
-            await counter.reset(caller_eoa=owner)
-            await counter.inc(caller_eoa=owner)
+            await counter.reset(caller_eoa=owner.starknet_contract)
+            await counter.inc(caller_eoa=owner.starknet_contract)
             assert await counter.count() == 1
 
     class TestDec:
         async def test_should_raise_from_modifier_when_count_is_0(self, counter, owner):
-            await counter.reset(caller_eoa=owner)
+            await counter.reset(caller_eoa=owner.starknet_contract)
             with evm_error("count should be strictly greater than 0"):
-                await counter.dec(caller_eoa=owner)
+                await counter.dec(caller_eoa=owner.starknet_contract)
 
         @pytest.mark.xfail(
             reason="https://github.com/kkrt-labs/kakarot/issues/683",
         )
         async def test_should_raise_from_vm_when_count_is_0(self, counter, owner):
-            await counter.reset(caller_eoa=owner)
+            await counter.reset(caller_eoa=owner.starknet_contract)
             with evm_error():
-                await counter.decUnchecked(caller_eoa=owner)
+                await counter.decUnchecked(caller_eoa=owner.starknet_contract)
 
         async def test_should_decrease_count(self, counter, owner):
-            await counter.reset(caller_eoa=owner)
-            await counter.inc(caller_eoa=owner)
-            await counter.dec(caller_eoa=owner)
+            await counter.reset(caller_eoa=owner.starknet_contract)
+            await counter.inc(caller_eoa=owner.starknet_contract)
+            await counter.dec(caller_eoa=owner.starknet_contract)
             assert await counter.count() == 0
 
         async def test_should_decrease_count_unchecked(self, counter, owner):
-            await counter.reset(caller_eoa=owner)
-            await counter.inc(caller_eoa=owner)
-            await counter.decUnchecked(caller_eoa=owner)
+            await counter.reset(caller_eoa=owner.starknet_contract)
+            await counter.inc(caller_eoa=owner.starknet_contract)
+            await counter.decUnchecked(caller_eoa=owner.starknet_contract)
             assert await counter.count() == 0
 
         async def test_should_decrease_count_in_place(self, counter, owner):
-            await counter.reset(caller_eoa=owner)
-            await counter.inc(caller_eoa=owner)
-            await counter.decInPlace(caller_eoa=owner)
+            await counter.reset(caller_eoa=owner.starknet_contract)
+            await counter.inc(caller_eoa=owner.starknet_contract)
+            await counter.decInPlace(caller_eoa=owner.starknet_contract)
             assert await counter.count() == 0
 
     class TestReset:
         async def test_should_set_count_to_0(self, counter, owner):
-            await counter.inc(caller_eoa=owner)
-            await counter.reset(caller_eoa=owner)
+            await counter.inc(caller_eoa=owner.starknet_contract)
+            await counter.reset(caller_eoa=owner.starknet_contract)
             assert await counter.count() == 0
 
     class TestDeploymentWithValue:
@@ -73,12 +73,12 @@ class TestCounter:
         async def test_should_set_counter_to_iterations_with_for_loop(
             self, counter, owner, iterations
         ):
-            await counter.incForLoop(iterations, caller_eoa=owner)
+            await counter.incForLoop(iterations, caller_eoa=owner.starknet_contract)
             assert await counter.count() == iterations
 
         @pytest.mark.parametrize("iterations", [0, 50, 200])
         async def test_should_set_counter_to_iterations_with_while_loop(
             self, counter, owner, iterations
         ):
-            await counter.incWhileLoop(iterations, caller_eoa=owner)
+            await counter.incWhileLoop(iterations, caller_eoa=owner.starknet_contract)
             assert await counter.count() == iterations

--- a/tests/end_to_end/PlainOpcodes/test_plain_opcodes.py
+++ b/tests/end_to_end/PlainOpcodes/test_plain_opcodes.py
@@ -100,33 +100,35 @@ class TestPlainOpcodes:
             }
 
         async def test_should_emit_log0_with_no_data(self, plain_opcodes, owner):
-            receipt = await plain_opcodes.opcodeLog0(caller_eoa=owner)
+            receipt = await plain_opcodes.opcodeLog0(caller_eoa=owner.starknet_contract)
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert events["Log0"] == [{}]
 
         async def test_should_emit_log0_with_data(self, plain_opcodes, owner, event):
-            receipt = await plain_opcodes.opcodeLog0Value(caller_eoa=owner)
+            receipt = await plain_opcodes.opcodeLog0Value(
+                caller_eoa=owner.starknet_contract
+            )
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert events["Log0Value"] == [{"value": event["value"]}]
 
         async def test_should_emit_log1(self, plain_opcodes, owner, event):
-            receipt = await plain_opcodes.opcodeLog1(caller_eoa=owner)
+            receipt = await plain_opcodes.opcodeLog1(caller_eoa=owner.starknet_contract)
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert events["Log1"] == [{"value": event["value"]}]
 
         async def test_should_emit_log2(self, plain_opcodes, owner, event):
-            receipt = await plain_opcodes.opcodeLog2(caller_eoa=owner)
+            receipt = await plain_opcodes.opcodeLog2(caller_eoa=owner.starknet_contract)
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             del event["spender"]
             assert events["Log2"] == [event]
 
         async def test_should_emit_log3(self, plain_opcodes, owner, event):
-            receipt = await plain_opcodes.opcodeLog3(caller_eoa=owner)
+            receipt = await plain_opcodes.opcodeLog3(caller_eoa=owner.starknet_contract)
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert events["Log3"] == [event]
 
         async def test_should_emit_log4(self, plain_opcodes, owner, event):
-            receipt = await plain_opcodes.opcodeLog4(caller_eoa=owner)
+            receipt = await plain_opcodes.opcodeLog4(caller_eoa=owner.starknet_contract)
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert events["Log4"] == [event]
 
@@ -151,7 +153,7 @@ class TestPlainOpcodes:
             receipt = await plain_opcodes.create(
                 bytecode=counter.constructor().data_in_transaction,
                 count=count,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert len(events["CreateAddress"]) == count
@@ -178,7 +180,7 @@ class TestPlainOpcodes:
             receipt = await plain_opcodes.create(
                 bytecode=bytecode,
                 count=1,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
 
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
@@ -234,7 +236,7 @@ class TestPlainOpcodes:
             receipt = await plain_opcodes.create2(
                 bytecode=counter.constructor().data_in_transaction,
                 salt=salt,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert len(events["Create2Address"]) == 1
@@ -276,12 +278,16 @@ class TestPlainOpcodes:
             self, plain_opcodes, owner
         ):
             with evm_error("FAIL"):
-                await plain_opcodes.newContractConstructorRevert(caller_eoa=owner)
+                await plain_opcodes.newContractConstructorRevert(
+                    caller_eoa=owner.starknet_contract
+                )
 
         async def test_should_revert_via_call(
             self, plain_opcodes, get_solidity_contract, owner
         ):
-            receipt = await plain_opcodes.contractCallRevert(caller_eoa=owner)
+            receipt = await plain_opcodes.contractCallRevert(
+                caller_eoa=owner.starknet_contract
+            )
 
             reverting_contract = get_solidity_contract(
                 "PlainOpcodes", "ContractRevertsOnMethodCall"
@@ -295,7 +301,9 @@ class TestPlainOpcodes:
         async def test_should_return_owner_as_origin_and_sender(
             self, plain_opcodes, owner
         ):
-            origin, sender = await plain_opcodes.originAndSender(caller_eoa=owner)
+            origin, sender = await plain_opcodes.originAndSender(
+                caller_eoa=owner.starknet_contract
+            )
             assert origin == sender == owner.address
 
         async def test_should_return_owner_as_origin_and_caller_as_sender(
@@ -304,7 +312,7 @@ class TestPlainOpcodes:
             receipt = await caller.call(
                 target=plain_opcodes.address,
                 payload=plain_opcodes.encodeABI("originAndSender"),
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
             events = caller.events.parse_starknet_events(receipt.events)
             assert len(events["Call"]) == 1
@@ -333,7 +341,9 @@ class TestPlainOpcodes:
             )
             sender_balance_before = await eth_balance_of(plain_opcodes.starknet_address)
 
-            await plain_opcodes.sendSome(other.address, amount, caller_eoa=owner)
+            await plain_opcodes.sendSome(
+                other.address, amount, caller_eoa=owner.starknet_contract
+            )
 
             receiver_balance_after = await eth_balance_of(
                 other.starknet_contract.address
@@ -351,7 +361,9 @@ class TestPlainOpcodes:
 
             sender_balance_before = await eth_balance_of(plain_opcodes.starknet_address)
             receipt = await plain_opcodes.sendSome(
-                other.address, sender_balance_before + 1, caller_eoa=owner
+                other.address,
+                sender_balance_before + 1,
+                caller_eoa=owner.starknet_contract,
             )
             events = plain_opcodes.events.parse_starknet_events(receipt.events)
             assert events["SentSome"] == [

--- a/tests/end_to_end/PlainOpcodes/test_safe.py
+++ b/tests/end_to_end/PlainOpcodes/test_safe.py
@@ -17,18 +17,22 @@ class TestSafe:
     class TestReceive:
         async def test_should_receive_eth(self, safe, owner):
             balance_before = await safe.balance()
-            await safe.deposit(value=ACCOUNT_BALANCE, caller_eoa=owner)
+            await safe.deposit(
+                value=ACCOUNT_BALANCE, caller_eoa=owner.starknet_contract
+            )
             balance_after = await safe.balance()
             assert balance_after - balance_before == ACCOUNT_BALANCE
 
     class TestWithdrawTransfer:
         async def test_should_withdraw_transfer_eth(self, safe, owner, eth_balance_of):
-            await safe.deposit(value=ACCOUNT_BALANCE, caller_eoa=owner)
+            await safe.deposit(
+                value=ACCOUNT_BALANCE, caller_eoa=owner.starknet_contract
+            )
 
             safe_balance = await safe.balance()
             owner_balance_before = await eth_balance_of(owner.address)
 
-            receipt = await safe.withdrawTransfer(caller_eoa=owner)
+            receipt = await safe.withdrawTransfer(caller_eoa=owner.starknet_contract)
 
             owner_balance_after = await eth_balance_of(owner.address)
             assert await safe.balance() == 0
@@ -39,12 +43,14 @@ class TestSafe:
 
     class TestWithdrawCall:
         async def test_should_withdraw_call_eth(self, safe, owner, eth_balance_of):
-            await safe.deposit(value=ACCOUNT_BALANCE, caller_eoa=owner)
+            await safe.deposit(
+                value=ACCOUNT_BALANCE, caller_eoa=owner.starknet_contract
+            )
 
             safe_balance = await safe.balance()
             owner_balance_before = await eth_balance_of(owner.address)
 
-            receipt = await safe.withdrawCall(caller_eoa=owner)
+            receipt = await safe.withdrawCall(caller_eoa=owner.starknet_contract)
 
             owner_balance_after = await eth_balance_of(owner.address)
             assert await safe.balance() == 0
@@ -58,6 +64,9 @@ class TestSafe:
             self, safe, deploy_solidity_contract, owner
         ):
             safe = await deploy_solidity_contract(
-                "PlainOpcodes", "Safe", caller_eoa=owner.starknet_contract, value=1
+                "PlainOpcodes",
+                "Safe",
+                caller_eoa=owner.starknet_contract,
+                value=1,
             )
             assert await safe.balance() == 1

--- a/tests/end_to_end/Solmate/test_erc20.py
+++ b/tests/end_to_end/Solmate/test_erc20.py
@@ -35,7 +35,9 @@ class TestERC20:
             total_supply_before = await erc_20.totalSupply()
             balance_before = await erc_20.balanceOf(other.address)
 
-            await erc_20.mint(other.address, TEST_SUPPLY, caller_eoa=owner)
+            await erc_20.mint(
+                other.address, TEST_SUPPLY, caller_eoa=owner.starknet_contract
+            )
 
             total_supply_after = await erc_20.totalSupply()
             balance_after = await erc_20.balanceOf(other.address)
@@ -45,12 +47,16 @@ class TestERC20:
 
     class TestBurn:
         async def test_should_burn(self, erc_20, owner, other):
-            await erc_20.mint(other.address, TEST_SUPPLY, caller_eoa=owner)
+            await erc_20.mint(
+                other.address, TEST_SUPPLY, caller_eoa=owner.starknet_contract
+            )
 
             total_supply_before = await erc_20.totalSupply()
             balance_before = await erc_20.balanceOf(other.address)
 
-            await erc_20.burn(other.address, TEST_SUPPLY, caller_eoa=owner)
+            await erc_20.burn(
+                other.address, TEST_SUPPLY, caller_eoa=owner.starknet_contract
+            )
 
             total_supply_after = await erc_20.totalSupply()
             balance_after = await erc_20.balanceOf(other.address)
@@ -62,7 +68,9 @@ class TestERC20:
         async def test_should_approve(self, erc_20, owner, other):
             allowance_before = await erc_20.allowance(owner.address, other.address)
 
-            assert await erc_20.approve(other.address, TEST_SUPPLY, caller_eoa=owner)
+            assert await erc_20.approve(
+                other.address, TEST_SUPPLY, caller_eoa=owner.starknet_contract
+            )
 
             allowance_after = await erc_20.allowance(owner.address, other.address)
 
@@ -70,7 +78,9 @@ class TestERC20:
 
     class TestTransfer:
         async def test_should_transfer(self, erc_20, owner, other):
-            await erc_20.mint(owner.address, TEST_SUPPLY, caller_eoa=owner)
+            await erc_20.mint(
+                owner.address, TEST_SUPPLY, caller_eoa=owner.starknet_contract
+            )
 
             balance_sender_before = await erc_20.balanceOf(owner.address)
             balance_receiver_before = await erc_20.balanceOf(other.address)
@@ -78,7 +88,7 @@ class TestERC20:
             assert await erc_20.transfer(
                 other.address,
                 TEST_SUPPLY,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
 
             balance_sender_after = await erc_20.balanceOf(owner.address)
@@ -90,13 +100,15 @@ class TestERC20:
         async def test_transfer_should_fail_when_insufficient_balance(
             self, erc_20, owner, other
         ):
-            await erc_20.mint(owner.address, TEST_AMOUNT, caller_eoa=owner)
+            await erc_20.mint(
+                owner.address, TEST_AMOUNT, caller_eoa=owner.starknet_contract
+            )
             balance_sender_before = await erc_20.balanceOf(owner.address)
             with evm_error():
                 await erc_20.transfer(
                     other.address,
                     balance_sender_before + 1,
-                    caller_eoa=owner,
+                    caller_eoa=owner.starknet_contract,
                 )
 
     class TestTransferFrom:
@@ -112,7 +124,7 @@ class TestERC20:
             await erc_20.mint(
                 from_wallet.address,
                 TEST_SUPPLY,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
 
             balance_sender_before = await erc_20.balanceOf(from_wallet.address)
@@ -121,13 +133,13 @@ class TestERC20:
             await erc_20.approve(
                 owner.address,
                 initial_allowance,
-                caller_eoa=from_wallet,
+                caller_eoa=from_wallet.starknet_contract,
             )
             assert await erc_20.transferFrom(
                 from_wallet.address,
                 to_wallet.address,
                 TEST_SUPPLY,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
 
             balance_sender_after = await erc_20.balanceOf(from_wallet.address)
@@ -143,28 +155,36 @@ class TestERC20:
         async def test_transfer_from_should_fail_when_insufficient_allowance(
             self, erc_20, owner, other, others
         ):
-            await erc_20.mint(other.address, TEST_SUPPLY, caller_eoa=owner)
-            await erc_20.approve(owner.address, TEST_AMOUNT, caller_eoa=other)
+            await erc_20.mint(
+                other.address, TEST_SUPPLY, caller_eoa=owner.starknet_contract
+            )
+            await erc_20.approve(
+                owner.address, TEST_AMOUNT, caller_eoa=other.starknet_contract
+            )
             with evm_error():
                 await erc_20.transferFrom(
                     other.address,
                     others[1].address,
                     TEST_SUPPLY,
-                    caller_eoa=owner,
+                    caller_eoa=owner.starknet_contract,
                 )
 
         async def test_transfer_from_should_fail_when_insufficient_balance(
             self, erc_20, owner, other, others
         ):
-            await erc_20.mint(other.address, TEST_AMOUNT, caller_eoa=owner)
+            await erc_20.mint(
+                other.address, TEST_AMOUNT, caller_eoa=owner.starknet_contract
+            )
             balance_other = await erc_20.balanceOf(other.address)
-            await erc_20.approve(owner.address, balance_other + 1, caller_eoa=other)
+            await erc_20.approve(
+                owner.address, balance_other + 1, caller_eoa=other.starknet_contract
+            )
             with evm_error():
                 await erc_20.transferFrom(
                     other.address,
                     others[1].address,
                     balance_other + 1,
-                    caller_eoa=owner,
+                    caller_eoa=owner.starknet_contract,
                 )
 
     class TestPermit:
@@ -191,7 +211,7 @@ class TestERC20:
                 v,
                 r,
                 s,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
             events = erc_20.events.parse_starknet_events(receipt.events)
 
@@ -229,7 +249,7 @@ class TestERC20:
                     v,
                     r,
                     s,
-                    caller_eoa=owner,
+                    caller_eoa=owner.starknet_contract,
                 )
 
         async def test_permit_should_fail_with_bad_deadline(
@@ -259,7 +279,7 @@ class TestERC20:
                     v,
                     r,
                     s,
-                    caller_eoa=owner,
+                    caller_eoa=owner.starknet_contract,
                 )
 
         async def test_permit_should_fail_on_replay(self, erc_20, owner, other):
@@ -285,7 +305,7 @@ class TestERC20:
                 v,
                 r,
                 s,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
 
             with evm_error("INVALID_SIGNER"):
@@ -297,5 +317,5 @@ class TestERC20:
                     v,
                     r,
                     s,
-                    caller_eoa=owner,
+                    caller_eoa=owner.starknet_contract,
                 )

--- a/tests/end_to_end/Solmate/test_erc721.py
+++ b/tests/end_to_end/Solmate/test_erc721.py
@@ -83,34 +83,40 @@ class TestERC721:
 
     class TestMint:
         async def test_should_mint(self, erc_721, other, token_id):
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
             assert await erc_721.balanceOf(other.address) == 1
             assert await erc_721.ownerOf(token_id) == other.address
 
         async def test_should_fail_mint_to_zero_address(self, erc_721, other, token_id):
             with evm_error("INVALID_RECIPIENT"):
-                await erc_721.mint(ZERO_ADDRESS, token_id, caller_eoa=other)
+                await erc_721.mint(
+                    ZERO_ADDRESS, token_id, caller_eoa=other.starknet_contract
+                )
 
         async def test_should_fail_to_double_mint(self, erc_721, other, token_id):
             await erc_721.mint(
                 other.address,
                 token_id,
-                caller_eoa=other,
+                caller_eoa=other.starknet_contract,
             )
 
             with evm_error("ALREADY_MINTED"):
                 await erc_721.mint(
                     other.address,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
     class TestBurn:
         async def test_should_burn(self, erc_721, other, token_id):
             balance_before = await erc_721.balanceOf(other.address)
 
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
-            await erc_721.burn(token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
+            await erc_721.burn(token_id, caller_eoa=other.starknet_contract)
 
             balance_after = await erc_721.balanceOf(other.address)
             assert balance_after == balance_before
@@ -120,25 +126,31 @@ class TestERC721:
 
         async def test_should_fail_to_burn_unminted(self, erc_721, other, token_id):
             with evm_error("NOT_MINTED"):
-                await erc_721.burn(token_id, caller_eoa=other)
+                await erc_721.burn(token_id, caller_eoa=other.starknet_contract)
 
         async def test_should_fail_to_double_burn(self, erc_721, other, token_id):
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
 
-            await erc_721.burn(token_id, caller_eoa=other)
+            await erc_721.burn(token_id, caller_eoa=other.starknet_contract)
 
             with evm_error("NOT_MINTED"):
-                await erc_721.burn(token_id, caller_eoa=other)
+                await erc_721.burn(token_id, caller_eoa=other.starknet_contract)
 
     class TestApprove:
         async def test_should_approve(self, erc_721, others, token_id):
-            await erc_721.mint(others[0].address, token_id, caller_eoa=others[0])
-            await erc_721.approve(others[1].address, token_id, caller_eoa=others[0])
+            await erc_721.mint(
+                others[0].address, token_id, caller_eoa=others[0].starknet_contract
+            )
+            await erc_721.approve(
+                others[1].address, token_id, caller_eoa=others[0].starknet_contract
+            )
             assert await erc_721.getApproved(token_id) == others[1].address
 
         async def test_should_approve_all(self, erc_721, others):
             await erc_721.setApprovalForAll(
-                others[1].address, True, caller_eoa=others[0]
+                others[1].address, True, caller_eoa=others[0].starknet_contract
             )
 
             assert (
@@ -151,29 +163,35 @@ class TestERC721:
                 await erc_721.approve(
                     others[1].address,
                     token_id,
-                    caller_eoa=others[0],
+                    caller_eoa=others[0].starknet_contract,
                 )
 
         async def test_should_fail_to_approve_unauthorized(
             self, erc_721, others, token_id
         ):
-            await erc_721.mint(others[0].address, token_id, caller_eoa=others[0])
+            await erc_721.mint(
+                others[0].address, token_id, caller_eoa=others[0].starknet_contract
+            )
             with evm_error("NOT_AUTHORIZED"):
                 await erc_721.approve(
                     others[1].address,
                     token_id,
-                    caller_eoa=others[2],
+                    caller_eoa=others[2].starknet_contract,
                 )
 
     class TestTransferFrom:
         async def test_should_transfer_from(self, erc_721, others, token_id):
-            await erc_721.mint(others[1].address, token_id, caller_eoa=others[0])
-            await erc_721.approve(others[2].address, token_id, caller_eoa=others[1])
+            await erc_721.mint(
+                others[1].address, token_id, caller_eoa=others[0].starknet_contract
+            )
+            await erc_721.approve(
+                others[2].address, token_id, caller_eoa=others[1].starknet_contract
+            )
             await erc_721.transferFrom(
                 others[1].address,
                 others[2].address,
                 token_id,
-                caller_eoa=others[1],
+                caller_eoa=others[1].starknet_contract,
             )
 
             approved = await erc_721.getApproved(token_id)
@@ -190,12 +208,14 @@ class TestERC721:
             receiver_balance_before = await erc_721.balanceOf(other.address)
             sender_balance_before = await erc_721.balanceOf(owner.address)
 
-            await erc_721.mint(owner.address, token_id, caller_eoa=owner)
+            await erc_721.mint(
+                owner.address, token_id, caller_eoa=owner.starknet_contract
+            )
             await erc_721.transferFrom(
                 owner.address,
                 other.address,
                 token_id,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
 
             approved = await erc_721.getApproved(token_id)
@@ -212,17 +232,19 @@ class TestERC721:
             receiver_balance_before = await erc_721.balanceOf(others[1].address)
             sender_balance_before = await erc_721.balanceOf(others[0].address)
 
-            await erc_721.mint(others[0].address, token_id, caller_eoa=others[0])
+            await erc_721.mint(
+                others[0].address, token_id, caller_eoa=others[0].starknet_contract
+            )
 
             await erc_721.setApprovalForAll(
-                others[1].address, True, caller_eoa=others[0]
+                others[1].address, True, caller_eoa=others[0].starknet_contract
             )
 
             await erc_721.transferFrom(
                 others[0].address,
                 others[1].address,
                 token_id,
-                caller_eoa=others[0],
+                caller_eoa=others[0].starknet_contract,
             )
 
             approved = await erc_721.getApproved(token_id)
@@ -244,46 +266,52 @@ class TestERC721:
                     others[0].address,
                     others[1].address,
                     token_id,
-                    caller_eoa=others[0],
+                    caller_eoa=others[0].starknet_contract,
                 )
 
         async def test_should_fail_to_transfer_from_wrong_from(
             self, erc_721, others, token_id
         ):
-            await erc_721.mint(others[1].address, token_id, caller_eoa=others[1])
+            await erc_721.mint(
+                others[1].address, token_id, caller_eoa=others[1].starknet_contract
+            )
             with evm_error():
                 await erc_721.transferFrom(
                     others[0].address,
                     others[2].address,
                     token_id,
-                    caller_eoa=others[0],
+                    caller_eoa=others[0].starknet_contract,
                 )
 
         async def test_should_fail_to_transfer_from_to_zero(
             self, erc_721, other, token_id
         ):
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
             with evm_error("INVALID_RECIPIENT"):
                 await erc_721.transferFrom(
                     other.address,
                     ZERO_ADDRESS,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_transfer_from_not_owner(
             self, erc_721, others, token_id
         ):
-            await erc_721.mint(others[0].address, token_id, caller_eoa=others[0])
+            await erc_721.mint(
+                others[0].address, token_id, caller_eoa=others[0].starknet_contract
+            )
             await erc_721.setApprovalForAll(
-                others[1].address, False, caller_eoa=others[0]
+                others[1].address, False, caller_eoa=others[0].starknet_contract
             )
             with evm_error("NOT_AUTHORIZED"):
                 await erc_721.transferFrom(
                     others[0].address,
                     others[2].address,
                     token_id,
-                    caller_eoa=others[1],
+                    caller_eoa=others[1].starknet_contract,
                 )
 
     class TestSafeTransferFrom:
@@ -293,17 +321,19 @@ class TestERC721:
             receiver_balance_before = await erc_721.balanceOf(others[1].address)
             sender_balance_before = await erc_721.balanceOf(others[0].address)
 
-            await erc_721.mint(others[0].address, token_id, caller_eoa=others[0])
+            await erc_721.mint(
+                others[0].address, token_id, caller_eoa=others[0].starknet_contract
+            )
 
             await erc_721.setApprovalForAll(
-                others[1].address, True, caller_eoa=others[0]
+                others[1].address, True, caller_eoa=others[0].starknet_contract
             )
 
             await erc_721.safeTransferFrom(
                 others[0].address,
                 others[1].address,
                 token_id,
-                caller_eoa=others[0],
+                caller_eoa=others[0].starknet_contract,
             )
 
             approved = await erc_721.getApproved(token_id)
@@ -324,17 +354,19 @@ class TestERC721:
             receiver_balance_before = await erc_721.balanceOf(recipient_address)
             sender_balance_before = await erc_721.balanceOf(others[0].address)
 
-            await erc_721.mint(others[0].address, token_id, caller_eoa=others[0])
+            await erc_721.mint(
+                others[0].address, token_id, caller_eoa=others[0].starknet_contract
+            )
 
             await erc_721.setApprovalForAll(
-                others[1].address, True, caller_eoa=others[0]
+                others[1].address, True, caller_eoa=others[0].starknet_contract
             )
 
             await erc_721.safeTransferFrom(
                 others[0].address,
                 recipient_address,
                 token_id,
-                caller_eoa=others[1],
+                caller_eoa=others[1].starknet_contract,
             )
 
             approved = await erc_721.getApproved(token_id)
@@ -366,10 +398,12 @@ class TestERC721:
             receiver_balance_before = await erc_721.balanceOf(recipient_address)
             sender_balance_before = await erc_721.balanceOf(others[0].address)
 
-            await erc_721.mint(others[0].address, token_id, caller_eoa=others[0])
+            await erc_721.mint(
+                others[0].address, token_id, caller_eoa=others[0].starknet_contract
+            )
 
             await erc_721.setApprovalForAll(
-                others[1].address, True, caller_eoa=others[0]
+                others[1].address, True, caller_eoa=others[0].starknet_contract
             )
 
             data = b"testing 123"
@@ -379,7 +413,7 @@ class TestERC721:
                 recipient_address,
                 token_id,
                 data,
-                caller_eoa=others[1],
+                caller_eoa=others[1].starknet_contract,
             )
 
             approved = await erc_721.getApproved(token_id)
@@ -411,14 +445,16 @@ class TestERC721:
         ):
             recipient_address = erc_721_non_recipient.address
 
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
 
             with evm_error():
                 await erc_721.safeTransferFrom(
                     other.address,
                     recipient_address,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_transfer_from_to_NonERC721Recipient_with_data(
@@ -426,7 +462,9 @@ class TestERC721:
         ):
             recipient_address = erc_721_non_recipient.address
 
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
 
             with evm_error():
                 await erc_721.safeTransferFrom2(
@@ -434,14 +472,16 @@ class TestERC721:
                     recipient_address,
                     token_id,
                     b"testing 123",
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_transfer_from_to_RevertingERC721Recipient(
             self, erc_721, erc_721_reverting_recipient, other, token_id
         ):
             recipient_address = erc_721_reverting_recipient.address
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
 
             selector = keccak(text="onERC721Received(address,address,uint256,bytes)")[
                 :4
@@ -451,7 +491,7 @@ class TestERC721:
                     other.address,
                     recipient_address,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_transfer_from_to_RevertingERC721Recipient_with_data(
@@ -459,7 +499,9 @@ class TestERC721:
         ):
             recipient_address = erc_721_reverting_recipient.address
 
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
             selector = keccak(text="onERC721Received(address,address,uint256,bytes)")[
                 :4
             ]
@@ -469,7 +511,7 @@ class TestERC721:
                     recipient_address,
                     token_id,
                     b"testing 123",
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_transfer_from_to_ERC721RecipientWithWrongReturnData(
@@ -477,13 +519,15 @@ class TestERC721:
         ):
             recipient_address = erc_721_recipient_with_wrong_return_data.address
 
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
             with evm_error("UNSAFE_RECIPIENT"):
                 await erc_721.safeTransferFrom(
                     other.address,
                     recipient_address,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_transfer_from_to_ERC721RecipientWithWrongReturnData_with_data(
@@ -491,7 +535,9 @@ class TestERC721:
         ):
             recipient_address = erc_721_recipient_with_wrong_return_data.address
 
-            await erc_721.mint(other.address, token_id, caller_eoa=other)
+            await erc_721.mint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
 
             with evm_error("UNSAFE_RECIPIENT"):
                 await erc_721.safeTransferFrom2(
@@ -499,14 +545,16 @@ class TestERC721:
                     recipient_address,
                     token_id,
                     b"testing 123",
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
     class TestSafeMint:
         async def test_should_safe_mint_to_EOA(self, erc_721, other, token_id):
             balance_before = await erc_721.balanceOf(other.address)
 
-            await erc_721.safeMint(other.address, token_id, caller_eoa=other)
+            await erc_721.safeMint(
+                other.address, token_id, caller_eoa=other.starknet_contract
+            )
 
             balance_after = await erc_721.balanceOf(other.address)
             nft_owner = await erc_721.ownerOf(token_id)
@@ -520,7 +568,9 @@ class TestERC721:
             recipient_address = erc_721_recipient.address
 
             balance_before = await erc_721.balanceOf(recipient_address)
-            await erc_721.safeMint(recipient_address, token_id, caller_eoa=owner)
+            await erc_721.safeMint(
+                recipient_address, token_id, caller_eoa=owner.starknet_contract
+            )
 
             balance_after = await erc_721.balanceOf(recipient_address)
             nft_owner = await erc_721.ownerOf(token_id)
@@ -549,7 +599,7 @@ class TestERC721:
                 recipient_address,
                 token_id,
                 data,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
 
             balance_after = await erc_721.balanceOf(recipient_address)
@@ -577,7 +627,7 @@ class TestERC721:
                 await erc_721.safeMint(
                     recipient_address,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_mint_to_NonERC721Recipient_with_data(
@@ -590,7 +640,7 @@ class TestERC721:
                     recipient_address,
                     token_id,
                     b"testing 123",
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_mint_to_RevertingERC721Recipient(
@@ -602,7 +652,7 @@ class TestERC721:
                 await erc_721.safeMint(
                     recipient_address,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_mint_to_RevertingERC721Recipient_with_data(
@@ -615,7 +665,7 @@ class TestERC721:
                     recipient_address,
                     token_id,
                     b"testing 123",
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_mint_to_ERC721RecipientWithWrongReturnData(
@@ -627,7 +677,7 @@ class TestERC721:
                 await erc_721.safeMint(
                     recipient_address,
                     token_id,
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )
 
         async def test_should_fail_to_safe_mint_to_ERC721RecipientWithWrongReturnData_with_data(
@@ -640,5 +690,5 @@ class TestERC721:
                     recipient_address,
                     token_id,
                     b"testing 123",
-                    caller_eoa=other,
+                    caller_eoa=other.starknet_contract,
                 )

--- a/tests/end_to_end/UniswapV2/test_uniswap_v2_erc20.py
+++ b/tests/end_to_end/UniswapV2/test_uniswap_v2_erc20.py
@@ -32,7 +32,7 @@ class TestUniswapV2ERC20:
     class TestApprove:
         async def test_should_set_allowance(self, token_a, owner, other):
             receipt = await token_a.approve(
-                other.address, TEST_AMOUNT, caller_eoa=owner
+                other.address, TEST_AMOUNT, caller_eoa=owner.starknet_contract
             )
             events = token_a.events.parse_starknet_events(receipt.events)
             assert events["Approval"] == [
@@ -50,7 +50,7 @@ class TestUniswapV2ERC20:
             self, token_a, owner, other
         ):
             receipt = await token_a.transfer(
-                other.address, TEST_AMOUNT, caller_eoa=owner
+                other.address, TEST_AMOUNT, caller_eoa=owner.starknet_contract
             )
             events = token_a.events.parse_starknet_events(receipt.events)
             assert events["Transfer"] == [
@@ -68,22 +68,29 @@ class TestUniswapV2ERC20:
         ):
             with evm_error():
                 await token_a.transfer(
-                    other.address, TOTAL_SUPPLY + 1, caller_eoa=owner
+                    other.address, TOTAL_SUPPLY + 1, caller_eoa=owner.starknet_contract
                 )
 
         async def test_should_fail_when_amount_is_greater_than_balance_and_balance_zero(
             self, token_a, owner, other
         ):
             with evm_error():
-                await token_a.transfer(owner.address, 1, caller_eoa=other)
+                await token_a.transfer(
+                    owner.address, 1, caller_eoa=other.starknet_contract
+                )
 
     class TestTransferFrom:
         async def test_should_transfer_token_when_signer_is_approved(
             self, token_a, owner, other
         ):
-            await token_a.approve(other.address, TEST_AMOUNT, caller_eoa=owner)
+            await token_a.approve(
+                other.address, TEST_AMOUNT, caller_eoa=owner.starknet_contract
+            )
             receipt = await token_a.transferFrom(
-                owner.address, other.address, TEST_AMOUNT, caller_eoa=other
+                owner.address,
+                other.address,
+                TEST_AMOUNT,
+                caller_eoa=other.starknet_contract,
             )
             events = token_a.events.parse_starknet_events(receipt.events)
             assert events["Transfer"] == [
@@ -97,9 +104,14 @@ class TestUniswapV2ERC20:
         async def test_should_transfer_token_when_signer_is_approved_max_uint(
             self, token_a, owner, other
         ):
-            await token_a.approve(other.address, MAX_INT, caller_eoa=owner)
+            await token_a.approve(
+                other.address, MAX_INT, caller_eoa=owner.starknet_contract
+            )
             receipt = await token_a.transferFrom(
-                owner.address, other.address, TEST_AMOUNT, caller_eoa=other
+                owner.address,
+                other.address,
+                TEST_AMOUNT,
+                caller_eoa=other.starknet_contract,
             )
             events = token_a.events.parse_starknet_events(receipt.events)
             assert events["Transfer"] == [
@@ -134,7 +146,7 @@ class TestUniswapV2ERC20:
                 v,
                 r,
                 s,
-                caller_eoa=owner,
+                caller_eoa=owner.starknet_contract,
             )
             events = token_a.events.parse_starknet_events(receipt.events)
             assert events["Approval"] == [


### PR DESCRIPTION
Time spent on this PR: 0.3

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No simple way to create a contract with a given bytecode in Katana.

## What is the new behavior?

Added an util to take the target bytecode and put it as RETURN_DATA of a simple tx.
Assert that the finally stored bytecode is the expected one.

I've also updated slightly the utils due to max_fee errors arising in Katana
when restarting tests without restarting Katana.
