### PR TITLE
Use jump table in Block Informations

### DIFF
--- a/src/kakarot/instructions/block_information.cairo
+++ b/src/kakarot/instructions/block_information.cairo
@@ -63,33 +63,18 @@ namespace BlockInformation {
         }
         assert range_check = range_check_ptr;
 
-        if (opcode_number == 0x40) {
-            jmp blockhash;
-        }
-        if (opcode_number == 0x41) {
-            jmp coinbase;
-        }
-        if (opcode_number == 0x42) {
-            jmp timestamp;
-        }
-        if (opcode_number == 0x43) {
-            jmp number;
-        }
-        if (opcode_number == 0x44) {
-            jmp prevrandao;
-        }
-        if (opcode_number == 0x45) {
-            jmp gaslimit;
-        }
-        if (opcode_number == 0x46) {
-            jmp chainid;
-        }
-        if (opcode_number == 0x47) {
-            jmp selfbalance;
-        }
-        if (opcode_number == 0x48) {
-            jmp basefee;
-        }
+        tempvar offset = 2 * (opcode_number - 0x40) + 1;
+
+        jmp rel offset;
+        jmp blockhash;
+        jmp coinbase;
+        jmp timestamp;
+        jmp number;
+        jmp prevrandao;
+        jmp gaslimit;
+        jmp chainid;
+        jmp selfbalance;
+        jmp basefee;
 
         blockhash:
         let syscall_ptr = cast([fp - 7], felt*);


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In BlockInformations, there is a big if/else to map the opcode number to the given opcode label.

## What is the new behavior?

Add a jump table to jump to the correct jump location.
