### PR TITLE
Add an Opcode constant

### DIFF
--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -22,8 +22,8 @@ from starkware.cairo.common.hash_state import (
     hash_update_with_hashchain,
 )
 
-from kakarot.constants import (
-    Constants,
+from kakarot.constants import Constants
+from kakarot.storages import (
     account_proxy_class_hash,
     native_token_address,
     contract_account_class_hash,

--- a/src/kakarot/constants.cairo
+++ b/src/kakarot/constants.cairo
@@ -2,30 +2,6 @@
 
 %lang starknet
 
-@storage_var
-func native_token_address() -> (res: felt) {
-}
-
-@storage_var
-func blockhash_registry_address() -> (res: felt) {
-}
-
-@storage_var
-func contract_account_class_hash() -> (value: felt) {
-}
-
-@storage_var
-func externally_owned_account_class_hash() -> (res: felt) {
-}
-
-@storage_var
-func account_proxy_class_hash() -> (res: felt) {
-}
-
-@storage_var
-func deploy_fee() -> (deploy_fee: felt) {
-}
-
 // @title Constants file.
 // @notice This file contains global constants.
 namespace Constants {

--- a/src/kakarot/instructions/block_information.cairo
+++ b/src/kakarot/instructions/block_information.cairo
@@ -12,7 +12,8 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 
 // Internal dependencies
-from kakarot.constants import Constants, blockhash_registry_address
+from kakarot.storages import blockhash_registry_address
+from kakarot.constants import Constants
 from kakarot.execution_context import ExecutionContext
 from kakarot.interfaces.interfaces import IBlockhashRegistry
 from kakarot.model import model

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -20,7 +20,8 @@ from starkware.cairo.common.registers import get_fp_and_pc
 
 // Internal dependencies
 from kakarot.account import Account
-from kakarot.constants import contract_account_class_hash, native_token_address, Constants
+from kakarot.storages import contract_account_class_hash, native_token_address
+from kakarot.constants import Constants
 from kakarot.errors import Errors
 from kakarot.execution_context import ExecutionContext
 from kakarot.memory import Memory

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -12,7 +12,7 @@ from starkware.starknet.common.syscalls import get_caller_address, get_tx_info
 from starkware.cairo.common.math_cmp import is_not_zero
 
 from kakarot.account import Account
-from kakarot.constants import (
+from kakarot.storages import (
     account_proxy_class_hash,
     blockhash_registry_address,
     contract_account_class_hash,

--- a/src/kakarot/state.cairo
+++ b/src/kakarot/state.cairo
@@ -17,7 +17,7 @@ from starkware.starknet.common.syscalls import call_contract
 from starkware.starknet.common.syscalls import emit_event
 
 from kakarot.account import Account
-from kakarot.constants import native_token_address, contract_account_class_hash
+from kakarot.storages import native_token_address, contract_account_class_hash
 from kakarot.interfaces.interfaces import IERC20
 from kakarot.model import model
 from utils.dict import default_dict_copy

--- a/src/kakarot/storages.cairo
+++ b/src/kakarot/storages.cairo
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+@storage_var
+func native_token_address() -> (res: felt) {
+}
+
+@storage_var
+func blockhash_registry_address() -> (res: felt) {
+}
+
+@storage_var
+func contract_account_class_hash() -> (value: felt) {
+}
+
+@storage_var
+func externally_owned_account_class_hash() -> (res: felt) {
+}
+
+@storage_var
+func account_proxy_class_hash() -> (res: felt) {
+}
+
+@storage_var
+func deploy_fee() -> (deploy_fee: felt) {
+}

--- a/tests/fixtures/EVM.cairo
+++ b/tests/fixtures/EVM.cairo
@@ -17,12 +17,12 @@ from kakarot.library import Kakarot
 from kakarot.model import model
 from kakarot.stack import Stack
 from kakarot.state import Internals as State
-from kakarot.constants import (
+from kakarot.constants import Constants
+from kakarot.storages import (
     native_token_address,
     contract_account_class_hash,
     blockhash_registry_address,
     account_proxy_class_hash,
-    Constants,
 )
 from utils.dict import dict_keys, dict_values
 

--- a/tests/src/kakarot/accounts/eoa/mock_kakarot.cairo
+++ b/tests/src/kakarot/accounts/eoa/mock_kakarot.cairo
@@ -8,7 +8,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.starknet.common.syscalls import get_caller_address
 
 from kakarot.account import Account
-from kakarot.constants import account_proxy_class_hash, externally_owned_account_class_hash
+from kakarot.storages import account_proxy_class_hash, externally_owned_account_class_hash
 from kakarot.library import native_token_address, Kakarot
 from kakarot.interfaces.interfaces import IAccount
 

--- a/tests/src/kakarot/instructions/test_block_information.cairo
+++ b/tests/src/kakarot/instructions/test_block_information.cairo
@@ -14,7 +14,8 @@ from starkware.cairo.common.registers import get_fp_and_pc
 from utils.utils import Helpers
 from kakarot.model import model
 from kakarot.stack import Stack
-from kakarot.constants import Constants, blockhash_registry_address
+from kakarot.constants import Constants
+from kakarot.storages import blockhash_registry_address
 from kakarot.execution_context import ExecutionContext
 from kakarot.instructions.block_information import BlockInformation
 from tests.utils.helpers import TestHelpers

--- a/tests/src/kakarot/instructions/test_environmental_information.cairo
+++ b/tests/src/kakarot/instructions/test_environmental_information.cairo
@@ -16,8 +16,8 @@ from openzeppelin.token.erc20.library import ERC20
 
 // Local dependencies
 from kakarot.account import Account
-from kakarot.constants import (
-    Constants,
+from kakarot.constants import Constants
+from kakarot.storages import (
     contract_account_class_hash,
     account_proxy_class_hash,
     native_token_address,

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -15,7 +15,8 @@ from starkware.starknet.common.syscalls import deploy, get_contract_address
 from openzeppelin.token.erc20.library import ERC20
 
 // Local dependencies
-from kakarot.constants import (
+from kakarot.constants import Constants
+from kakarot.storages import (
     Constants,
     native_token_address,
     contract_account_class_hash,


### PR DESCRIPTION
Time spent on this PR: 0.4

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Some opcode families defines their own `opcode_label`.

## What is the new behavior?

One single `opcode_label` constant is defined and used everywhere.
