### PR TITLE
fix: signature extraction in decode legacy tx

### DIFF
--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -61,8 +61,8 @@ namespace EthTransaction {
         // 1 + s_len bytes for s = 1 byte for len (<= 32) + length in bytes for s word
         // This signature_len depends on CHAIN_ID, which is currently 0x 4b 4b 52 54
         local signature_start_index = 6;
-        tempvar r_len = sub_items[signature_start_index + 1].data_len;
-        tempvar s_len = sub_items[signature_start_index + 2].data_len;
+        let r_len = sub_items[signature_start_index + 1].data_len;
+        let s_len = sub_items[signature_start_index + 2].data_len;
         local signature_len = 1 + 4 + 1 + r_len + 1 + s_len;
 
         // 1. extract v, r, s

--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -70,12 +70,8 @@ namespace EthTransaction {
             sub_items[signature_start_index].data_len, sub_items[signature_start_index].data, 0
         );
         let v = (v - 2 * Constants.CHAIN_ID - 35);
-        let r = Helpers.bytes_i_to_uint256(
-            sub_items[signature_start_index + 1].data, r_len
-        );
-        let s = Helpers.bytes_i_to_uint256(
-            sub_items[signature_start_index + 2].data, s_len
-        );
+        let r = Helpers.bytes_i_to_uint256(sub_items[signature_start_index + 1].data, r_len);
+        let s = Helpers.bytes_i_to_uint256(sub_items[signature_start_index + 2].data, s_len);
 
         // 2. Encode signed tx data
         // Copy encoded data from input

--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -61,7 +61,9 @@ namespace EthTransaction {
         // 1 + s_len bytes for s = 1 byte for len (<= 32) + length in bytes for s word
         // This signature_len depends on CHAIN_ID, which is currently 0x 4b 4b 52 54
         local signature_start_index = 6;
-        local signature_len = 1 + 4 + 1 + sub_items[signature_start_index + 1].data_len + 1 + sub_items[signature_start_index + 2].data_len;
+        tempvar r_len = sub_items[signature_start_index + 1].data_len;
+        tempvar s_len = sub_items[signature_start_index + 2].data_len;
+        local signature_len = 1 + 4 + 1 + r_len + 1 + s_len;
 
         // 1. extract v, r, s
         let (v) = Helpers.bytes_to_felt(
@@ -69,10 +71,10 @@ namespace EthTransaction {
         );
         let v = (v - 2 * Constants.CHAIN_ID - 35);
         let r = Helpers.bytes_i_to_uint256(
-            sub_items[signature_start_index + 1].data, sub_items[signature_start_index + 1].data_len
+            sub_items[signature_start_index + 1].data, r_len
         );
         let s = Helpers.bytes_i_to_uint256(
-            sub_items[signature_start_index + 2].data, sub_items[signature_start_index + 2].data_len
+            sub_items[signature_start_index + 2].data, s_len
         );
 
         // 2. Encode signed tx data

--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -57,19 +57,23 @@ namespace EthTransaction {
         // Verify signature
         // The signature is at the end of the rlp encoded list and takes
         // 5 bytes for v = 1 byte for len (=4) + 4 bytes for {0,1} + CHAIN_ID * 2 + 35
-        // 33 bytes for r = 1 byte for len (=32) + 32 bytes for r word
-        // 33 bytes for s = 1 byte for len (=32) + 32 bytes for s word
+        // 1 + r_len bytes for r = 1 byte for len (<= 32) + length in bytes for r word
+        // 1 + s_len bytes for s = 1 byte for len (<= 32) + length in bytes for s word
         // This signature_len depends on CHAIN_ID, which is currently 0x 4b 4b 52 54
-        local signature_len = 1 + 4 + 1 + 32 + 1 + 32;
         local signature_start_index = 6;
+        local signature_len = 1 + 4 + 1 + sub_items[signature_start_index + 1].data_len + 1 + sub_items[signature_start_index + 2].data_len;
 
         // 1. extract v, r, s
         let (v) = Helpers.bytes_to_felt(
             sub_items[signature_start_index].data_len, sub_items[signature_start_index].data, 0
         );
         let v = (v - 2 * Constants.CHAIN_ID - 35);
-        let r = Helpers.bytes32_to_uint256(sub_items[signature_start_index + 1].data);
-        let s = Helpers.bytes32_to_uint256(sub_items[signature_start_index + 2].data);
+        let r = Helpers.bytes_i_to_uint256(
+            sub_items[signature_start_index + 1].data, sub_items[signature_start_index + 1].data_len
+        );
+        let s = Helpers.bytes_i_to_uint256(
+            sub_items[signature_start_index + 2].data, sub_items[signature_start_index + 2].data_len
+        );
 
         // 2. Encode signed tx data
         // Copy encoded data from input


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.1 day

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
R and S part of the signature are assumed to be 32 bytes.

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves [573](https://github.com/kkrt-labs/ef-tests/issues/573)

## What is the new behavior?
R and S are correctly decoded by taking the length of the values.
