### PR TITLE
Stop raising Cairo VM errors for Stack over/under-flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,5 @@ docs/callgraphs/*
 # Hypothesis
 .hypothesis/*
 node_modules
-tmp
+tmp*
 broadcast

--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -202,8 +202,8 @@ namespace Account {
     // @return The updated Account
     // @return The read value
     func read_storage{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        self: model.Account*, address: model.Address*, key: Uint256
-    ) -> (model.Account*, Uint256) {
+        self: model.Account*, address: model.Address*, key: Uint256*
+    ) -> (model.Account*, Uint256*) {
         alloc_locals;
         let storage = self.storage;
         let (local storage_addr) = Internals._storage_addr(key);
@@ -222,7 +222,7 @@ namespace Account {
                 self.nonce,
                 self.selfdestruct,
             );
-            return (self, [value_ptr]);
+            return (self, value_ptr);
         }
 
         // Case reading from Starknet storage
@@ -255,7 +255,7 @@ namespace Account {
             self.nonce,
             self.selfdestruct,
         );
-        return (self, [value_ptr]);
+        return (self, value_ptr);
     }
 
     // @notice Update a storage key with the given value
@@ -263,7 +263,7 @@ namespace Account {
     // @param key The pointer to the Uint256 storage key
     // @param value The pointer to the Uint256 value
     func write_storage{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        self: model.Account*, key: Uint256, value: Uint256*
+        self: model.Account*, key: Uint256*, value: Uint256*
     ) -> model.Account* {
         alloc_locals;
         local storage: DictAccess* = self.storage;
@@ -454,10 +454,10 @@ namespace Internals {
     // @notice Compute the storage address of the given key when the storage var interface is
     //         storage_(key: Uint256)
     // @dev    Just the generated addr method when compiling the contract_account
-    func _storage_addr{pedersen_ptr: HashBuiltin*, range_check_ptr}(key: Uint256) -> (res: felt) {
+    func _storage_addr{pedersen_ptr: HashBuiltin*, range_check_ptr}(key: Uint256*) -> (res: felt) {
         let res = 1510236440068827666686527023008568026372765124888307403567795291192307314167;
-        let (res) = hash2{hash_ptr=pedersen_ptr}(res, cast(&key, felt*)[0]);
-        let (res) = hash2{hash_ptr=pedersen_ptr}(res, cast(&key, felt*)[1]);
+        let (res) = hash2{hash_ptr=pedersen_ptr}(res, cast(key, felt*)[0]);
+        let (res) = hash2{hash_ptr=pedersen_ptr}(res, cast(key, felt*)[1]);
         let (res) = normalize_address(addr=res);
         return (res=res);
     }

--- a/src/kakarot/evm.cairo
+++ b/src/kakarot/evm.cairo
@@ -78,7 +78,7 @@ namespace EVM {
         }
 
         // Compute the corresponding offset in the jump table:
-        // count 1 for "next line" and 4 steps per opcode: call, opcode, ret
+        // count 1 for "next line" and 3 steps per opcode: call, opcode, ret
         tempvar offset = 1 + 3 * opcode;
 
         // move program counter + 1 after opcode is read

--- a/src/kakarot/execution_context.cairo
+++ b/src/kakarot/execution_context.cairo
@@ -187,26 +187,6 @@ namespace ExecutionContext {
         );
     }
 
-    // @notice Read and return data from bytecode.
-    // @dev The data is read from the bytecode from the current program counter.
-    // @param self The pointer to the execution context.
-    // @param len The size of the data to read.
-    // @return self The pointer to the updated execution context.
-    // @return output The data read from the bytecode.
-    func read_code(self: model.ExecutionContext*, len: felt) -> (
-        self: model.ExecutionContext*, output: felt*
-    ) {
-        alloc_locals;
-        // Get current pc value
-        let pc = self.program_counter;
-        let (output: felt*) = alloc();
-        // Copy code slice
-        memcpy(dst=output, src=self.call_context.bytecode + pc, len=len);
-        // Move program counter
-        let self = ExecutionContext.increment_program_counter(self=self, inc_value=len);
-        return (self=self, output=output);
-    }
-
     // @notice Update the stack of the current execution context.
     // @dev The stack is updated with the given stack.
     // @param self The pointer to the execution context.

--- a/src/kakarot/instructions/block_information.cairo
+++ b/src/kakarot/instructions/block_information.cairo
@@ -223,9 +223,7 @@ namespace BlockInformation {
         }
 
         // Get the Difficulty.
-        let difficulty = Helpers.to_uint256(val=0);
-
-        let stack: model.Stack* = Stack.push(self=ctx.stack, element=difficulty);
+        let stack: model.Stack* = Stack.push_uint128(ctx.stack, 0);
 
         // Update the execution context.
         // Update context stack.
@@ -292,8 +290,7 @@ namespace BlockInformation {
             return ctx;
         }
 
-        let chain_id = Helpers.to_uint256(val=Constants.CHAIN_ID);
-        let stack: model.Stack* = Stack.push(self=ctx.stack, element=chain_id);
+        let stack: model.Stack* = Stack.push_uint128(ctx.stack, Constants.CHAIN_ID);
 
         // Update the execution context.
         // Update context stack.

--- a/src/kakarot/instructions/comparison_operations.cairo
+++ b/src/kakarot/instructions/comparison_operations.cairo
@@ -360,11 +360,10 @@ namespace ComparisonOperations {
 
         // a & b: the bitwise AND result.
         let (result) = uint256_and(a, b);
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // a & b: the bitwise AND result.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
+        let stack = Stack.push_uint256(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -408,11 +407,10 @@ namespace ComparisonOperations {
 
         // a & b: the bitwise AND result.
         let (result) = uint256_or(a, b);
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // a & b: the bitwise AND result.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
+        let stack = Stack.push_uint256(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -454,11 +452,10 @@ namespace ComparisonOperations {
 
         // a & b: the bitwise XOR result.
         let (result) = uint256_xor([a], [b]);
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // a & b: the bitwise XOR result.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
+        let stack = Stack.push_uint256(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -504,13 +501,11 @@ namespace ComparisonOperations {
         let (right) = uint256_sub(Uint256(248, 0), mul);
         let (shift_right) = uint256_shr(value, right);
         let (result) = uint256_and(shift_right, Uint256(0xFF, 0));
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
+        let stack = Stack.push_uint256(stack, result);
 
-        // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
         // Increment gas used.
         let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_BYTE);
@@ -552,13 +547,10 @@ namespace ComparisonOperations {
 
         // Left shift `value` by `shift`.
         let (result) = uint256_shl(a=value, b=shift);
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
-
-        // Update context stack.
+        let stack = Stack.push_uint256(stack, result);
         let ctx = ExecutionContext.update_stack(ctx, stack);
         // Increment gas used.
         let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_SHL);
@@ -600,13 +592,10 @@ namespace ComparisonOperations {
 
         // Right shift `value` by `shift`.
         let (result) = uint256_shr(a=value, b=shift);
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
-
-        // Update context stack.
+        let stack = Stack.push_uint256(stack, result);
         let ctx = ExecutionContext.update_stack(ctx, stack);
         // Increment gas used.
         let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_SHR);
@@ -678,11 +667,10 @@ namespace ComparisonOperations {
         let (step2) = uint256_shr(step1, shift);
         // `sign & x >> n ^ sign`
         let (result) = uint256_xor(step2, sign);
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
+        let stack = Stack.push_uint256(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -721,11 +709,10 @@ namespace ComparisonOperations {
 
         // Bitwise NOT operation
         let (result) = uint256_not([a]);
-        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=item);
+        let stack = Stack.push_uint256(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);

--- a/src/kakarot/instructions/comparison_operations.cairo
+++ b/src/kakarot/instructions/comparison_operations.cairo
@@ -18,11 +18,14 @@ from starkware.cairo.common.uint256 import (
     uint256_mul,
     uint256_sub,
 )
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.bool import TRUE, FALSE
 
 // Internal dependencies
 from kakarot.model import model
 from kakarot.execution_context import ExecutionContext
 from kakarot.stack import Stack
+from kakarot.errors import Errors
 
 const BIT_MASK = 2 ** 127;
 
@@ -63,6 +66,12 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         let stack = ctx.stack;
 
@@ -78,11 +87,9 @@ namespace ComparisonOperations {
 
         // Stack output:
         // a < b: integer result of comparison a less than b
-        let stack: model.Stack* = Stack.push(self=stack, element=Uint256(result, 0));
+        let stack: model.Stack* = Stack.push_uint128(stack, result);
 
-        // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
-        // Increment gas used.
         let ctx = ExecutionContext.increment_gas_used(self=ctx, inc_value=GAS_COST_LT);
         return ctx;
     }
@@ -104,6 +111,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -118,7 +132,7 @@ namespace ComparisonOperations {
 
         // Stack output:
         // a < b: integer result of comparison a less than b
-        let stack: model.Stack* = Stack.push(stack, Uint256(result, 0));
+        let stack: model.Stack* = Stack.push_uint128(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -144,6 +158,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -158,7 +179,7 @@ namespace ComparisonOperations {
 
         // Stack output:
         // a < b: integer result of comparison a less than b
-        let stack: model.Stack* = Stack.push(self=stack, element=Uint256(result, 0));
+        let stack: model.Stack* = Stack.push_uint128(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -184,6 +205,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -198,7 +226,7 @@ namespace ComparisonOperations {
 
         // Stack output:
         // a < b: integer result of comparison a less than b
-        let stack: model.Stack* = Stack.push(self=stack, element=Uint256(result, 0));
+        let stack: model.Stack* = Stack.push_uint128(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -224,6 +252,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -238,7 +273,7 @@ namespace ComparisonOperations {
 
         // Stack output:
         // a == b: 1 if the left side is equal to the right side, 0 otherwise.
-        let stack: model.Stack* = Stack.push(self=stack, element=Uint256(result, 0));
+        let stack: model.Stack* = Stack.push_uint128(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -252,7 +287,7 @@ namespace ComparisonOperations {
     // @custom:since Frontier
     // @custom:group Comparison & Bitwise Logic Operations
     // @custom:gas 3
-    // @custom:stack_consumed_elements 2
+    // @custom:stack_consumed_elements 1
     // @custom:stack_produced_elements 1
     // @param ctx The pointer to the execution context.
     // @return ExecutionContext The pointer to the execution context.
@@ -264,6 +299,12 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        if (ctx.stack.size == 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -271,11 +312,11 @@ namespace ComparisonOperations {
         let (stack, a) = Stack.pop(stack);
 
         // a == 0: 1 if a is 0, 0 otherwise.
-        let (result) = uint256_eq(a=a, b=Uint256(0, 0));
+        let (result) = uint256_eq(a=[a], b=Uint256(0, 0));
 
         // Stack output:
         // a == 0: 1 if a is 0, 0 otherwise.
-        let stack: model.Stack* = Stack.push(self=stack, element=Uint256(result, 0));
+        let stack: model.Stack* = Stack.push_uint128(stack, result);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -301,6 +342,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input
@@ -312,10 +360,11 @@ namespace ComparisonOperations {
 
         // a & b: the bitwise AND result.
         let (result) = uint256_and(a, b);
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // a & b: the bitwise AND result.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -341,6 +390,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input
@@ -352,10 +408,11 @@ namespace ComparisonOperations {
 
         // a & b: the bitwise AND result.
         let (result) = uint256_or(a, b);
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // a & b: the bitwise AND result.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -380,6 +437,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input
@@ -389,11 +453,12 @@ namespace ComparisonOperations {
         let (stack, b) = Stack.pop(stack);
 
         // a & b: the bitwise XOR result.
-        let (result) = uint256_xor(a, b);
+        let (result) = uint256_xor([a], [b]);
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // a & b: the bitwise XOR result.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -418,23 +483,32 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
         // 0 - i: offset.
         // 1 - x: value.
-        let (stack, offset) = Stack.pop(stack);
-        let (stack, value) = Stack.pop(stack);
+        let (stack, popped) = Stack.pop_n(self=stack, n=2);
+        let offset = popped[0];
+        let value = popped[1];
 
         // compute y = (x >> (248 - i * 8)) & 0xFF
         let (mul, _) = uint256_mul(offset, Uint256(8, 0));
         let (right) = uint256_sub(Uint256(248, 0), mul);
         let (shift_right) = uint256_shr(value, right);
         let (result) = uint256_and(shift_right, Uint256(0xFF, 0));
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -460,6 +534,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -471,10 +552,11 @@ namespace ComparisonOperations {
 
         // Left shift `value` by `shift`.
         let (result) = uint256_shl(a=value, b=shift);
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -500,6 +582,13 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -511,10 +600,11 @@ namespace ComparisonOperations {
 
         // Right shift `value` by `shift`.
         let (result) = uint256_shr(a=value, b=shift);
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -539,6 +629,14 @@ namespace ComparisonOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -580,10 +678,11 @@ namespace ComparisonOperations {
         let (step2) = uint256_shr(step1, shift);
         // `sign & x >> n ^ sign`
         let (result) = uint256_xor(step2, sign);
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -608,6 +707,12 @@ namespace ComparisonOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        if (ctx.stack.size == 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -615,11 +720,12 @@ namespace ComparisonOperations {
         let (stack, a) = Stack.pop(stack);
 
         // Bitwise NOT operation
-        let (result) = uint256_not(a);
+        let (result) = uint256_not([a]);
+        tempvar item = new Uint256(result.low, result.high);
 
         // Stack output:
         // The result of the shift operation.
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        let stack: model.Stack* = Stack.push(self=stack, element=item);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -107,8 +107,7 @@ namespace EnvironmentalInformation {
         let (starknet_address) = Account.compute_starknet_address(evm_address);
         tempvar address = new model.Address(starknet_address, evm_address);
         let (state, balance) = State.read_balance(ctx.state, address);
-        tempvar item = new Uint256(balance.low, balance.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, balance);
 
         let ctx = ExecutionContext.update_stack(ctx, stack);
         let ctx = ExecutionContext.update_state(ctx, state);
@@ -262,8 +261,7 @@ namespace EnvironmentalInformation {
         let uint256_sliced_calldata = Helpers.bytes32_to_uint256(sliced_calldata);
 
         // Push CallData word onto stack
-        tempvar item = new Uint256(uint256_sliced_calldata.low, uint256_sliced_calldata.high);
-        let stack: model.Stack* = Stack.push(stack, item);
+        let stack: model.Stack* = Stack.push_uint256(stack, uint256_sliced_calldata);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);

--- a/src/kakarot/instructions/exchange_operations.cairo
+++ b/src/kakarot/instructions/exchange_operations.cairo
@@ -30,7 +30,7 @@ namespace ExchangeOperations {
         let stack: model.Stack* = ctx.stack;
 
         // Get the value top i-th stack item.
-        let stack = Stack.swap_i(self=stack, i=i + 1);
+        let stack = Stack.swap_i(self=stack, i=i);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);

--- a/src/kakarot/instructions/logging_operations.cairo
+++ b/src/kakarot/instructions/logging_operations.cairo
@@ -7,6 +7,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.starknet.common.syscalls import emit_event
+from starkware.cairo.common.math_cmp import is_le
 
 // Internal dependencies
 from kakarot.errors import Errors
@@ -36,6 +37,13 @@ namespace LoggingOperations {
 
         if (ctx.call_context.read_only != FALSE) {
             let (revert_reason_len, revert_reason) = Errors.stateModificationError();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
+        let stack_underflow = is_le(ctx.stack.size, topics_len + 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
             let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
             return ctx;
         }

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -54,8 +54,6 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        let fp_and_pc = get_fp_and_pc();
-        local __fp__: felt* = fp_and_pc.fp_val;
 
         if (ctx.stack.size == 0) {
             let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
@@ -70,10 +68,10 @@ namespace MemoryOperations {
         let (stack, offset) = Stack.pop(stack);
 
         // Read word from memory at offset
-        let (new_memory, local value, cost) = Memory.load(self=ctx.memory, offset=offset.low);
+        let (new_memory, value, cost) = Memory.load(self=ctx.memory, offset=offset.low);
 
         // Push word to the stack
-        let stack: model.Stack* = Stack.push(stack, &value);
+        let stack: model.Stack* = Stack.push_uint256(stack, value);
 
         // Update context memory.
         let ctx = ExecutionContext.update_memory(ctx, new_memory);

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -9,6 +9,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.dict import DictAccess, dict_new, dict_read, dict_write
 from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.math_cmp import is_le
 
 from kakarot.errors import Errors
 from kakarot.execution_context import ExecutionContext
@@ -17,6 +18,7 @@ from kakarot.model import model
 from kakarot.stack import Stack
 from kakarot.state import State
 from utils.utils import Helpers
+from kakarot.constants import Constants
 
 // @title Exchange operations opcodes.
 // @notice This file contains the functions to execute for memory operations opcodes.
@@ -52,6 +54,14 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+        let fp_and_pc = get_fp_and_pc();
+        local __fp__: felt* = fp_and_pc.fp_val;
+
+        if (ctx.stack.size == 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         let stack = ctx.stack;
 
@@ -60,10 +70,10 @@ namespace MemoryOperations {
         let (stack, offset) = Stack.pop(stack);
 
         // Read word from memory at offset
-        let (new_memory, value, cost) = Memory.load(self=ctx.memory, offset=offset.low);
+        let (new_memory, local value, cost) = Memory.load(self=ctx.memory, offset=offset.low);
 
         // Push word to the stack
-        let stack: model.Stack* = Stack.push(stack, value);
+        let stack: model.Stack* = Stack.push(stack, &value);
 
         // Update context memory.
         let ctx = ExecutionContext.update_memory(ctx, new_memory);
@@ -91,6 +101,13 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         let stack = ctx.stack;
 
@@ -126,9 +143,13 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        let pc = Helpers.to_uint256(ctx.program_counter - 1);
+        if (ctx.stack.size == Constants.STACK_MAX_DEPTH) {
+            let (revert_reason_len, revert_reason) = Errors.stackOverflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
-        let stack: model.Stack* = Stack.push(ctx.stack, pc);
+        let stack: model.Stack* = Stack.push_uint128(ctx.stack, ctx.program_counter - 1);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -151,10 +172,13 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
-        let len = ctx.memory.bytes_len;
-        let msize = Helpers.to_uint256(len);
+        if (ctx.stack.size == Constants.STACK_MAX_DEPTH) {
+            let (revert_reason_len, revert_reason) = Errors.stackOverflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
-        let stack: model.Stack* = Stack.push(ctx.stack, msize);
+        let stack = Stack.push_uint128(ctx.stack, ctx.memory.bytes_len);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
@@ -178,6 +202,12 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+
+        if (ctx.stack.size == 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         let stack = ctx.stack;
 
@@ -208,6 +238,13 @@ namespace MemoryOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let stack = ctx.stack;
 
         // Stack input:
@@ -234,7 +271,7 @@ namespace MemoryOperations {
     // @dev Serves as a check that JUMP or JUMPI was executed correctly. We only update gas used.
     // @custom:since Frontier
     // @custom:group Stack Memory Storage and Flow operations.
-    // @custom:stack_produced_elements 1
+    // @custom:stack_produced_elements 0
     // @param ctx The pointer to the execution context
     // @return ExecutionContext Updated execution context.
     func exec_jumpdest{
@@ -266,6 +303,12 @@ namespace MemoryOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        if (ctx.stack.size == 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Get stack from context.
         let stack: model.Stack* = ctx.stack;
 
@@ -295,6 +338,13 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         let stack = ctx.stack;
 
@@ -348,9 +398,16 @@ namespace MemoryOperations {
             return ctx;
         }
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let (stack, popped) = Stack.pop_n(self=ctx.stack, n=2);
 
-        let key = popped[0];  // Uint256*
+        let key = popped;  // Uint256*
         let value = popped + Uint256.SIZE;  // Uint256*
         let state = State.write_storage(ctx.state, ctx.call_context.address, key, value);
         let ctx = ExecutionContext.update_state(ctx, state);
@@ -375,6 +432,13 @@ namespace MemoryOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+
+        if (ctx.stack.size == 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let (stack, key) = Stack.pop(ctx.stack);
         let (state, value) = State.read_storage(ctx.state, ctx.call_context.address, key);
         let stack = Stack.push(stack, value);
@@ -399,12 +463,18 @@ namespace MemoryOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        if (ctx.stack.size == Constants.STACK_MAX_DEPTH) {
+            let (revert_reason_len, revert_reason) = Errors.stackOverflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Get stack from context.
         let stack: model.Stack* = ctx.stack;
 
         // Compute remaining gas.
         let remaining_gas = ctx.call_context.gas_limit - ctx.gas_used - GAS_COST_GAS;
-        let stack: model.Stack* = Stack.push(ctx.stack, Uint256(remaining_gas, 0));
+        let stack: model.Stack* = Stack.push_uint128(ctx.stack, remaining_gas);
 
         // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);

--- a/src/kakarot/instructions/push_operations.cairo
+++ b/src/kakarot/instructions/push_operations.cairo
@@ -5,11 +5,16 @@
 // Starkware dependencies
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.math_cmp import is_not_zero
+from starkware.cairo.common.math_cmp import is_not_zero, is_le
 from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.bool import FALSE, TRUE
 
 // Internal dependencies
 from kakarot.model import model
+from kakarot.constants import Constants
+from kakarot.errors import Errors
 from utils.utils import Helpers
 from kakarot.execution_context import ExecutionContext
 from kakarot.stack import Stack
@@ -31,24 +36,27 @@ namespace PushOperations {
     ) -> model.ExecutionContext* {
         alloc_locals;
 
-        // Get stack from context.
-        let stack: model.Stack* = ctx.stack;
+        if (ctx.stack.size == Constants.STACK_MAX_DEPTH) {
+            let (revert_reason_len, revert_reason) = Errors.stackOverflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
-        // Read i bytes.
-        let (ctx, data) = ExecutionContext.read_code(self=ctx, len=i);
+        let pc = ctx.program_counter;
+        // Copy code slice
+        let out_of_bounds = is_le(ctx.call_context.bytecode_len, pc + i);
+        local len = (1 - out_of_bounds) * i + out_of_bounds * (ctx.call_context.bytecode_len - pc);
 
-        // Convert to Uint256.
-        let stack_element: Uint256 = Helpers.bytes_i_to_uint256(val=data, i=i);
+        let stack_element = Helpers.bytes_i_to_uint256(ctx.call_context.bytecode + pc, len);
+        tempvar item = new Uint256(stack_element.low, stack_element.high);
+        let stack = Stack.push(ctx.stack, item);
 
-        // Push to the stack.
-        let stack: model.Stack* = Stack.push(stack, stack_element);
-
-        // Update context stack.
         let ctx = ExecutionContext.update_stack(ctx, stack);
-        // Increment gas used.
         let i_is_not_zero = is_not_zero(i);
-        // Gascost for push0 is 2; all else are 3
         let ctx = ExecutionContext.increment_gas_used(ctx, BASE_GAS_COST + i_is_not_zero);
+        // Move program counter
+        let ctx = ExecutionContext.increment_program_counter(ctx, len);
+
         return ctx;
     }
 

--- a/src/kakarot/instructions/push_operations.cairo
+++ b/src/kakarot/instructions/push_operations.cairo
@@ -48,8 +48,7 @@ namespace PushOperations {
         local len = (1 - out_of_bounds) * i + out_of_bounds * (ctx.call_context.bytecode_len - pc);
 
         let stack_element = Helpers.bytes_i_to_uint256(ctx.call_context.bytecode + pc, len);
-        tempvar item = new Uint256(stack_element.low, stack_element.high);
-        let stack = Stack.push(ctx.stack, item);
+        let stack = Stack.push_uint256(ctx.stack, stack_element);
 
         let ctx = ExecutionContext.update_stack(ctx, stack);
         let i_is_not_zero = is_not_zero(i);

--- a/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
@@ -100,8 +100,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a + b: integer result of the addition modulo 2^256
-        tempvar item = new Uint256(result.low, result.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, result);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_ADD);
         return ctx;
     }
@@ -143,8 +142,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a * b: integer result of the multiplication modulo 2^256
-        tempvar item = new Uint256(result.low, result.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, result);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_MUL);
         return ctx;
     }
@@ -186,8 +184,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a - b: integer result of the subtraction modulo 2^256
-        tempvar item = new Uint256(result.low, result.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, result);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_SUB);
         return ctx;
     }
@@ -229,8 +226,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a / b: integer result of the division modulo 2^256
-        tempvar item = new Uint256(result.low, result.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, result);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_DIV);
         return ctx;
     }
@@ -272,8 +268,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a / b: signed integer result of the division modulo 2^256
-        tempvar item = new Uint256(result.low, result.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, result);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_SDIV);
         return ctx;
     }
@@ -315,8 +310,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a % b:  integer result of the a % b
-        tempvar item = new Uint256(rem.low, rem.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, rem);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_MOD);
         return ctx;
     }
@@ -358,8 +352,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a % b:  signed integer result of the a % b
-        tempvar item = new Uint256(rem.low, rem.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, rem);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_SMOD);
         return ctx;
     }
@@ -405,8 +398,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // integer result of a + b % c
-        tempvar item = new Uint256(rem.low, rem.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, rem);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_ADDMOD);
         return ctx;
     }
@@ -450,8 +442,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // integer result of the a * b % c
-        tempvar item = new Uint256(rem.low, rem.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, rem);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_MULMOD);
         return ctx;
     }
@@ -493,8 +484,7 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // integer result of a ** b
-        tempvar item = new Uint256(result.low, result.high);
-        let stack = Stack.push(stack, item);
+        let stack = Stack.push_uint256(stack, result);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_EXP);
         return ctx;
     }

--- a/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
+++ b/src/kakarot/instructions/stop_and_arithmetic_operations.cairo
@@ -15,6 +15,7 @@ from starkware.cairo.common.uint256 import (
     uint256_unsigned_div_rem,
     uint256_mul_div_mod,
 )
+from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.alloc import alloc
 
@@ -22,6 +23,7 @@ from starkware.cairo.common.alloc import alloc
 from kakarot.model import model
 from kakarot.execution_context import ExecutionContext
 from kakarot.stack import Stack
+from kakarot.errors import Errors
 
 // @title Arithmetic operations opcodes.
 // @notice This contract contains the functions to execute for arithmetic operations opcodes.
@@ -78,6 +80,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: first integer value to add.
         // 1 - b: second integer value to add.
@@ -91,7 +100,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a + b: integer result of the addition modulo 2^256
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        tempvar item = new Uint256(result.low, result.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_ADD);
         return ctx;
     }
@@ -113,6 +123,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: first integer value to multiply.
         // 1 - b: second integer value to multiply.
@@ -126,7 +143,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a * b: integer result of the multiplication modulo 2^256
-        let stack: model.Stack* = Stack.push(stack, result);
+        tempvar item = new Uint256(result.low, result.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_MUL);
         return ctx;
     }
@@ -148,6 +166,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: first integer value to sub.
         // 1 - b: second integer value to sub.
@@ -161,7 +186,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a - b: integer result of the subtraction modulo 2^256
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        tempvar item = new Uint256(result.low, result.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_SUB);
         return ctx;
     }
@@ -183,6 +209,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: numerator.
         // 1 - b: denominator.
@@ -196,7 +229,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a / b: integer result of the division modulo 2^256
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        tempvar item = new Uint256(result.low, result.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_DIV);
         return ctx;
     }
@@ -218,6 +252,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: numerator.
         // 1 - b: denominator.
@@ -231,7 +272,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a / b: signed integer result of the division modulo 2^256
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        tempvar item = new Uint256(result.low, result.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_SDIV);
         return ctx;
     }
@@ -253,6 +295,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: number.
         // 1 - b: modulo.
@@ -266,7 +315,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a % b:  integer result of the a % b
-        let stack: model.Stack* = Stack.push(self=stack, element=rem);
+        tempvar item = new Uint256(rem.low, rem.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_MOD);
         return ctx;
     }
@@ -288,6 +338,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: number.
         // 1 - b: modulo.
@@ -301,7 +358,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // a % b:  signed integer result of the a % b
-        let stack: model.Stack* = Stack.push(self=stack, element=rem);
+        tempvar item = new Uint256(rem.low, rem.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_SMOD);
         return ctx;
     }
@@ -323,6 +381,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 2);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: number.
         // 1 - b: number.
@@ -340,7 +405,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // integer result of a + b % c
-        let stack: model.Stack* = Stack.push(self=stack, element=rem);
+        tempvar item = new Uint256(rem.low, rem.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_ADDMOD);
         return ctx;
     }
@@ -362,6 +428,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 2);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: number.
         // 1 - b: number.
@@ -377,7 +450,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // integer result of the a * b % c
-        let stack: model.Stack* = Stack.push(self=stack, element=rem);
+        tempvar item = new Uint256(rem.low, rem.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_MULMOD);
         return ctx;
     }
@@ -399,6 +473,13 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: number.
         // 1 - b: exponent.
@@ -412,7 +493,8 @@ namespace StopAndArithmeticOperations {
 
         // Stack output:
         // integer result of a ** b
-        let stack: model.Stack* = Stack.push(self=stack, element=result);
+        tempvar item = new Uint256(result.low, result.high);
+        let stack = Stack.push(stack, item);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_EXP);
         return ctx;
     }
@@ -434,16 +516,23 @@ namespace StopAndArithmeticOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - a: number.
         // 1 - b: exponent.
         let stack = ctx.stack;
         let (stack, popped) = Stack.pop_n(self=stack, n=2);
         let b = popped[0];
-        let a = popped[1];
+        let a = popped + Uint256.SIZE;
 
         // Value is already a uint256
-        let stack: model.Stack* = Stack.push(self=stack, element=a);
+        let stack = Stack.push(self=stack, element=a);
         let ctx = apply_context_changes(ctx=ctx, stack=stack, gas_cost=GAS_COST_SIGNEXTEND);
         return ctx;
     }

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -60,6 +60,13 @@ namespace SystemOperations {
             return ctx;
         }
 
+        let stack_underflow = is_le(ctx.stack.size, 2);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - value: value in wei to send to the new account
         // 1 - offset: byte offset in the memory in bytes (initialization code)
@@ -98,6 +105,13 @@ namespace SystemOperations {
 
         if (ctx.call_context.read_only != FALSE) {
             let (revert_reason_len, revert_reason) = Errors.stateModificationError();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
+        let stack_underflow = is_le(ctx.stack.size, 3);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
             let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
             return ctx;
         }
@@ -155,6 +169,13 @@ namespace SystemOperations {
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
 
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         // Stack input:
         // 0 - offset: byte offset in the memory in bytes
         // 1 - size: byte size to copy
@@ -188,6 +209,13 @@ namespace SystemOperations {
         bitwise_ptr: BitwiseBuiltin*,
     }(ctx: model.ExecutionContext*) -> model.ExecutionContext* {
         alloc_locals;
+
+        let stack_underflow = is_le(ctx.stack.size, 1);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         // Stack input:
         // 0 - offset: byte offset in the memory in bytes
@@ -228,6 +256,10 @@ namespace SystemOperations {
         let sub_ctx = CallHelper.init_sub_context(
             ctx=ctx, with_value=TRUE, read_only=ctx.call_context.read_only, self_call=FALSE
         );
+        if (sub_ctx.reverted != 0) {
+            return sub_ctx;
+        }
+
         if (ctx.call_context.read_only * sub_ctx.call_context.value != FALSE) {
             let (revert_reason_len, revert_reason) = Errors.stateModificationError();
             let ctx = sub_ctx.call_context.calling_context;
@@ -338,13 +370,16 @@ namespace SystemOperations {
             return ctx;
         }
 
-        // Stack input:
-        // 0 - address: account to send the current balance to
+        if (ctx.stack.size == 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
 
         // Transfer funds
-        let (stack, address) = Stack.pop(ctx.stack);
-        let (_, address_high) = unsigned_div_rem(address.high, 2 ** 32);
-        let address = Uint256(address_high, address.low);
+        let (stack, popped) = Stack.pop(ctx.stack);
+        let (_, address_high) = unsigned_div_rem(popped.high, 2 ** 32);
+        let address = Uint256(popped.low, address_high);
         let recipient_evm_address = Helpers.uint256_to_felt(address);
         let (recipient_starknet_address) = Account.compute_starknet_address(recipient_evm_address);
         tempvar recipient = new model.Address(recipient_starknet_address, recipient_evm_address);
@@ -390,6 +425,7 @@ namespace CallHelper {
         ctx: model.ExecutionContext*, call_args: CallArgs
     ) {
         alloc_locals;
+
         // Note: We don't pop ret_offset and ret_size here but at the end of the sub context
         // See finalize_calling_context
         let (stack, popped) = Stack.pop_n(self=ctx.stack, n=4 + with_value);
@@ -434,6 +470,14 @@ namespace CallHelper {
         ctx: model.ExecutionContext*, with_value: felt, read_only: felt, self_call: felt
     ) -> model.ExecutionContext* {
         alloc_locals;
+
+        let stack_underflow = is_le(ctx.stack.size, with_value + 3);
+        if (stack_underflow != 0) {
+            let (revert_reason_len, revert_reason) = Errors.stackUnderflow();
+            let ctx = ExecutionContext.stop(ctx, revert_reason_len, revert_reason, TRUE);
+            return ctx;
+        }
+
         let (ctx, local call_args) = CallHelper.prepare_args(ctx, with_value);
 
         // Check if the called address is a precompiled contract
@@ -492,13 +536,13 @@ namespace CallHelper {
         alloc_locals;
 
         // Pop ret_offset and ret_size
+        // See init_sub_context, the Stack here is guaranteed to have enough items
         let (stack, popped) = Stack.pop_n(self=summary.calling_context.stack, n=2);
         let ret_offset = 2 ** 128 * popped[0].high + popped[0].low;
         let ret_size = 2 ** 128 * popped[1].high + popped[1].low;
 
         // Put status in stack
-        let status = Uint256(low=1 - summary.reverted, high=0);
-        let stack = Stack.push(stack, status);
+        let stack = Stack.push_uint128(stack, 1 - summary.reverted);
 
         // Store RETURN_DATA in memory
         let return_data = Helpers.slice_data(
@@ -830,9 +874,8 @@ namespace CreateHelper {
 
         // Stack output: the address of the deployed contract, 0 if the deployment failed.
         let (address_high, address_low) = split_felt(summary.address.evm * (1 - summary.reverted));
-        let stack = Stack.push(
-            summary.calling_context.stack, Uint256(low=address_low, high=address_high)
-        );
+        tempvar address = new Uint256(low=address_low, high=address_high);
+        let stack = Stack.push(summary.calling_context.stack, address);
 
         // Re-create the calling context with updated stack and return_data
         tempvar ctx = new model.ExecutionContext(

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -381,6 +381,15 @@ namespace SystemOperations {
         let (_, address_high) = unsigned_div_rem(popped.high, 2 ** 32);
         let address = Uint256(popped.low, address_high);
         let recipient_evm_address = Helpers.uint256_to_felt(address);
+
+        // Remove this when https://eips.ethereum.org/EIPS/eip-6780 is validated
+        if (recipient_evm_address == ctx.call_context.address.evm) {
+            tempvar is_recipient_self = TRUE;
+        } else {
+            tempvar is_recipient_self = FALSE;
+        }
+        let recipient_evm_address = (1 - is_recipient_self) * recipient_evm_address;
+
         let (recipient_starknet_address) = Account.compute_starknet_address(recipient_evm_address);
         tempvar recipient = new model.Address(recipient_starknet_address, recipient_evm_address);
         let (state, balance) = State.read_balance(ctx.state, ctx.call_context.address);

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -125,7 +125,7 @@ namespace Kakarot {
         let state = ctx.state;
         // Handle value
         let amount = Helpers.to_uint256(value);
-        let transfer = model.Transfer(origin, address, amount);
+        let transfer = model.Transfer(origin, address, [amount]);
         let (state, success) = State.add_transfer(state, transfer);
 
         // Check collision
@@ -294,7 +294,7 @@ namespace Kakarot {
             contract_address=native_token_address,
             sender=starknet_contract_address,
             recipient=caller_address,
-            amount=amount,
+            amount=[amount],
         );
 
         return (starknet_contract_address=starknet_contract_address);

--- a/src/kakarot/model.cairo
+++ b/src/kakarot/model.cairo
@@ -10,14 +10,14 @@ namespace model {
     // @notice Info: https://www.evm.codes/about#stack
     // @notice Stack with a 1024 items maximum size. Each item is a 256 bits word. The stack is used by most
     // @notice opcodes to consume their parameters from.
-    // @dev Each word is represented by two 128bits (16bytes) chunks.
-    // @param word_dict_start pointer to a DictAccess array used to store the stack's value at a given index.
-    // @param word_dict pointer to the end of the DictAccess array.
-    // @param len_16_bytes length of the DictAccess array.
+    // @dev The dict stores a pointer to the word (a Uint256).
+    // @param size The size of the Stack.
+    // @param dict_ptr_start pointer to a DictAccess array used to store the stack's value at a given index.
+    // @param dict_ptr pointer to the end of the DictAccess array.
     struct Stack {
-        word_dict_start: DictAccess*,
-        word_dict: DictAccess*,
-        len_16bytes: felt,
+        dict_ptr_start: DictAccess*,
+        dict_ptr: DictAccess*,
+        size: felt,
     }
 
     // @notice info: https://www.evm.codes/about#memory

--- a/src/kakarot/stack.cairo
+++ b/src/kakarot/stack.cairo
@@ -3,11 +3,12 @@
 %lang starknet
 
 // Starkware dependencies
-from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
 from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
 from starkware.cairo.common.math import assert_le, unsigned_div_rem
+from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256
 
 // Internal dependencies
@@ -64,6 +65,17 @@ namespace Stack {
         tempvar item = new Uint256(element, 0);
 
         return push(self, item);
+    }
+
+    // @notice Store a uint128 into the stack.
+    // @param self The pointer to the stack.
+    // @param element The element to push.
+    // @return stack The new pointer to the stack.
+    func push_uint256{range_check_ptr}(self: model.Stack*, element: Uint256) -> model.Stack* {
+        alloc_locals;
+        let fp_and_pc = get_fp_and_pc();
+        local __fp__: felt* = fp_and_pc.fp_val;
+        return push(self, &element);
     }
 
     // @notice Pop N elements from the stack.

--- a/src/kakarot/state.cairo
+++ b/src/kakarot/state.cairo
@@ -214,7 +214,7 @@ namespace State {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(self: model.State*, address: model.Address*, key: Uint256) -> (model.State*, Uint256) {
+    }(self: model.State*, address: model.Address*, key: Uint256*) -> (model.State*, Uint256*) {
         alloc_locals;
         let (self, account) = get_account(self, address);
         let (account, value) = Account.read_storage(account, address, key);
@@ -228,7 +228,7 @@ namespace State {
     // @param key The pointer to the Uint256 storage key
     // @param value The pointer to the Uint256 value
     func write_storage{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        self: model.State*, address: model.Address*, key: Uint256, value: Uint256*
+        self: model.State*, address: model.Address*, key: Uint256*, value: Uint256*
     ) -> model.State* {
         alloc_locals;
         let (self, account) = get_account(self, address);

--- a/src/utils/dict.cairo
+++ b/src/utils/dict.cairo
@@ -6,15 +6,88 @@ from starkware.cairo.common.dict import dict_write, dict_squash
 from starkware.cairo.common.math_cmp import is_not_zero
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import unsigned_div_rem
+from starkware.cairo.common.uint256 import Uint256
 
-// @dev Copy a default_dict
-// @param start The pointer to the beginning of the dict
-// @param self The pointer to the end of the dict
+func dict_keys{range_check_ptr}(dict_start: DictAccess*, dict_end: DictAccess*) -> (
+    keys_len: felt, keys: felt*
+) {
+    alloc_locals;
+    let (local keys_start: felt*) = alloc();
+    let dict_len = dict_end - dict_start;
+    let (local keys_len, _) = unsigned_div_rem(dict_len, DictAccess.SIZE);
+    local range_check_ptr = range_check_ptr;
+
+    if (dict_len == 0) {
+        return (keys_len, keys_start);
+    }
+
+    tempvar keys = keys_start;
+    tempvar len = keys_len;
+    tempvar dict = dict_start;
+
+    loop:
+    let keys = cast([ap - 3], felt*);
+    let len = [ap - 2];
+    let dict = cast([ap - 1], DictAccess*);
+
+    assert [keys] = dict.key;
+    tempvar keys = keys + 1;
+    tempvar len = len - 1;
+    tempvar dict = dict + DictAccess.SIZE;
+
+    static_assert keys == [ap - 3];
+    static_assert len == [ap - 2];
+    static_assert dict == [ap - 1];
+
+    jmp loop if len != 0;
+
+    return (keys_len, keys_start);
+}
+
+func dict_values{range_check_ptr}(dict_start: DictAccess*, dict_end: DictAccess*) -> (
+    values_len: felt, values: Uint256*
+) {
+    alloc_locals;
+    let (local values: Uint256*) = alloc();
+    let dict_len = dict_end - dict_start;
+    let (local values_len, _) = unsigned_div_rem(dict_len, DictAccess.SIZE);
+    local range_check_ptr = range_check_ptr;
+
+    if (dict_len == 0) {
+        return (values_len, values);
+    }
+
+    tempvar index = 0;
+    tempvar len = values_len;
+    tempvar dict = dict_start;
+
+    loop:
+    let index = [ap - 3];
+    let len = [ap - 2];
+    let dict = cast([ap - 1], DictAccess*);
+
+    let pointer = cast(dict.new_value, Uint256*);
+    assert values[index] = pointer[0];
+
+    tempvar index = index + 1;
+    tempvar len = len - 1;
+    tempvar dict = dict + DictAccess.SIZE;
+
+    static_assert index == [ap - 3];
+    static_assert len == [ap - 2];
+    static_assert dict == [ap - 1];
+
+    jmp loop if len != 0;
+
+    return (values_len, values);
+}
+
 func default_dict_copy{range_check_ptr}(start: DictAccess*, end: DictAccess*) -> (
     DictAccess*, DictAccess*
 ) {
     alloc_locals;
     let (squashed_start, squashed_end) = dict_squash(start, end);
+    local range_check_ptr = range_check_ptr;
     let dict_len = squashed_end - squashed_start;
 
     if (dict_len == 0) {
@@ -30,13 +103,11 @@ func default_dict_copy{range_check_ptr}(start: DictAccess*, end: DictAccess*) ->
         return (new_start, new_ptr);
     }
 
-    tempvar range_check_ptr = range_check_ptr;
     tempvar squashed_start = squashed_start;
     tempvar dict_len = dict_len;
     tempvar new_ptr = new_ptr;
 
     loop:
-    let range_check_ptr = [ap - 4];
     let squashed_start = cast([ap - 3], DictAccess*);
     let dict_len = [ap - 2];
     let new_ptr = cast([ap - 1], DictAccess*);
@@ -46,12 +117,10 @@ func default_dict_copy{range_check_ptr}(start: DictAccess*, end: DictAccess*) ->
 
     dict_write{dict_ptr=new_ptr}(key=key, new_value=new_value);
 
-    tempvar range_check_ptr = range_check_ptr;
     tempvar squashed_start = squashed_start + DictAccess.SIZE;
     tempvar dict_len = dict_len - DictAccess.SIZE;
     tempvar new_ptr = new_ptr;
 
-    static_assert range_check_ptr == [ap - 4];
     static_assert squashed_start == [ap - 3];
     static_assert dict_len == [ap - 2];
     static_assert new_ptr == [ap - 1];
@@ -59,43 +128,4 @@ func default_dict_copy{range_check_ptr}(start: DictAccess*, end: DictAccess*) ->
     jmp loop if dict_len != 0;
 
     return (new_start, new_ptr);
-}
-
-func dict_keys{range_check_ptr}(dict_start: DictAccess*, dict_end: DictAccess*) -> (
-    keys_len: felt, keys: felt*
-) {
-    alloc_locals;
-    let (local keys_start: felt*) = alloc();
-    let dict_len = dict_end - dict_start;
-    let (local keys_len, _) = unsigned_div_rem(dict_len, DictAccess.SIZE);
-
-    if (dict_len == 0) {
-        return (keys_len, keys_start);
-    }
-
-    tempvar range_check_ptr = range_check_ptr;
-    tempvar keys = keys_start;
-    tempvar len = keys_len;
-    tempvar dict = dict_start;
-
-    loop:
-    let range_check_ptr = [ap - 4];
-    let keys = cast([ap - 3], felt*);
-    let len = [ap - 2];
-    let dict = cast([ap - 1], DictAccess*);
-
-    assert [keys] = dict.key;
-    tempvar range_check_ptr = range_check_ptr;
-    tempvar keys = keys + 1;
-    tempvar len = len - 1;
-    tempvar dict = dict + DictAccess.SIZE;
-
-    static_assert range_check_ptr == [ap - 4];
-    static_assert keys == [ap - 3];
-    static_assert len == [ap - 2];
-    static_assert dict == [ap - 1];
-
-    jmp loop if len != 0;
-
-    return (keys_len, keys_start);
 }

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -31,9 +31,9 @@ from starkware.cairo.common.hash_state import hash_finalize, hash_init, hash_upd
 // @title Helper Functions
 // @notice This file contains a selection of helper function that simplify tasks such as type conversion and bit manipulation
 namespace Helpers {
-    func to_uint256{range_check_ptr}(val: felt) -> Uint256 {
+    func to_uint256{range_check_ptr}(val: felt) -> Uint256* {
         let (high, low) = split_felt(val);
-        let res = Uint256(low, high);
+        tempvar res = new Uint256(low, high);
         return res;
     }
 

--- a/tests/end_to_end/test_kakarot.py
+++ b/tests/end_to_end/test_kakarot.py
@@ -11,7 +11,6 @@ from tests.end_to_end.bytecodes import test_cases
 from tests.utils.constants import PRE_FUND_AMOUNT
 from tests.utils.helpers import (
     extract_memory_from_execute,
-    extract_stack_from_execute,
     generate_random_evm_address,
     hex_string_to_bytes_array,
 )
@@ -58,11 +57,10 @@ class TestKakarot:
                     bytecode=hex_string_to_bytes_array(params["code"]),
                     calldata=hex_string_to_bytes_array(params["calldata"]),
                 )
-            stack_result = extract_stack_from_execute(result)
             memory_result = extract_memory_from_execute(result)
 
             assert result.success == params["success"]
-            assert stack_result == (
+            assert result.stack_values[: result.stack_size] == (
                 [
                     int(x)
                     for x in params["stack"]

--- a/tests/fixtures/EVM.cairo
+++ b/tests/fixtures/EVM.cairo
@@ -24,7 +24,7 @@ from kakarot.constants import (
     account_proxy_class_hash,
     Constants,
 )
-from utils.dict import dict_keys
+from utils.dict import dict_keys, dict_values
 
 // Constructor
 @constructor
@@ -83,9 +83,11 @@ func evm_call{
 ) -> (
     block_number: felt,
     block_timestamp: felt,
-    stack_accesses_len: felt,
-    stack_accesses: felt*,
-    stack_len: felt,
+    stack_size: felt,
+    stack_keys_len: felt,
+    stack_keys: felt*,
+    stack_values_len: felt,
+    stack_values: Uint256*,
     memory_accesses_len: felt,
     memory_accesses: felt*,
     memory_bytes_len: felt,
@@ -104,7 +106,13 @@ func evm_call{
     let (local block_timestamp) = get_block_timestamp();
     let summary = execute(origin, value, bytecode_len, bytecode, calldata_len, calldata);
 
-    let stack_accesses_len = summary.stack.squashed_end - summary.stack.squashed_start;
+    let (stack_keys_len, stack_keys) = dict_keys(
+        summary.stack.squashed_start, summary.stack.squashed_end
+    );
+    let (stack_values_len, stack_values) = dict_values(
+        summary.stack.squashed_start, summary.stack.squashed_end
+    );
+
     let memory_accesses_len = summary.memory.squashed_end - summary.memory.squashed_start;
 
     // Return only accounts keys, ie. touched starknet addresses
@@ -115,9 +123,11 @@ func evm_call{
     return (
         block_number=block_number,
         block_timestamp=block_timestamp,
-        stack_accesses_len=stack_accesses_len,
-        stack_accesses=summary.stack.squashed_start,
-        stack_len=summary.stack.len_16bytes,
+        stack_size=summary.stack.size,
+        stack_keys_len=stack_keys_len,
+        stack_keys=stack_keys,
+        stack_values_len=stack_values_len,
+        stack_values=stack_values,
         memory_accesses_len=memory_accesses_len,
         memory_accesses=summary.memory.squashed_start,
         memory_bytes_len=summary.memory.bytes_len,

--- a/tests/src/kakarot/instructions/test_block_information.cairo
+++ b/tests/src/kakarot/instructions/test_block_information.cairo
@@ -5,9 +5,10 @@
 // Starkware dependencies
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.uint256 import Uint256, uint256_sub
+from starkware.cairo.common.uint256 import Uint256, uint256_sub, assert_uint256_eq
 from starkware.cairo.common.math import assert_nn
 from starkware.starknet.common.syscalls import get_block_number, get_block_timestamp
+from starkware.cairo.common.registers import get_fp_and_pc
 
 // Local dependencies
 from utils.utils import Helpers
@@ -44,46 +45,48 @@ func test__blockhash_should_push_blockhash_to_stack{
 }() {
     // Given # 1
     alloc_locals;
+    let fp_and_pc = get_fp_and_pc();
+    local __fp__: felt* = fp_and_pc.fp_val;
+
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let (block_number_: Uint256) = block_number.read();
+    let (local block_number_: Uint256) = block_number.read();
 
-    let stack: model.Stack* = Stack.push(stack, block_number_);
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
+    let stack = Stack.push(stack, &block_number_);
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = BlockInformation.exec_blockhash(ctx);
 
     // Then
     assert result.gas_used = 20;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     let (blockhash_) = blockhash.read();
     let value = Helpers.to_uint256(val=blockhash_);
-    assert index0 = value;
+    assert_uint256_eq([index0], [value]);
 
     // Given # 2
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
     let (current_block_number: felt) = get_block_number();
     let out_of_range_block = current_block_number - 260;
     assert_nn(out_of_range_block);
-    let block_number_: Uint256 = Helpers.to_uint256(val=out_of_range_block);
-    let stack: model.Stack* = Stack.push(stack, block_number_);
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
+    let out_of_range_block_uint256 = Helpers.to_uint256(val=out_of_range_block);
+    let stack = Stack.push(stack, out_of_range_block_uint256);
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = BlockInformation.exec_blockhash(ctx);
 
     // Then
     assert result.gas_used = 20;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
 
     return ();
 }
@@ -95,17 +98,17 @@ func test__chainId__should_push_chain_id_to_stack{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
+    let ctx = TestHelpers.init_context(0, bytecode);
 
     // When
     let result = BlockInformation.exec_chainid(ctx);
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1263227476, 0);
+    assert index0.low = 1263227476;
+    assert index0.high = 0;
     return ();
 }
 
@@ -116,18 +119,17 @@ func test__coinbase_should_push_coinbase_address_to_stack{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
+    let ctx = TestHelpers.init_context(0, bytecode);
 
     // When
     let result = BlockInformation.exec_coinbase(ctx);
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     let coinbase_address = Helpers.to_uint256(Constants.MOCK_COINBASE_ADDRESS);
-    assert index0 = coinbase_address;
+    assert_uint256_eq([index0], [coinbase_address]);
     return ();
 }
 
@@ -138,19 +140,18 @@ func test__timestamp_should_push_block_timestamp_to_stack{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
+    let ctx = TestHelpers.init_context(0, bytecode);
 
     // When
     let result = BlockInformation.exec_timestamp(ctx);
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     let (current_timestamp) = get_block_timestamp();
     let block_timestamp = Helpers.to_uint256(current_timestamp);
-    assert index0 = block_timestamp;
+    assert_uint256_eq([index0], [block_timestamp]);
     return ();
 }
 
@@ -161,19 +162,18 @@ func test__number_should_push_block_number_to_stack{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
+    let ctx = TestHelpers.init_context(0, bytecode);
 
     // When
     let result = BlockInformation.exec_number(ctx);
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     let (current_block) = get_block_number();
     let block_number = Helpers.to_uint256(current_block);
-    assert index0 = block_number;
+    assert_uint256_eq([index0], [block_number]);
     return ();
 }
 
@@ -184,18 +184,17 @@ func test__gaslimit_should_push_gaslimit_to_stack{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
+    let ctx = TestHelpers.init_context(0, bytecode);
 
     // When
     let result = BlockInformation.exec_gaslimit(ctx);
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     let gas_limit = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
-    assert index0 = gas_limit;
+    assert_uint256_eq([index0], [gas_limit]);
     return ();
 }
 
@@ -206,18 +205,17 @@ func test__difficulty_should_push_difficulty_to_stack{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
+    let ctx = TestHelpers.init_context(0, bytecode);
 
     // When
     let result = BlockInformation.exec_difficulty(ctx);
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     let difficulty = Helpers.to_uint256(0);
-    assert index0 = difficulty;
+    assert_uint256_eq([index0], [difficulty]);
     return ();
 }
 
@@ -228,17 +226,16 @@ func test__basefee_should_push_basefee_to_stack{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
+    let ctx = TestHelpers.init_context(0, bytecode);
 
     // When
     let result = BlockInformation.exec_basefee(ctx);
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
     let basefee = Helpers.to_uint256(0);
-    assert index0 = basefee;
+    assert_uint256_eq([index0], [basefee]);
     return ();
 }

--- a/tests/src/kakarot/instructions/test_comparison_operations.cairo
+++ b/tests/src/kakarot/instructions/test_comparison_operations.cairo
@@ -21,10 +21,13 @@ func test__exec_lt__should_pop_0_and_1_and_push_0__when_0_not_lt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    tempvar item_0 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(1, 0);
+
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -32,10 +35,10 @@ func test__exec_lt__should_pop_0_and_1_and_push_0__when_0_not_lt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -46,10 +49,12 @@ func test__exec_lt__should_pop_0_and_1_and_push_1__when_0_lt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -57,10 +62,10 @@ func test__exec_lt__should_pop_0_and_1_and_push_1__when_0_lt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -71,10 +76,12 @@ func test__exec_gt__should_pop_0_and_1_and_push_0__when_0_not_gt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -82,10 +89,10 @@ func test__exec_gt__should_pop_0_and_1_and_push_0__when_0_not_gt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -96,10 +103,12 @@ func test__exec_gt__should_pop_0_and_1_and_push_1__when_0_gt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(1, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -107,10 +116,10 @@ func test__exec_gt__should_pop_0_and_1_and_push_1__when_0_gt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -121,10 +130,12 @@ func test__exec_slt__should_pop_0_and_1_and_push_0__when_0_not_slt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(1, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -132,10 +143,10 @@ func test__exec_slt__should_pop_0_and_1_and_push_0__when_0_not_slt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -146,10 +157,12 @@ func test__exec_slt__should_pop_0_and_1_and_push_1__when_0_slt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -157,10 +170,10 @@ func test__exec_slt__should_pop_0_and_1_and_push_1__when_0_slt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -171,10 +184,12 @@ func test__exec_sgt__should_pop_0_and_1_and_push_0__when_0_not_sgt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -182,10 +197,10 @@ func test__exec_sgt__should_pop_0_and_1_and_push_0__when_0_not_sgt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -196,10 +211,12 @@ func test__exec_sgt__should_pop_0_and_1_and_push_1__when_0_sgt_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(1, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -207,10 +224,10 @@ func test__exec_sgt__should_pop_0_and_1_and_push_1__when_0_sgt_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -221,10 +238,12 @@ func test__exec_eq__should_pop_0_and_1_and_push_0__when_0_not_eq_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -232,10 +251,10 @@ func test__exec_eq__should_pop_0_and_1_and_push_0__when_0_not_eq_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -246,10 +265,12 @@ func test__exec_eq__should_pop_0_and_1_and_push_1__when_0_eq_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(2, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -257,10 +278,10 @@ func test__exec_eq__should_pop_0_and_1_and_push_1__when_0_eq_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -271,9 +292,10 @@ func test__exec_iszero__should_pop_0_and_push_0__when_0_is_not_zero{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -281,10 +303,10 @@ func test__exec_iszero__should_pop_0_and_push_0__when_0_is_not_zero{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -295,9 +317,10 @@ func test__exec_iszero__should_pop_0_and_push_1__when_0_is_zero{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(0, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -305,10 +328,10 @@ func test__exec_iszero__should_pop_0_and_push_1__when_0_is_zero{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -319,10 +342,12 @@ func test__exec_and__should_pop_0_and_1_and_push_0__when_0_and_1_are_not_true{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(0, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -330,10 +355,10 @@ func test__exec_and__should_pop_0_and_1_and_push_0__when_0_and_1_are_not_true{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -344,10 +369,12 @@ func test__exec_and__should_pop_0_and_1_and_push_1__when_0_and_1_are_true{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(1, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -355,10 +382,10 @@ func test__exec_and__should_pop_0_and_1_and_push_1__when_0_and_1_are_true{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -369,10 +396,14 @@ func test__exec_and__should_pop_0_and_1_and_push_0x89__when_0_is_0xC9_and_1_is_0
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0xC9, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0xBD, 0));
+    tempvar item_0 = new Uint256(0xbd, 0);
+    tempvar item_1 = new Uint256(0xc9, 0);
+
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
+
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -380,10 +411,10 @@ func test__exec_and__should_pop_0_and_1_and_push_0x89__when_0_is_0xC9_and_1_is_0
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0x89, 0);
+    assert index0.low = 0x89;
+    assert index0.high = 0;
     return ();
 }
 
@@ -394,10 +425,12 @@ func test__exec_or__should_pop_0_and_1_and_push_0__when_0_or_1_are_not_true{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(0, 0);
+    tempvar item_1 = new Uint256(0, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -405,10 +438,10 @@ func test__exec_or__should_pop_0_and_1_and_push_0__when_0_or_1_are_not_true{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -419,10 +452,12 @@ func test__exec_or__should_pop_0_and_1_and_push_1__when_0_or_1_are_true{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(0, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -430,10 +465,10 @@ func test__exec_or__should_pop_0_and_1_and_push_1__when_0_or_1_are_true{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -444,10 +479,12 @@ func test__exec_or__should_pop_0_and_1_and_push_0xCD__when_0_is_0x89_and_1_is_0x
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(0xc5, 0);
+    tempvar item_1 = new Uint256(0x89, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0x89, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0xC5, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -455,10 +492,10 @@ func test__exec_or__should_pop_0_and_1_and_push_0xCD__when_0_is_0x89_and_1_is_0x
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0xCD, 0);
+    assert index0.low = 0xcd;
+    assert index0.high = 0;
     return ();
 }
 
@@ -469,10 +506,12 @@ func test__exec_xor__should_pop_0_and_1_and_push_0__when_0_and_1_are_true{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(1, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -480,10 +519,10 @@ func test__exec_xor__should_pop_0_and_1_and_push_0__when_0_and_1_are_true{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -494,10 +533,12 @@ func test__exec_xor__should_pop_0_and_1_and_push_0__when_0_and_1_are_not_true{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(0, 0);
+    tempvar item_1 = new Uint256(0, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -505,10 +546,10 @@ func test__exec_xor__should_pop_0_and_1_and_push_0__when_0_and_1_are_not_true{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -519,10 +560,12 @@ func test__exec_xor__should_pop_0_and_1_and_push_1__when_0_is_true_and_1_is_not_
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(0, 0);
+    tempvar item_1 = new Uint256(1, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -530,10 +573,10 @@ func test__exec_xor__should_pop_0_and_1_and_push_1__when_0_is_true_and_1_is_not_
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -544,10 +587,12 @@ func test__exec_xor__should_pop_0_and_1_and_push_1__when_0_is_not_true_and_1_is_
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(0, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -555,10 +600,10 @@ func test__exec_xor__should_pop_0_and_1_and_push_1__when_0_is_not_true_and_1_is_
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -569,10 +614,12 @@ func test__exec_xor__should_pop_0_and_1_and_push_0x64__when_0_is_0xB9_and_1_is_0
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    tempvar item_0 = new Uint256(0xdd, 0);
+    tempvar item_1 = new Uint256(0xb9, 0);
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0xB9, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0xDD, 0));
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -580,10 +627,10 @@ func test__exec_xor__should_pop_0_and_1_and_push_0x64__when_0_is_0xB9_and_1_is_0
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0x64, 0);
+    assert index0.low = 0x64;
+    assert index0.high = 0;
     return ();
 }
 
@@ -594,10 +641,14 @@ func test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_less_than_16_byte
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0xFFEEDDCCBBAA998877665544332211, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(23, 0));
+    tempvar item_0 = new Uint256(23, 0);
+    tempvar item_1 = new Uint256(0xFFEEDDCCBBAA998877665544332211, 0);
+
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
+
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -605,10 +656,10 @@ func test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_less_than_16_byte
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0x99, 0);
+    assert index0.low = 0x99;
+    assert index0.high = 0;
     return ();
 }
 
@@ -619,10 +670,14 @@ func test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_larger_than_16_by
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0x123456789ABCDEF0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(8, 0));
+    tempvar item_0 = new Uint256(8, 0);
+    tempvar item_1 = new Uint256(0, 0x123456789ABCDEF0);
+
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
+
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -630,10 +685,10 @@ func test__exec_byte__should_pop_0_and_1_and_push_0__when_0_is_larger_than_16_by
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0x12, 0);
+    assert index0.low = 0x12;
+    assert index0.high = 0;
     return ();
 }
 
@@ -644,10 +699,14 @@ func test__exec_shl__should_pop_0_and_1_and_push_left_shift{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(4, 0));
+    tempvar item_0 = new Uint256(4, 0);
+    tempvar item_1 = new Uint256(2, 0);
+
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
+
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -655,10 +714,10 @@ func test__exec_shl__should_pop_0_and_1_and_push_left_shift{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(32, 0);
+    assert index0.low = 32;
+    assert index0.high = 0;
     return ();
 }
 
@@ -669,10 +728,14 @@ func test__exec_shr__should_pop_0_and_1_and_push_right_shift{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(4, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    tempvar item_0 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(4, 0);
+
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
+
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -680,10 +743,10 @@ func test__exec_shr__should_pop_0_and_1_and_push_right_shift{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -694,10 +757,14 @@ func test__exec_sar__should_pop_0_and_1_and_push_shr{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(4, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    tempvar item_0 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(4, 0);
+
+    let stack = Stack.init();
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
+
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -705,9 +772,9 @@ func test__exec_sar__should_pop_0_and_1_and_push_shr{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }

--- a/tests/src/kakarot/instructions/test_duplication_operations.cairo
+++ b/tests/src/kakarot/instructions/test_duplication_operations.cairo
@@ -23,22 +23,21 @@ func test__exec_dup1_should_duplicate_1st_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 1, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 1, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup1(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 2);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 2;
     return ();
 }
 
@@ -50,22 +49,21 @@ func test__exec_dup2_should_duplicate_2nd_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 2, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 2, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup2(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 3);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 3;
     return ();
 }
 
@@ -77,22 +75,21 @@ func test__exec_dup3_should_duplicate_3rd_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 3, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 3, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup3(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 4);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 4;
     return ();
 }
 
@@ -104,22 +101,21 @@ func test__exec_dup4_should_duplicate_4th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 4, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 4, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup4(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 5);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 5;
     return ();
 }
 
@@ -131,22 +127,21 @@ func test__exec_dup5_should_duplicate_5th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 5, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 5, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup5(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 6);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 6;
     return ();
 }
 
@@ -158,22 +153,21 @@ func test__exec_dup6_should_duplicate_6th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 6, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 6, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup6(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 7);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 7;
     return ();
 }
 
@@ -185,22 +179,21 @@ func test__exec_dup7_should_duplicate_7th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 7, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 7, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup7(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 8);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 8;
     return ();
 }
 
@@ -212,22 +205,21 @@ func test__exec_dup8_should_duplicate_8th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 8, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 8, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup8(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 9);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 9;
     return ();
 }
 
@@ -239,22 +231,21 @@ func test__exec_dup9_should_duplicate_9th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, 9, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 9, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup9(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 10);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 10;
     return ();
 }
 
@@ -266,24 +257,21 @@ func test__exec_dup10_should_duplicate_10th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(
-        start, 10, stack
-    );
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 10, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup10(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 11);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 11;
     return ();
 }
 
@@ -295,24 +283,21 @@ func test__exec_dup11_should_duplicate_11th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(
-        start, 11, stack
-    );
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 11, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup11(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 12);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 12;
     return ();
 }
 
@@ -324,24 +309,21 @@ func test__exec_dup12_should_duplicate_12th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(
-        start, 12, stack
-    );
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 12, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup12(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 13);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 13;
     return ();
 }
 
@@ -353,24 +335,21 @@ func test__exec_dup13_should_duplicate_13th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(
-        start, 13, stack
-    );
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 13, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup13(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 14);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 14;
     return ();
 }
 
@@ -382,24 +361,21 @@ func test__exec_dup14_should_duplicate_14th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(
-        start, 14, stack
-    );
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 14, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup14(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 15);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 15;
     return ();
 }
 
@@ -411,24 +387,21 @@ func test__exec_dup15_should_duplicate_15th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(
-        start, 15, stack
-    );
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 15, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup15(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 16);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 16;
     return ();
 }
 
@@ -440,24 +413,21 @@ func test__exec_dup16_should_duplicate_16th_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(
-        start, 16, stack
-    );
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, 16, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup16(ctx);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, 17);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = 17;
     return ();
 }
 
@@ -482,21 +452,20 @@ func _test__exec_dup_i_should_duplicate_ith_item_to_top_of_stack{
 
     // Given
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    // Push elements to stack
-    let start: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = TestHelpers.push_elements_in_range_to_stack(start, i, stack);
+    let stack = Stack.init();
+    let start = 1;
+    let stack = TestHelpers.push_elements_in_range_to_stack(1, i, stack);
 
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(
-        0, bytecode, prepared_stack
-    );
+    let ctx = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
     let result = DuplicationOperations.exec_dup_i(ctx, i);
 
     // Then
     assert result.gas_used = DuplicationOperations.GAS_COST_DUP;
-    TestHelpers.assert_stack_last_element_contains_uint256(result.stack, start);
-    TestHelpers.assert_stack_len_16bytes_equal(result.stack, i + 1);
+    let (stack, top) = Stack.peek(result.stack, 0);
+    assert top.low = start;
+    assert top.high = 0;
+    assert result.stack.size = i + 1;
     return ();
 }

--- a/tests/src/kakarot/instructions/test_duplication_operations.py
+++ b/tests/src/kakarot/instructions/test_duplication_operations.py
@@ -8,7 +8,7 @@ async def duplication_operations(starknet: Starknet):
     class_hash = await starknet.deprecated_declare(
         source="./tests/src/kakarot/instructions/test_duplication_operations.cairo",
         cairo_path=["src"],
-        disable_hint_validation=False,
+        disable_hint_validation=True,
     )
     return await starknet.deploy(class_hash=class_hash.class_hash)
 

--- a/tests/src/kakarot/instructions/test_exchange_operations.cairo
+++ b/tests/src/kakarot/instructions/test_exchange_operations.cairo
@@ -8,6 +8,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
 from starkware.cairo.common.math import assert_nn
+from starkware.cairo.common.registers import get_fp_and_pc
 
 // Local dependencies
 from kakarot.instructions.exchange_operations import ExchangeOperations
@@ -22,36 +23,30 @@ func init_stack{range_check_ptr}(
     swap_idx_element: Uint256,
     top_stack_element: Uint256,
     stack: model.Stack*,
-) -> (prepared_stack: model.Stack*) {
+) -> (stack: model.Stack*) {
     alloc_locals;
-    // We set the last prepared_stack_len to a special number so we can test for successful swapping
+    let fp_and_pc = get_fp_and_pc();
+    local __fp__: felt* = fp_and_pc.fp_val;
+
     if (stack_len == 0) {
-        let updated_stack: model.Stack* = Stack.push(stack, top_stack_element);
-        return (prepared_stack=updated_stack);
-    }
-    // As well as user defined prepared_stack_len
-    if (swap_idx == stack_len) {
-        let _updated_stack: model.Stack* = Stack.push(stack, swap_idx_element);
-        let updated_stack: model.Stack* = init_stack(
-            stack_len=stack_len - 1,
-            swap_idx=swap_idx,
-            swap_idx_element=swap_idx_element,
-            top_stack_element=top_stack_element,
-            stack=_updated_stack,
-        );
-        return (prepared_stack=updated_stack);
+        let stack = Stack.push(stack, &top_stack_element);
+        return (stack,);
     }
 
-    // otherwise we just fill with zero
-    let _updated_stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
-    let updated_stack: model.Stack* = init_stack(
+    if (stack_len == swap_idx) {
+        tempvar item = &swap_idx_element;
+    } else {
+        tempvar item = new Uint256(0, 0);
+    }
+
+    let stack = Stack.push(stack, &swap_idx_element);
+    return init_stack(
         stack_len=stack_len - 1,
         swap_idx=swap_idx,
         swap_idx_element=swap_idx_element,
         top_stack_element=top_stack_element,
-        stack=_updated_stack,
+        stack=stack,
     );
-    return (prepared_stack=updated_stack);
 }
 
 // @notice Checks if previously prepared stack has its values properly swapped.
@@ -65,8 +60,8 @@ func assert_stack_is_swapped{range_check_ptr}(
     let (stack, swapped_element) = Stack.peek(stack, 0);
     let (stack, swapped_element_at_swap_idx) = Stack.peek(stack, swap_idx);
 
-    assert_uint256_eq(preswap_top_stack_element, swapped_element_at_swap_idx);
-    assert_uint256_eq(preswap_element_at_swap_idx, swapped_element);
+    assert_uint256_eq(preswap_top_stack_element, [swapped_element_at_swap_idx]);
+    assert_uint256_eq(preswap_element_at_swap_idx, [swapped_element]);
     return ();
 }
 
@@ -83,7 +78,7 @@ func test__util_init_stack__should_create_stack_with_top_and_preswapped_elements
     let length_of_stack_indexed_from_zero = 15;
 
     // When
-    let prepared_stack: model.Stack* = init_stack(
+    let stack: model.Stack* = init_stack(
         stack_len=length_of_stack_indexed_from_zero,
         swap_idx=15,
         swap_idx_element=preswap_element_at_idx,
@@ -92,13 +87,12 @@ func test__util_init_stack__should_create_stack_with_top_and_preswapped_elements
     );
 
     // Then
-    let stack_len = prepared_stack.len_16bytes / 2;
-    let (stack, top_element) = Stack.peek(prepared_stack, 0);
+    let (stack, top_element) = Stack.peek(stack, 0);
     let (stack, element_at_swap_idx) = Stack.peek(stack, 15);
 
-    assert stack_len = length_of_stack_indexed_from_zero + 1;
-    assert_uint256_eq(top_element, top_stack_element);
-    assert_uint256_eq(element_at_swap_idx, preswap_element_at_idx);
+    assert stack.size = length_of_stack_indexed_from_zero + 1;
+    assert_uint256_eq([top_element], top_stack_element);
+    assert_uint256_eq([element_at_swap_idx], preswap_element_at_idx);
 
     return ();
 }
@@ -139,21 +133,6 @@ func test__exec_swap1__should_swap_1st_and_2nd{
 }
 
 @external
-func test__exec_swap1__should_fail__when_index_1_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap1(ctx);
-    return ();
-}
-
-@external
 func test__exec_swap2__should_swap_1st_and_3rd{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
@@ -185,22 +164,6 @@ func test__exec_swap2__should_swap_1st_and_3rd{
         swap_idx=2,
         stack=result.stack,
     );
-    return ();
-}
-
-@external
-func test__exec_swap2__should_fail__when_index_2_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap2(ctx);
     return ();
 }
 
@@ -240,31 +203,6 @@ func test__exec_swap8__should_swap_1st_and_9th{
 }
 
 @external
-func test__exec_swap8__should_fail__when_index_8_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=7,
-        swap_idx=7,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap8(ctx);
-    return ();
-}
-
-@external
 func test__exec_swap9__should_swap_1st_and_10th{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
@@ -296,31 +234,6 @@ func test__exec_swap9__should_swap_1st_and_10th{
         swap_idx=9,
         stack=result.stack,
     );
-    return ();
-}
-
-@external
-func test__exec_swap9__should_fail__when_index_9_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=8,
-        swap_idx=8,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap9(ctx);
     return ();
 }
 
@@ -360,31 +273,6 @@ func test__exec_swap10__should_swap_1st_and_11th{
 }
 
 @external
-func test__exec_swap10__should_fail__when_index_10_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=9,
-        swap_idx=9,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap10(ctx);
-    return ();
-}
-
-@external
 func test__exec_swap11__should_swap_1st_and_12th{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
@@ -416,31 +304,6 @@ func test__exec_swap11__should_swap_1st_and_12th{
         swap_idx=11,
         stack=result.stack,
     );
-    return ();
-}
-
-@external
-func test__exec_swap11__should_fail__when_index_11_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=10,
-        swap_idx=10,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap11(ctx);
     return ();
 }
 
@@ -480,31 +343,6 @@ func test__exec_swap12__should_swap_1st_and_13th{
 }
 
 @external
-func test__exec_swap12__should_fail__when_index_12_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=11,
-        swap_idx=11,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap12(ctx);
-    return ();
-}
-
-@external
 func test__exec_swap13__should_swap_1st_and_14th{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
@@ -536,31 +374,6 @@ func test__exec_swap13__should_swap_1st_and_14th{
         swap_idx=13,
         stack=result.stack,
     );
-    return ();
-}
-
-@external
-func test__exec_swap13__should_fail__when_index_13_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=12,
-        swap_idx=12,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap13(ctx);
     return ();
 }
 
@@ -600,31 +413,6 @@ func test__exec_swap14__should_swap_1st_and_15th{
 }
 
 @external
-func test__exec_swap14__should_fail__when_index_14_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=13,
-        swap_idx=13,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap14(ctx);
-    return ();
-}
-
-@external
 func test__exec_swap15__should_swap_1st_and_16th{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
@@ -660,31 +448,6 @@ func test__exec_swap15__should_swap_1st_and_16th{
 }
 
 @external
-func test__exec_swap15__should_fail__when_index_15_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=13,
-        swap_idx=14,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap15(ctx);
-    return ();
-}
-
-@external
 func test__exec_swap16__should_swap_1st_and_17th{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
@@ -716,30 +479,5 @@ func test__exec_swap16__should_swap_1st_and_17th{
         swap_idx=16,
         stack=result.stack,
     );
-    return ();
-}
-
-@external
-func test__exec_swap16__should_fail__when_index_16_is_underflow{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    alloc_locals;
-    // Given
-    let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
-    let top_stack_element: Uint256 = Uint256(2, 0);
-    let preswap_element_at_idx: Uint256 = Uint256(1, 0);
-    let prepared_stack: model.Stack* = init_stack(
-        stack_len=14,
-        swap_idx=14,
-        swap_idx_element=preswap_element_at_idx,
-        top_stack_element=top_stack_element,
-        stack=stack,
-    );
-
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
-
-    // When & Then
-    let result = ExchangeOperations.exec_swap16(ctx);
     return ();
 }

--- a/tests/src/kakarot/instructions/test_exchange_operations.py
+++ b/tests/src/kakarot/instructions/test_exchange_operations.py
@@ -2,8 +2,6 @@ import pytest
 import pytest_asyncio
 from starkware.starknet.testing.starknet import Starknet
 
-from tests.utils.errors import cairo_error
-
 
 @pytest_asyncio.fixture(scope="module")
 async def exchange_operations(starknet: Starknet):
@@ -17,49 +15,52 @@ async def exchange_operations(starknet: Starknet):
 
 @pytest.mark.asyncio
 class TestExchangeOperations:
-    async def test_everything_context(self, exchange_operations):
-        await exchange_operations.test__util_init_stack__should_create_stack_with_top_and_preswapped_elements().call()
-        await exchange_operations.test__exec_swap1__should_swap_1st_and_2nd().call()
-        await exchange_operations.test__exec_swap2__should_swap_1st_and_3rd().call()
-        await exchange_operations.test__exec_swap8__should_swap_1st_and_9th().call()
-        await exchange_operations.test__exec_swap9__should_swap_1st_and_10th().call()
-        await exchange_operations.test__exec_swap10__should_swap_1st_and_11th().call()
-        await exchange_operations.test__exec_swap11__should_swap_1st_and_12th().call()
-        await exchange_operations.test__exec_swap12__should_swap_1st_and_13th().call()
-        await exchange_operations.test__exec_swap13__should_swap_1st_and_14th().call()
-        await exchange_operations.test__exec_swap14__should_swap_1st_and_15th().call()
-        await exchange_operations.test__exec_swap15__should_swap_1st_and_16th().call()
-        await exchange_operations.test__exec_swap16__should_swap_1st_and_17th().call()
+    class TestInitStack:
+        async def test_should_create_stack_with_top_and_preswapped_elements(
+            self, exchange_operations
+        ):
+            await exchange_operations.test__util_init_stack__should_create_stack_with_top_and_preswapped_elements().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap1__should_fail__when_index_1_is_underflow().call()
+    class TestSwap1:
+        async def test_should_swap_1st_and_2nd(self, exchange_operations):
+            await exchange_operations.test__exec_swap1__should_swap_1st_and_2nd().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap2__should_fail__when_index_2_is_underflow().call()
+    class TestSwap2:
+        async def test_should_swap_1st_and_3rd(self, exchange_operations):
+            await exchange_operations.test__exec_swap2__should_swap_1st_and_3rd().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap8__should_fail__when_index_8_is_underflow().call()
+    class TestSwap8:
+        async def test_should_swap_1st_and_9th(self, exchange_operations):
+            await exchange_operations.test__exec_swap8__should_swap_1st_and_9th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap9__should_fail__when_index_9_is_underflow().call()
+    class TestSwap9:
+        async def test_should_swap_1st_and_10th(self, exchange_operations):
+            await exchange_operations.test__exec_swap9__should_swap_1st_and_10th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap10__should_fail__when_index_10_is_underflow().call()
+    class TestSwap10:
+        async def test_should_swap_1st_and_11th(self, exchange_operations):
+            await exchange_operations.test__exec_swap10__should_swap_1st_and_11th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap11__should_fail__when_index_11_is_underflow().call()
+    class TestSwap11:
+        async def test_should_swap_1st_and_12th(self, exchange_operations):
+            await exchange_operations.test__exec_swap11__should_swap_1st_and_12th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap12__should_fail__when_index_12_is_underflow().call()
+    class TestSwap12:
+        async def test_should_swap_1st_and_13th(self, exchange_operations):
+            await exchange_operations.test__exec_swap12__should_swap_1st_and_13th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap13__should_fail__when_index_13_is_underflow().call()
+    class TestSwap13:
+        async def test_should_swap_1st_and_14th(self, exchange_operations):
+            await exchange_operations.test__exec_swap13__should_swap_1st_and_14th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap14__should_fail__when_index_14_is_underflow().call()
+    class TestSwap14:
+        async def test_should_swap_1st_and_15th(self, exchange_operations):
+            await exchange_operations.test__exec_swap14__should_swap_1st_and_15th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap15__should_fail__when_index_15_is_underflow().call()
+    class TestSwap15:
+        async def test_should_swap_1st_and_16th(self, exchange_operations):
+            await exchange_operations.test__exec_swap15__should_swap_1st_and_16th().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await exchange_operations.test__exec_swap16__should_fail__when_index_16_is_underflow().call()
+    class TestSwap16:
+        async def test_should_swap_1st_and_17th(self, exchange_operations):
+            await exchange_operations.test__exec_swap16__should_swap_1st_and_17th().call()

--- a/tests/src/kakarot/instructions/test_memory_operations.cairo
+++ b/tests/src/kakarot/instructions/test_memory_operations.cairo
@@ -32,10 +32,10 @@ func test__exec_pc__should_update_after_incrementing{
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(increment - 1, 0);
+    assert index0.low = increment - 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -48,10 +48,13 @@ func test__exec_pop_should_pop_an_item_from_execution_context{
     let (bytecode) = alloc();
     let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
     // Given
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
+    tempvar item_1 = new Uint256(1, 0);
+    tempvar item_0 = new Uint256(2, 0);
+
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx = ExecutionContext.update_stack(ctx, stack);
 
     // When
@@ -59,10 +62,9 @@ func test__exec_pop_should_pop_an_item_from_execution_context{
 
     // Then
     assert result.gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert_uint256_eq(index0, Uint256(1, 0));
+    assert_uint256_eq([index0], Uint256(1, 0));
     return ();
 }
 
@@ -75,13 +77,19 @@ func test__exec_mload_should_load_a_value_from_memory{
     let (bytecode) = alloc();
     let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
     // Given
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    tempvar item_1 = new Uint256(1, 0);
+    tempvar item_0 = new Uint256(0, 0);
+
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
+
     let ctx = ExecutionContext.update_stack(ctx, stack);
     let ctx = MemoryOperations.exec_mstore(ctx);
-    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(0, 0));
+
+    tempvar item_0 = new Uint256(0, 0);
+    let stack = Stack.push(ctx.stack, item_0);
     let ctx = ExecutionContext.update_stack(ctx, stack);
 
     // When
@@ -91,10 +99,9 @@ func test__exec_mload_should_load_a_value_from_memory{
 
     // Then
     assert gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert_uint256_eq(index0, Uint256(1, 0));
+    assert_uint256_eq([index0], Uint256(1, 0));
     return ();
 }
 
@@ -108,13 +115,19 @@ func test__exec_mload_should_load_a_value_from_memory_with_memory_expansion{
     let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
     let test_offset = 16;
     // Given
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    tempvar item_1 = new Uint256(1, 0);
+    tempvar item_0 = new Uint256(0, 0);
+
+    let stack: model.Stack* = Stack.push(stack, item_1);
+    let stack: model.Stack* = Stack.push(stack, item_0);
+
     let ctx = ExecutionContext.update_stack(ctx, stack);
     let ctx = MemoryOperations.exec_mstore(ctx);
-    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(test_offset, 0));
+
+    tempvar offset = new Uint256(test_offset, 0);
+    let stack = Stack.push(ctx.stack, offset);
     let ctx = ExecutionContext.update_stack(ctx, stack);
 
     // When
@@ -124,10 +137,9 @@ func test__exec_mload_should_load_a_value_from_memory_with_memory_expansion{
 
     // Then
     assert gas_used = 6;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert_uint256_eq(index0, Uint256(0, 1));
+    assert_uint256_eq([index0], Uint256(0, 1));
     assert result.memory.bytes_len = test_offset + 32;
     return ();
 }
@@ -142,13 +154,18 @@ func test__exec_mload_should_load_a_value_from_memory_with_offset_larger_than_ms
     let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
     let test_offset = 684;
     // Given
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    tempvar item_1 = new Uint256(1, 0);
+    tempvar item_0 = new Uint256(0, 0);
+
+    let stack: model.Stack* = Stack.push(stack, item_1);
+    let stack: model.Stack* = Stack.push(stack, item_0);
+
     let ctx = ExecutionContext.update_stack(ctx, stack);
     let ctx = MemoryOperations.exec_mstore(ctx);
-    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(test_offset, 0));
+    tempvar offset = new Uint256(test_offset, 0);
+    let stack = Stack.push(ctx.stack, offset);
     let ctx = ExecutionContext.update_stack(ctx, stack);
 
     // When
@@ -156,10 +173,9 @@ func test__exec_mload_should_load_a_value_from_memory_with_offset_larger_than_ms
 
     // Then
     assert result.gas_used = 73;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert_uint256_eq(index0, Uint256(0, 0));
+    assert_uint256_eq([index0], Uint256(0, 0));
     assert result.memory.bytes_len = test_offset + 32;
     return ();
 }
@@ -173,7 +189,7 @@ func test__exec_gas_should_return_remaining_gas{
     let (bytecode) = alloc();
     let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
     // Given
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
     let ctx = ExecutionContext.update_stack(ctx, stack);
 
@@ -184,11 +200,10 @@ func test__exec_gas_should_return_remaining_gas{
 
     // Then
     assert gas_used = 2;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, actual_remaining_gas) = Stack.peek(result.stack, 0);
     let expected_remaining_gas = Constants.TRANSACTION_GAS_LIMIT - gas_used;
     let expected_remaining_gas_uint256 = Uint256(expected_remaining_gas, 0);
-    assert_uint256_eq(actual_remaining_gas, expected_remaining_gas_uint256);
+    assert_uint256_eq([actual_remaining_gas], expected_remaining_gas_uint256);
     return ();
 }

--- a/tests/src/kakarot/instructions/test_push_operations.cairo
+++ b/tests/src/kakarot/instructions/test_push_operations.cairo
@@ -15,57 +15,13 @@ from kakarot.execution_context import ExecutionContext
 from kakarot.instructions.push_operations import PushOperations
 from tests.utils.helpers import TestHelpers
 
-// per https://eips.ethereum.org/EIPS/eip-3855,
-// we want to check that
-// we can push0 1024 times, where all values are zero
-// we can push0 1025 times, causing a stackoverlfow
-func exec_push_n_times{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(ctx: model.ExecutionContext*, times: felt, value: felt) -> (ctx: model.ExecutionContext*) {
-    alloc_locals;
-
-    if (times == 0) {
-        return (ctx=ctx);
-    }
-
-    let res = PushOperations.exec_push_i(ctx, value);
-    return exec_push_n_times(res, times - 1, value);
-}
-
-@external
-func test__exec_push_should_push_n_times{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(times: felt, value: felt) -> (stack_accesses_len: felt, stack_accesses: felt*, stack_len: felt) {
-    alloc_locals;
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_bytecode(value + 1, 0xFF);
-    let (ctx) = exec_push_n_times(ctx, times, value);
-    let stack_summary = Stack.finalize(ctx.stack);
-    let stack_accesses_len = stack_summary.squashed_end - stack_summary.squashed_start;
-    return (
-        stack_accesses_len=stack_accesses_len,
-        stack_accesses=stack_summary.squashed_start,
-        stack_len=stack_summary.len_16bytes,
-    );
-}
-
-@external
-func test__exec_push_should_raise{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(i: felt) {
-    alloc_locals;
-    let ctx: model.ExecutionContext* = TestHelpers.init_context_with_bytecode(i - 1, 0xFF);
-    PushOperations.exec_push_i(ctx, i);
-
-    return ();
-}
-
 @external
 func test__exec_push_should_push{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(i: felt) -> (value: Uint256) {
+}(i: felt) -> (value_len: felt, value: Uint256*) {
     alloc_locals;
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_bytecode(i + 1, 0xFF);
     let res = PushOperations.exec_push_i(ctx, i);
     let (stack, result) = Stack.peek(res.stack, 0);
-    return (value=result);
+    return (1, result);
 }

--- a/tests/src/kakarot/instructions/test_push_operations.py
+++ b/tests/src/kakarot/instructions/test_push_operations.py
@@ -2,8 +2,6 @@ import pytest
 import pytest_asyncio
 from starkware.starknet.testing.starknet import Starknet
 
-from tests.utils.errors import cairo_error
-from tests.utils.helpers import extract_stack_from_execute
 from tests.utils.uint256 import int_to_uint256
 
 
@@ -19,11 +17,6 @@ async def push_operations(starknet: Starknet):
 
 @pytest.mark.asyncio
 class TestPushOperations:
-    @pytest.mark.parametrize("i", range(2, 33))
-    async def test__exec_push_should_raise(self, push_operations, i):
-        with cairo_error():
-            await push_operations.test__exec_push_should_raise(i).call()
-
     # The `exec_push_i` is tested by initializing the bytecode with a fill value of 0xFF.
     # As we push 'i' bytes onto the stack,
     # this results in a stack value of 0xFF repeated 'i' times.
@@ -32,24 +25,4 @@ class TestPushOperations:
     @pytest.mark.parametrize("i", range(0, 33))
     async def test__exec_push_should_push(self, push_operations, i):
         res = await push_operations.test__exec_push_should_push(i).call()
-        assert res.result.value == int_to_uint256(256**i - 1)
-
-    # per https://eips.ethereum.org/EIPS/eip-3855,
-    # we want to check that
-    # we can push0 1024 times, where all values are zero
-    async def test__exec_push0_should_push_to_stack_max_depth(self, push_operations):
-        stack_len = 1024
-        res = await push_operations.test__exec_push_should_push_n_times(
-            stack_len, 0
-        ).call()
-        stack = extract_stack_from_execute(res.result)
-        assert stack == [0] * stack_len
-
-    # we cannot push0 1025 times -> there should be a stackoverlfow
-    # our impl throws at 1026
-    async def test__exec_push0_should_overflow(self, push_operations):
-        stack_len = 1026
-        with cairo_error("Kakarot: StackOverflow"):
-            await push_operations.test__exec_push_should_push_n_times(
-                stack_len, 0
-            ).call()
+        assert res.result.value == [int_to_uint256(256**i - 1)]

--- a/tests/src/kakarot/instructions/test_stop_and_arithmetic_operations.cairo
+++ b/tests/src/kakarot/instructions/test_stop_and_arithmetic_operations.cairo
@@ -23,11 +23,15 @@ func test__exec_add__should_add_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -35,12 +39,13 @@ func test__exec_add__should_add_0_and_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(5, 0);
+    assert index0.low = 5;
+    assert index0.high = 0;
     let (stack, index1) = Stack.peek(stack, 1);
-    assert index1 = Uint256(1, 0);
+    assert index1.low = 1;
+    assert index1.high = 0;
     return ();
 }
 
@@ -51,11 +56,15 @@ func test__exec_mul__should_mul_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -63,12 +72,13 @@ func test__exec_mul__should_mul_0_and_1{
 
     // Then
     assert result.gas_used = 5;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(6, 0);
+    assert index0.low = 6;
+    assert index0.high = 0;
     let (stack, index1) = Stack.peek(stack, 1);
-    assert index1 = Uint256(1, 0);
+    assert index1.low = 1;
+    assert index1.high = 0;
     return ();
 }
 
@@ -79,11 +89,15 @@ func test__exec_sub__should_sub_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -91,12 +105,13 @@ func test__exec_sub__should_sub_0_and_1{
 
     // Then
     assert result.gas_used = 3;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     let (stack, index1) = Stack.peek(stack, 1);
-    assert index1 = Uint256(1, 0);
+    assert index1.low = 1;
+    assert index1.high = 0;
     return ();
 }
 
@@ -107,11 +122,15 @@ func test__exec_div__should_div_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -119,12 +138,13 @@ func test__exec_div__should_div_0_and_1{
 
     // Then
     assert result.gas_used = 5;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     let (stack, index1) = Stack.peek(stack, 1);
-    assert index1 = Uint256(1, 0);
+    assert index1.low = 1;
+    assert index1.high = 0;
     return ();
 }
 
@@ -135,11 +155,15 @@ func test__exec_sdiv__should_signed_div_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -147,12 +171,13 @@ func test__exec_sdiv__should_signed_div_0_and_1{
 
     // Then
     assert result.gas_used = 5;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     let (stack, index1) = Stack.peek(stack, 1);
-    assert index1 = Uint256(1, 0);
+    assert index1.low = 1;
+    assert index1.high = 0;
     return ();
 }
 
@@ -163,11 +188,15 @@ func test__exec_mod__should_mod_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -175,12 +204,13 @@ func test__exec_mod__should_mod_0_and_1{
 
     // Then
     assert result.gas_used = 5;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     let (stack, index1) = Stack.peek(stack, 1);
-    assert index1 = Uint256(1, 0);
+    assert index1.low = 1;
+    assert index1.high = 0;
     return ();
 }
 
@@ -191,11 +221,15 @@ func test__exec_smod__should_smod_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -203,12 +237,13 @@ func test__exec_smod__should_smod_0_and_1{
 
     // Then
     assert result.gas_used = 5;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     let (stack, index1) = Stack.peek(stack, 1);
-    assert index1 = Uint256(1, 0);
+    assert index1.low = 1;
+    assert index1.high = 0;
     return ();
 }
 
@@ -219,11 +254,15 @@ func test__exec_addmod__should_add_0_and_1_and_div_rem_by_2{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(2, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -231,10 +270,10 @@ func test__exec_addmod__should_add_0_and_1_and_div_rem_by_2{
 
     // Then
     assert result.gas_used = 8;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(1, 0);
+    assert index0.low = 1;
+    assert index0.high = 0;
     return ();
 }
 
@@ -245,11 +284,15 @@ func test__exec_mulmod__should_mul_0_and_1_and_div_rem_by_2{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -257,10 +300,10 @@ func test__exec_mulmod__should_mul_0_and_1_and_div_rem_by_2{
 
     // Then
     assert result.gas_used = 8;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 1;
+    assert result.stack.size = 1;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(0, 0);
+    assert index0.low = 0;
+    assert index0.high = 0;
     return ();
 }
 
@@ -271,11 +314,15 @@ func test__exec_exp__should_exp_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -283,10 +330,10 @@ func test__exec_exp__should_exp_0_and_1{
 
     // Then
     assert result.gas_used = 10;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(9, 0);
+    assert index0.low = 9;
+    assert index0.high = 0;
     return ();
 }
 
@@ -297,11 +344,15 @@ func test__exec_signextend__should_signextend_0_and_1{
     // Given
     alloc_locals;
     let (bytecode) = alloc();
-    let stack: model.Stack* = Stack.init();
+    let stack = Stack.init();
 
-    let stack: model.Stack* = Stack.push(stack, Uint256(1, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(2, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(3, 0));
+    tempvar item_2 = new Uint256(1, 0);
+    tempvar item_1 = new Uint256(2, 0);
+    tempvar item_0 = new Uint256(3, 0);
+
+    let stack = Stack.push(stack, item_2);
+    let stack = Stack.push(stack, item_1);
+    let stack = Stack.push(stack, item_0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
 
     // When
@@ -309,10 +360,10 @@ func test__exec_signextend__should_signextend_0_and_1{
 
     // Then
     assert result.gas_used = 5;
-    let len: felt = result.stack.len_16bytes / 2;
-    assert len = 2;
+    assert result.stack.size = 2;
     let (stack, index0) = Stack.peek(result.stack, 0);
-    assert index0 = Uint256(2, 0);
+    assert index0.low = 2;
+    assert index0.high = 0;
     return ();
 }
 
@@ -321,6 +372,7 @@ func test__exec_stop{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() {
     alloc_locals;
+
     let (bytecode) = alloc();
     let ctx: model.ExecutionContext* = TestHelpers.init_context(0, bytecode);
     assert ctx.stopped = FALSE;

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -110,14 +110,14 @@ func test__exec_return_should_return_context_with_updated_return_data{
     let stack: model.Stack* = Stack.init();
 
     // When
-    let stack: model.Stack* = Stack.push(stack, Uint256(return_data, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let stack: model.Stack* = Stack.push_uint128(stack, return_data);
+    let stack: model.Stack* = Stack.push_uint128(stack, 0);
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
     let ctx: model.ExecutionContext* = MemoryOperations.exec_mstore(ctx);
 
     // Then
-    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(32, 0));
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));
+    let stack: model.Stack* = Stack.push_uint128(ctx.stack, 32);
+    let stack: model.Stack* = Stack.push_uint128(stack, 0);
     let ctx: model.ExecutionContext* = ExecutionContext.update_stack(ctx, stack);
     let ctx: model.ExecutionContext* = SystemOperations.exec_return(ctx);
 
@@ -136,8 +136,8 @@ func test__exec_revert{
 ) {
     // Given
     alloc_locals;
-    let reason_uint256 = Uint256(low=reason_low, high=reason_high);
-    local offset: Uint256 = Uint256(32, 0);
+    tempvar reason_uint256 = new Uint256(low=reason_low, high=reason_high);
+    tempvar offset = new Uint256(32, 0);
 
     let (bytecode) = alloc();
     let stack: model.Stack* = Stack.init();
@@ -146,8 +146,8 @@ func test__exec_revert{
     let ctx: model.ExecutionContext* = TestHelpers.init_context_with_stack(0, bytecode, stack);
     let ctx: model.ExecutionContext* = MemoryOperations.exec_mstore(ctx);
 
-    let stack: model.Stack* = Stack.push(ctx.stack, Uint256(size, 0));  // size
-    let stack: model.Stack* = Stack.push(stack, Uint256(0, 0));  // offset is 0 to have the reason at 0x20
+    let stack: model.Stack* = Stack.push_uint128(ctx.stack, size);  // size
+    let stack: model.Stack* = Stack.push_uint128(stack, 0);  // offset is 0 to have the reason at 0x20
 
     let ctx: model.ExecutionContext* = ExecutionContext.update_stack(ctx, stack);
 
@@ -182,12 +182,12 @@ func test__exec_call__should_return_a_new_context_based_on_calling_ctx_stack{
     let stack: model.Stack* = Stack.init();
     let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(callee_evm_contract_address);
-    let address = Uint256(address_low, address_high);
-    tempvar value = Uint256(2, 0);
-    let args_offset = Uint256(3, 0);
-    let args_size = Uint256(4, 0);
-    tempvar ret_offset = Uint256(5, 0);
-    tempvar ret_size = Uint256(6, 0);
+    tempvar address = new Uint256(address_low, address_high);
+    tempvar value = new Uint256(2, 0);
+    tempvar args_offset = new Uint256(3, 0);
+    tempvar args_size = new Uint256(4, 0);
+    tempvar ret_offset = new Uint256(5, 0);
+    tempvar ret_size = new Uint256(6, 0);
     let stack = Stack.push(stack, ret_size);
     let stack = Stack.push(stack, ret_offset);
     let stack = Stack.push(stack, args_size);
@@ -198,8 +198,8 @@ func test__exec_call__should_return_a_new_context_based_on_calling_ctx_stack{
     // Put some value in memory as it is used for calldata with args_size and args_offset
     // Word is 0x 11 22 33 44 55 66 77 88 00 00 ... 00
     // calldata should be 0x 44 55 66 77
-    let memory_word = Uint256(low=0, high=0x11223344556677880000000000000000);
-    let memory_offset = Uint256(0, 0);
+    tempvar memory_word = new Uint256(low=0, high=0x11223344556677880000000000000000);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, memory_word);
     let stack = Stack.push(stack, memory_offset);
     let (bytecode) = alloc();
@@ -276,12 +276,12 @@ func test__exec_call__should_transfer_value{
     let stack: model.Stack* = Stack.init();
     let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(callee_evm_contract_address);
-    let address = Uint256(address_low, address_high);
-    tempvar value = Uint256(2, 0);
-    let args_offset = Uint256(3, 0);
-    let args_size = Uint256(4, 0);
-    tempvar ret_offset = Uint256(5, 0);
-    tempvar ret_size = Uint256(6, 0);
+    tempvar address = new Uint256(address_low, address_high);
+    tempvar value = new Uint256(2, 0);
+    tempvar args_offset = new Uint256(3, 0);
+    tempvar args_size = new Uint256(4, 0);
+    tempvar ret_offset = new Uint256(5, 0);
+    tempvar ret_size = new Uint256(6, 0);
     let stack = Stack.push(stack, ret_size);
     let stack = Stack.push(stack, ret_offset);
     let stack = Stack.push(stack, args_size);
@@ -289,8 +289,8 @@ func test__exec_call__should_transfer_value{
     let stack = Stack.push(stack, value);
     let stack = Stack.push(stack, address);
     let stack = Stack.push(stack, gas);
-    let memory_word = Uint256(low=0, high=22774453838368691922685013100469420032);
-    let memory_offset = Uint256(0, 0);
+    tempvar memory_word = new Uint256(low=0, high=22774453838368691922685013100469420032);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, memory_word);
     let stack = Stack.push(stack, memory_offset);
     let (bytecode) = alloc();
@@ -337,12 +337,12 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
     let stack: model.Stack* = Stack.init();
     let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(callee_evm_contract_address);
-    let address = Uint256(address_low, address_high);
-    tempvar value = Uint256(2, 0);
-    let args_offset = Uint256(3, 0);
-    let args_size = Uint256(4, 0);
-    tempvar ret_offset = Uint256(5, 0);
-    tempvar ret_size = Uint256(6, 0);
+    tempvar address = new Uint256(address_low, address_high);
+    tempvar value = new Uint256(2, 0);
+    tempvar args_offset = new Uint256(3, 0);
+    tempvar args_size = new Uint256(4, 0);
+    tempvar ret_offset = new Uint256(5, 0);
+    tempvar ret_size = new Uint256(6, 0);
     let stack = Stack.push(stack, ret_size);
     let stack = Stack.push(stack, ret_offset);
     let stack = Stack.push(stack, args_size);
@@ -353,8 +353,8 @@ func test__exec_callcode__should_return_a_new_context_based_on_calling_ctx_stack
     // Put some value in memory as it is used for calldata with args_size and args_offset
     // Word is 0x 11 22 33 44 55 66 77 88 00 00 ... 00
     // calldata should be 0x 44 55 66 77
-    let memory_word = Uint256(low=0, high=22774453838368691922685013100469420032);
-    let memory_offset = Uint256(0, 0);
+    tempvar memory_word = new Uint256(low=0, high=22774453838368691922685013100469420032);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, memory_word);
     let stack = Stack.push(stack, memory_offset);
     let (bytecode) = alloc();
@@ -425,12 +425,12 @@ func test__exec_callcode__should_transfer_value{
     let stack: model.Stack* = Stack.init();
     let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(callee_evm_contract_address);
-    let address = Uint256(address_low, address_high);
-    tempvar value = Uint256(2, 0);
-    let args_offset = Uint256(3, 0);
-    let args_size = Uint256(4, 0);
-    tempvar ret_offset = Uint256(5, 0);
-    tempvar ret_size = Uint256(6, 0);
+    tempvar address = new Uint256(address_low, address_high);
+    tempvar value = new Uint256(2, 0);
+    tempvar args_offset = new Uint256(3, 0);
+    tempvar args_size = new Uint256(4, 0);
+    tempvar ret_offset = new Uint256(5, 0);
+    tempvar ret_size = new Uint256(6, 0);
     let stack = Stack.push(stack, ret_size);
     let stack = Stack.push(stack, ret_offset);
     let stack = Stack.push(stack, args_size);
@@ -438,8 +438,8 @@ func test__exec_callcode__should_transfer_value{
     let stack = Stack.push(stack, value);
     let stack = Stack.push(stack, address);
     let stack = Stack.push(stack, gas);
-    let memory_word = Uint256(low=0, high=22774453838368691922685013100469420032);
-    let memory_offset = Uint256(0, 0);
+    tempvar memory_word = new Uint256(low=0, high=22774453838368691922685013100469420032);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, memory_word);
     let stack = Stack.push(stack, memory_offset);
     let (bytecode) = alloc();
@@ -484,11 +484,11 @@ func test__exec_staticcall__should_return_a_new_context_based_on_calling_ctx_sta
     let stack: model.Stack* = Stack.init();
     let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(evm_contract_address);
-    let address = Uint256(address_low, address_high);
-    let args_offset = Uint256(3, 0);
-    let args_size = Uint256(4, 0);
-    tempvar ret_offset = Uint256(5, 0);
-    tempvar ret_size = Uint256(6, 0);
+    tempvar address = new Uint256(address_low, address_high);
+    tempvar args_offset = new Uint256(3, 0);
+    tempvar args_size = new Uint256(4, 0);
+    tempvar ret_offset = new Uint256(5, 0);
+    tempvar ret_size = new Uint256(6, 0);
     let stack = Stack.push(stack, ret_size);
     let stack = Stack.push(stack, ret_offset);
     let stack = Stack.push(stack, args_size);
@@ -498,8 +498,8 @@ func test__exec_staticcall__should_return_a_new_context_based_on_calling_ctx_sta
     // Put some value in memory as it is used for calldata with args_size and args_offset
     // Word is 0x 11 22 33 44 55 66 77 88 00 00 ... 00
     // calldata should be 0x 44 55 66 77
-    let memory_word = Uint256(low=0, high=22774453838368691922685013100469420032);
-    let memory_offset = Uint256(0, 0);
+    tempvar memory_word = new Uint256(low=0, high=22774453838368691922685013100469420032);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, memory_word);
     let stack = Stack.push(stack, memory_offset);
     let (bytecode) = alloc();
@@ -558,11 +558,11 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
     let stack: model.Stack* = Stack.init();
     let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(evm_contract_address);
-    let address = Uint256(address_low, address_high);
-    let args_offset = Uint256(3, 0);
-    let args_size = Uint256(4, 0);
-    tempvar ret_offset = Uint256(5, 0);
-    tempvar ret_size = Uint256(6, 0);
+    tempvar address = new Uint256(address_low, address_high);
+    tempvar args_offset = new Uint256(3, 0);
+    tempvar args_size = new Uint256(4, 0);
+    tempvar ret_offset = new Uint256(5, 0);
+    tempvar ret_size = new Uint256(6, 0);
     let stack = Stack.push(stack, ret_size);
     let stack = Stack.push(stack, ret_offset);
     let stack = Stack.push(stack, args_size);
@@ -572,8 +572,8 @@ func test__exec_delegatecall__should_return_a_new_context_based_on_calling_ctx_s
     // Put some value in memory as it is used for calldata with args_size and args_offset
     // Word is 0x 11 22 33 44 55 66 77 88 00 00 ... 00
     // calldata should be 0x 44 55 66 77
-    let memory_word = Uint256(low=0, high=22774453838368691922685013100469420032);
-    let memory_offset = Uint256(0, 0);
+    tempvar memory_word = new Uint256(low=0, high=22774453838368691922685013100469420032);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, memory_word);
     let stack = Stack.push(stack, memory_offset);
     let (bytecode) = alloc();
@@ -623,9 +623,9 @@ func test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at
 
     // Fill the stack with exec_create args
     let stack: model.Stack* = Stack.init();
-    tempvar value = Uint256(1, 0);
-    let offset = Uint256(3, 0);
-    let size = Uint256(4, 0);
+    tempvar value = new Uint256(1, 0);
+    tempvar offset = new Uint256(3, 0);
+    tempvar size = new Uint256(4, 0);
     let stack = Stack.push(stack, size);
     let stack = Stack.push(stack, offset);
     let stack = Stack.push(stack, value);
@@ -633,8 +633,8 @@ func test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at
     // Put some value in memory as it is used for bytecode with size and offset
     // Word is 0x 11 22 33 44 55 66 77 88 00 00 ... 00
     // bytecode should be 0x 44 55 66 77
-    let memory_word = Uint256(low=0, high=0x11223344556677880000000000000000);
-    let memory_offset = Uint256(0, 0);
+    tempvar memory_word = new Uint256(low=0, high=0x11223344556677880000000000000000);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, memory_word);
     let stack = Stack.push(stack, memory_offset);
     let bytecode_len = 0;
@@ -680,7 +680,7 @@ func test__exec_create__should_return_a_new_context_with_bytecode_from_memory_at
 
     // Then
     let (stack, address) = Stack.peek(ctx.stack, 0);
-    let evm_contract_address = Helpers.uint256_to_felt(address);
+    let evm_contract_address = Helpers.uint256_to_felt([address]);
     assert evm_contract_address = sub_ctx.call_context.address.evm;
     assert sub_ctx.call_context.address.evm = expected_create_address;
     let (state, account) = State.get_account(ctx.state, sub_ctx.call_context.address);
@@ -707,9 +707,9 @@ func test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_a
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(
     evm_caller_address: felt,
-    bytecode_offset: Uint256,
-    bytecode_size: Uint256,
-    nonce: Uint256,
+    bytecode_offset: felt,
+    bytecode_size: felt,
+    nonce: felt,
     memory_word: Uint256,
     expected_create2_address: felt,
 ) {
@@ -717,18 +717,16 @@ func test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_a
 
     // Fill the stack with exec_create2 args
     let stack: model.Stack* = Stack.init();
-    tempvar value = Uint256(1, 0);
-    let offset = bytecode_offset;
-    let size = bytecode_size;
-    let nonce = nonce;
-    let stack = Stack.push(stack, nonce);
-    let stack = Stack.push(stack, size);
-    let stack = Stack.push(stack, offset);
+    tempvar value = new Uint256(1, 0);
+    let stack = Stack.push_uint128(stack, nonce);
+    let stack = Stack.push_uint128(stack, bytecode_size);
+    let stack = Stack.push_uint128(stack, bytecode_offset);
     let stack = Stack.push(stack, value);
 
     // Put some value in memory as it is used for byte
-    let memory_offset = Uint256(0, 0);
-    let stack = Stack.push(stack, memory_word);
+    tempvar word = new Uint256(memory_word.low, memory_word.high);
+    tempvar memory_offset = new Uint256(0, 0);
+    let stack = Stack.push(stack, word);
     let stack = Stack.push(stack, memory_offset);
     let bytecode_len = 0;
     let (bytecode: felt*) = alloc();
@@ -770,7 +768,7 @@ func test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_a
 
     // Then
     let (stack, address) = Stack.peek(ctx.stack, 0);
-    let evm_contract_address = Helpers.uint256_to_felt(address);
+    let evm_contract_address = Helpers.uint256_to_felt([address]);
     assert evm_contract_address = sub_ctx.call_context.address.evm;
     assert sub_ctx.call_context.address.evm = expected_create2_address;
     let state = ctx.state;
@@ -781,79 +779,3 @@ func test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_a
 
     return ();
 }
-
-// @external
-// func test__exec_selfdestruct__should_add_account_to_state{
-//     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-// }() {
-//     alloc_locals;
-
-// // Create sub_ctx writing directly in memory because need to update calling_context
-//     let (bytecode) = alloc();
-//     let stack: model.Stack* = Stack.init();
-//     let memory: model.Memory* = Memory.init();
-//     let (bytecode) = alloc();
-//     let (return_data) = alloc();
-//     assert [return_data] = 0;
-//     assert [return_data + 1] = 10;
-//     let (selfdestructs) = alloc();
-//     let (calldata) = alloc();
-//     assert [calldata] = '';
-//     local call_context: model.CallContext* = new model.CallContext(
-//         bytecode=bytecode, bytecode_len=0, calldata=calldata, calldata_len=1, value=0
-//     );
-//     let stack = Stack.push(stack, Uint256(10, 0));
-//     let (local revert_contract_state_dict_start) = default_dict_new(0);
-//     tempvar revert_contract_state: model.RevertContractState* = new model.RevertContractState(
-//         revert_contract_state_dict_start, revert_contract_state_dict_start
-//     );
-
-// // Simulate contract creation
-//     let (contract_account_class_hash_) = contract_account_class_hash.read();
-//     let (evm_contract_address) = CreateHelper.get_create_address(0, 0);
-//     let (local starknet_contract_address) = Account.deploy(
-//         contract_account_class_hash_, evm_contract_address
-//     );
-
-// // Fill contract bytecode
-//     let (bytecode) = alloc();
-//     assert [bytecode] = 1907;
-//     IContractAccount.write_bytecode(
-//         contract_address=starknet_contract_address, bytecode_len=1, bytecode=bytecode
-//     );
-
-// tempvar address = new model.Address(starknet_contract_address, evm_contract_address);
-//     // Create context
-//     let (sub_ctx: felt*) = alloc();
-//     let sub_ctx_object: model.ExecutionContext* = cast(sub_ctx, model.ExecutionContext*);
-
-// assert [sub_ctx + 0] = cast(call_context, felt);  // call_context
-//     assert [sub_ctx + 1] = 0;  // program_counter
-//     assert [sub_ctx + 2] = 0;  // stopped
-//     assert [sub_ctx + 3] = cast(return_data + 1, felt);  // return_data
-//     assert [sub_ctx + 4] = 1;  // return_data_len
-//     assert [sub_ctx + 5] = cast(stack, felt);  // stack
-//     assert [sub_ctx + 6] = cast(memory, felt);  // memory
-//     assert [sub_ctx + 7] = 0;  // gas_used
-//     assert [sub_ctx + 8] = 0;  // gas_limit
-//     assert [sub_ctx + 9] = 0;  // intrinsic_gas_cost
-//     assert [sub_ctx + 10] = cast(address, felt);  // address
-//     assert [sub_ctx + 12] = 0;  // origin
-//     assert [sub_ctx + 13] = 0;  // calling_context
-//     assert [sub_ctx + 14] = 0;  // selfdestructs_len
-//     assert [sub_ctx + 15] = cast(selfdestructs, felt);  // selfdestructs
-//     assert [sub_ctx + 17] = cast(0, felt);  // state
-//     assert [sub_ctx + 21] = 0;  // reverted
-//     assert [sub_ctx + 22] = 0;  // read only
-
-// // When
-//     let sub_ctx_object: model.ExecutionContext* = SystemOperations.exec_selfdestruct(
-//         sub_ctx_object
-//     );
-
-// // Then
-//     assert_non_zero(sub_ctx.selfdestructs_len);
-//     let address = [sub_ctx.selfdestructs + sub_ctx.selfdestructs_len - 1];
-//     assert address = sub_ctx_object.address.starknet;
-//     return ();
-// }

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -134,9 +134,9 @@ class TestSystemOperations:
 
         await system_operations.test__exec_create2__should_return_a_new_context_with_bytecode_from_memory_at_expected_address(
             evm_caller_address_int,
-            (offset, 0),
-            (size, 0),
-            (salt, 0),
+            offset,
+            size,
+            salt,
             (0, memory_word),
             int(expected_create2_addr, 16),
         ).call()

--- a/tests/src/kakarot/precompiles/test_datacopy.cairo
+++ b/tests/src/kakarot/precompiles/test_datacopy.cairo
@@ -55,12 +55,12 @@ func test__datacopy_via_staticcall{
     let stack: model.Stack* = Stack.init();
     let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
     let (address_high, address_low) = split_felt(PrecompileDataCopy.PRECOMPILE_ADDRESS);
-    let address = Uint256(address_low, address_high);
-    let args_offset = Uint256(31, 0);
-    let args_size = Uint256(1, 0);
+    tempvar address = new Uint256(address_low, address_high);
+    tempvar args_offset = new Uint256(31, 0);
+    tempvar args_size = new Uint256(1, 0);
 
-    tempvar ret_offset = Uint256(63, 0);
-    tempvar ret_size = Uint256(1, 0);
+    tempvar ret_offset = new Uint256(63, 0);
+    tempvar ret_size = new Uint256(1, 0);
 
     let stack = Stack.push(stack, ret_size);
     let stack = Stack.push(stack, ret_offset);
@@ -69,8 +69,8 @@ func test__datacopy_via_staticcall{
     let stack = Stack.push(stack, address);
     let stack = Stack.push(stack, gas);
 
-    tempvar preset_memory = Uint256(low=0xFF, high=0);
-    let memory_offset = Uint256(0, 0);
+    tempvar preset_memory = new Uint256(low=0xFF, high=0);
+    tempvar memory_offset = new Uint256(0, 0);
     let stack = Stack.push(stack, preset_memory);
 
     let stack = Stack.push(stack, memory_offset);
@@ -84,7 +84,7 @@ func test__datacopy_via_staticcall{
 
     // Put the result alone on the stack
     let result = MemoryOperations.exec_pop(result);
-    let stack = Stack.push(result.stack, Uint256(32, 0));
+    let stack = Stack.push_uint128(result.stack, 32);
     let result = ExecutionContext.update_stack(result, stack);
     let result = MemoryOperations.exec_mload(result);
     let (stack, stack_result) = Stack.peek(result.stack, 0);

--- a/tests/src/kakarot/test_account.cairo
+++ b/tests/src/kakarot/test_account.cairo
@@ -40,7 +40,7 @@ func test__copy__should_return_new_account_with_same_attributes{
     alloc_locals;
     // Given
     let account = Account.init(evm_address, code_len, code, nonce);
-    let key = Uint256(1, 2);
+    tempvar key = new Uint256(1, 2);
     tempvar value = new Uint256(3, 4);
     let account = Account.write_storage(account, key, value);
 
@@ -61,13 +61,13 @@ func test__copy__should_return_new_account_with_same_attributes{
     assert storage_len = storage_copy_len;
     tempvar address = new model.Address(0, evm_address);
     let (account_copy, value_copy) = Account.read_storage(account_copy, address, key);
-    assert_uint256_eq([value], value_copy);
+    assert_uint256_eq([value], [value_copy]);
 
     // Updating copy doesn't update original
     tempvar new_value = new Uint256(5, 6);
     let account_copy = Account.write_storage(account_copy, key, new_value);
     let (account, value_original) = Account.read_storage(account, address, key);
-    assert_uint256_eq([value], value_original);
+    assert_uint256_eq([value], [value_original]);
 
     return ();
 }
@@ -79,7 +79,7 @@ func test__finalize__should_return_summary{
     // Given
     alloc_locals;
     let account = Account.init(evm_address, code_len, code, nonce);
-    let key = Uint256(1, 2);
+    tempvar key = new Uint256(1, 2);
     tempvar value = new Uint256(3, 4);
     tempvar address = new model.Address(0, evm_address);
     let account = Account.write_storage(account, key, value);
@@ -98,7 +98,7 @@ func test__finalize__should_return_summary{
     let (account, value_summary) = Account.read_storage(
         cast(summary, model.Account*), address, key
     );
-    assert_uint256_eq(value_read, value_summary);
+    assert_uint256_eq([value_read], [value_summary]);
 
     return ();
 }
@@ -109,7 +109,7 @@ func test__finalize__should_return_summary_with_no_default_dict{
 }(evm_address: felt, code_len: felt, code: felt*, nonce: felt) {
     // Given
     alloc_locals;
-    tempvar key = Uint256(1, 2);
+    tempvar key = new Uint256(1, 2);
     tempvar address = new model.Address(0, evm_address);
     let account = Account.init(evm_address, code_len, code, nonce);
 
@@ -137,13 +137,13 @@ func test__write_storage__should_store_value_at_key{
     let account = Account.init(0, 0, code, 0);
 
     // When
-    let account = Account.write_storage(account, key, &value);
+    let account = Account.write_storage(account, &key, &value);
 
     // Then
     let storage_len = account.storage - account.storage_start;
     assert storage_len = DictAccess.SIZE;
-    let (account, value_read) = Account.read_storage(account, address, key);
-    assert_uint256_eq(value_read, value);
+    let (account, value_read) = Account.read_storage(account, address, &key);
+    assert_uint256_eq([value_read], value);
 
     return ();
 }

--- a/tests/src/kakarot/test_execution_context.cairo
+++ b/tests/src/kakarot/test_execution_context.cairo
@@ -53,7 +53,7 @@ func test__init__should_return_an_empty_execution_context{
     assert result.call_context.calldata = calldata;
     assert result.program_counter = 0;
     assert result.stopped = FALSE;
-    assert result.stack.len_16bytes = 0;
+    assert result.stack.size = 0;
     assert result.memory.bytes_len = 0;
     assert result.gas_used = 0;
     assert result.call_context.gas_limit = Constants.TRANSACTION_GAS_LIMIT;  // TODO: Add support for gas limit

--- a/tests/src/kakarot/test_stack.py
+++ b/tests/src/kakarot/test_stack.py
@@ -2,10 +2,8 @@ import pytest
 import pytest_asyncio
 from starkware.starknet.testing.starknet import Starknet
 
-from tests.utils.errors import cairo_error
 
-
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="session")
 async def stack(starknet: Starknet):
     class_hash = await starknet.deprecated_declare(
         source="./tests/src/kakarot/test_stack.cairo",
@@ -17,29 +15,28 @@ async def stack(starknet: Starknet):
 
 @pytest.mark.asyncio
 class TestStack:
-    async def test_everything_stack(self, stack):
-        await stack.test__init__should_return_an_empty_stack().call()
-        await stack.test__len__should_return_the_length_of_the_stack().call()
-        await stack.test__push__should_add_an_element_to_the_stack().call()
-        await stack.test__pop__should_pop_an_element_to_the_stack().call()
-        await stack.test__pop__should_pop_N_elements_to_the_stack().call()
+    class TestPeek:
+        async def test_should_return_stack_at_given_index__when_value_is_0(self, stack):
+            await stack.test__peek__should_return_stack_at_given_index__when_value_is_0().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await stack.test__pop__should_fail__when_stack_underflow_pop().call()
+        async def test_should_return_stack_at_given_index__when_value_is_1(self, stack):
+            await stack.test__peek__should_return_stack_at_given_index__when_value_is_1().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await stack.test__pop__should_fail__when_stack_underflow_pop_n().call()
+    class TestInit:
+        async def test_should_return_an_empty_stack(self, stack):
+            await stack.test__init__should_return_an_empty_stack().call()
 
-        await stack.test__peek__should_return_stack_at_given_index__when_value_is_0().call()
-        await stack.test__peek__should_return_stack_at_given_index__when_value_is_1().call()
+    class TestPush:
+        async def test_should_add_an_element_to_the_stack(self, stack):
+            await stack.test__push__should_add_an_element_to_the_stack().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await stack.test__peek__should_fail_when_underflow().call()
+    class TestPop:
+        async def test_should_pop_an_element_to_the_stack(self, stack):
+            await stack.test__pop__should_pop_an_element_to_the_stack().call()
 
-        await stack.test__swap__should_swap_2_stacks().call()
+        async def test_should_pop_N_elements_to_the_stack(self, stack):
+            await stack.test__pop__should_pop_N_elements_to_the_stack().call()
 
-        with cairo_error("Kakarot: StackUnderflow"):
-            await stack.test__swap__should_fail__when_index_1_is_underflow().call()
-
-        with cairo_error("Kakarot: StackUnderflow"):
-            await stack.test__swap__should_fail__when_index_2_is_underflow().call()
+    class TestSwap:
+        async def test_should_swap_2_stacks(self, stack):
+            await stack.test__swap__should_swap_2_stacks().call()

--- a/tests/src/kakarot/test_state.cairo
+++ b/tests/src/kakarot/test_state.cairo
@@ -53,8 +53,8 @@ func test__copy__should_return_new_state_with_same_attributes{
     // 2. Put two accounts with some storage
     tempvar address_0 = new model.Address(1, 2);
     tempvar address_1 = new model.Address(3, 4);
-    tempvar key_0 = Uint256(1, 2);
-    tempvar key_1 = Uint256(3, 4);
+    tempvar key_0 = new Uint256(1, 2);
+    tempvar key_1 = new Uint256(3, 4);
     tempvar value = new Uint256(3, 4);
     let state = State.write_storage(state, address_0, key_0, value);
     let state = State.write_storage(state, address_1, key_0, value);
@@ -89,11 +89,11 @@ func test__copy__should_return_new_state_with_same_attributes{
 
     // Storage
     let (state_copy, value_copy) = State.read_storage(state_copy, address_0, key_0);
-    assert_uint256_eq([value], value_copy);
+    assert_uint256_eq([value], [value_copy]);
     let (state_copy, value_copy) = State.read_storage(state_copy, address_1, key_0);
-    assert_uint256_eq([value], value_copy);
+    assert_uint256_eq([value], [value_copy]);
     let (state_copy, value_copy) = State.read_storage(state_copy, address_1, key_1);
-    assert_uint256_eq([value], value_copy);
+    assert_uint256_eq([value], [value_copy]);
 
     // Events
     assert state_copy.events_len = state.events_len;

--- a/tests/src/utils/test_dict.cairo
+++ b/tests/src/utils/test_dict.cairo
@@ -6,8 +6,9 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
 from starkware.cairo.common.dict import dict_write, dict_read
 from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.common.uint256 import Uint256
 
-from utils.dict import dict_keys, default_dict_copy
+from utils.dict import dict_keys, default_dict_copy, dict_values
 
 @external
 func test__dict_keys__should_return_keys{
@@ -82,6 +83,45 @@ func test__default_dict_copy__should_return_copied_dict{range_check_ptr}() {
         let (value) = dict_read(key + 10);
         assert value = default_value;
     }
+
+    return ();
+}
+
+@external
+func test__dict_values__should_return_values{range_check_ptr}() {
+    alloc_locals;
+    let (local dict_start) = default_dict_new(0);
+    tempvar value_a = new Uint256(2, 0);
+    tempvar value_tmp = new Uint256(3, 0);
+    tempvar value_b = new Uint256(4, 0);
+    tempvar value_c = new Uint256(5, 0);
+    let dict_ptr = dict_start;
+
+    with dict_ptr {
+        dict_write(0xa, cast(value_a, felt));
+        dict_write(0xb, cast(value_tmp, felt));
+        dict_write(0xb, cast(value_b, felt));
+        dict_read(0xb);
+        dict_write(0xc, cast(value_c, felt));
+    }
+
+    let (values_len, values) = dict_values(dict_start, dict_ptr);
+
+    assert values_len = 5;
+    assert values[0] = value_a[0];
+    assert values[1] = value_tmp[0];
+    assert values[2] = value_b[0];
+    assert values[3] = value_b[0];
+    assert values[4] = value_c[0];
+
+    let (squashed_start, squashed_end) = default_dict_finalize(dict_start, dict_ptr, 0);
+
+    let (values_len, values) = dict_values(squashed_start, squashed_end);
+
+    assert values_len = 3;
+    assert values[0] = value_a[0];
+    assert values[1] = value_b[0];
+    assert values[2] = value_c[0];
 
     return ();
 }

--- a/tests/src/utils/test_dict.py
+++ b/tests/src/utils/test_dict.py
@@ -19,6 +19,10 @@ class TestDict:
         async def test_should_return_keys(self, dict_):
             await dict_.test__dict_keys__should_return_keys().call()
 
+    class TestDictValues:
+        async def test_should_return_values(self, dict_):
+            await dict_.test__dict_values__should_return_values().call()
+
     class TestDefaultDictCopy:
         async def test_should_return_copied_dict(self, dict_):
             await dict_.test__default_dict_copy__should_return_copied_dict().call()

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -153,31 +153,13 @@ namespace TestHelpers {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(start: Uint256, n: felt, stack: model.Stack*) -> model.Stack* {
-        alloc_locals;
+    }(start: felt, n: felt, stack: model.Stack*) -> model.Stack* {
         if (n == 0) {
             return stack;
         }
 
-        uint256_check(start);
-        let updated_stack: model.Stack* = Stack.push(stack, start);
-        let (local element: Uint256, _) = uint256_add(start, Uint256(1, 0));
-        return push_elements_in_range_to_stack(element, n - 1, updated_stack);
-    }
-
-    func assert_stack_last_element_contains_uint256{range_check_ptr}(
-        stack: model.Stack*, value: Uint256
-    ) {
-        let (stack, result) = Stack.peek(stack, 0);
-        assert_uint256_eq(result, value);
-
-        return ();
-    }
-
-    func assert_stack_len_16bytes_equal{range_check_ptr}(stack: model.Stack*, len: felt) {
-        assert stack.len_16bytes / 2 = len;
-
-        return ();
+        let updated_stack: model.Stack* = Stack.push_uint128(stack, start);
+        return push_elements_in_range_to_stack(start + 1, n - 1, updated_stack);
     }
 
     func assert_array_equal(array_0_len: felt, array_0: felt*, array_1_len: felt, array_1: felt*) {

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -40,20 +40,6 @@ def extract_memory_from_execute(result):
     return mem
 
 
-def extract_stack_from_execute(result):
-    stack = [0] * int(result.stack_len / 2)
-    for i in range(0, result.stack_len * 3, 6):
-        k = result.stack_accesses[i]  # Word index.
-        index = int(k / 2)
-        assert result.stack_accesses[i + 1] == 0  # Initial value.
-        high = result.stack_accesses[i + 2]  # Final value.
-        assert result.stack_accesses[i + 4] == 0  # Initial value.
-        low = result.stack_accesses[i + 5]  # Final value.
-        stack[index] = 2**128 * high + low
-
-    return stack
-
-
 # The following helpers are translated from https://github.com/Uniswap/v2-core/blob/master/test/shared/utilities.ts
 def expand_to_18_decimals(n: int) -> int:
     return n * 10**18


### PR DESCRIPTION
Time spent on this PR: 1 day

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In stack.cairo, one checks for each push/pop op that there is enough and not too many items in the Stack, and possibly raises a Cairo VM errors.

Resolves #776

## What is the new behavior?

No more Cairo error for Stack over/under-flow, but a reverted ExecutionContext.
No extra checks: checks are made only once in the beginning of the opcode.
Stack has been updated to use a `Dict<Uint256*>`, dividing by two the number of dict ops.
