### PR TITLE
Stop reverting on precompiles

### DIFF
--- a/src/kakarot/errors.cairo
+++ b/src/kakarot/errors.cairo
@@ -352,7 +352,7 @@ namespace Errors {
         assert [error + 24] = 108;  // l
         assert [error + 25] = 101;  // e
         assert [error + 26] = 32;  // " "
-        assert [error + 27] = address;  //
+        assert [error + 27] = '0' + address;  // convert uint address to str
         return (28, error);
     }
 
@@ -393,7 +393,7 @@ namespace Errors {
         assert [error + 31] = 108;  // l
         assert [error + 32] = 101;  // e
         assert [error + 33] = 32;  //
-        assert [error + 34] = address;  //
+        assert [error + 34] = '0' + address;  //
         return (35, error);
     }
 
@@ -498,5 +498,68 @@ namespace Errors {
         dw 'G';
         dw 'a';
         dw 's';
+    }
+
+    func precompileInputError() -> (error_len: felt, error: felt*) {
+        let (error) = get_label_location(precompile_input_error_message);
+        return (27, error);
+
+        precompile_input_error_message:
+        dw 'P';
+        dw 'r';
+        dw 'e';
+        dw 'c';
+        dw 'o';
+        dw 'm';
+        dw 'p';
+        dw 'i';
+        dw 'l';
+        dw 'e';
+        dw ':';
+        dw ' ';
+        dw 'w';
+        dw 'r';
+        dw 'o';
+        dw 'n';
+        dw 'g';
+        dw ' ';
+        dw 'i';
+        dw 'n';
+        dw 'p';
+        dw 'u';
+        dw 't';
+        dw '_';
+        dw 'l';
+        dw 'e';
+        dw 'n';
+    }
+
+    func precompileFlagError() -> (error_len: felt, error: felt*) {
+        let (error) = get_label_location(precompile_flag_error);
+        return (22, error);
+
+        precompile_flag_error:
+        dw 'P';
+        dw 'r';
+        dw 'e';
+        dw 'c';
+        dw 'o';
+        dw 'm';
+        dw 'p';
+        dw 'i';
+        dw 'l';
+        dw 'e';
+        dw ':';
+        dw ' ';
+        dw 'f';
+        dw 'l';
+        dw 'a';
+        dw 'g';
+        dw ' ';
+        dw 'e';
+        dw 'r';
+        dw 'r';
+        dw 'o';
+        dw 'r';
     }
 }

--- a/src/kakarot/precompiles/datacopy.cairo
+++ b/src/kakarot/precompiles/datacopy.cairo
@@ -31,9 +31,9 @@ namespace PrecompileDataCopy {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(_address: felt, input_len: felt, input: felt*) -> (
-        output_len: felt, output: felt*, gas_used: felt
+        output_len: felt, output: felt*, gas_used: felt, reverted: felt
     ) {
         let (minimum_word_size) = Helpers.minimum_word_count(input_len);
-        return (input_len, input, 3 * minimum_word_size + GAS_COST_DATACOPY);
+        return (input_len, input, 3 * minimum_word_size + GAS_COST_DATACOPY, 0);
     }
 }

--- a/src/kakarot/precompiles/ecadd.cairo
+++ b/src/kakarot/precompiles/ecadd.cairo
@@ -33,7 +33,7 @@ namespace PrecompileEcAdd {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(_address: felt, input_len: felt, input: felt*) -> (
-        output_len: felt, output: felt*, gas_used: felt
+        output_len: felt, output: felt*, gas_used: felt, reverted: felt
     ) {
         alloc_locals;
 
@@ -53,6 +53,6 @@ namespace PrecompileEcAdd {
         // We fill `output + bytes_x_len` ptr with `bytes_y` elements
         Helpers.fill_array(bytes_y_len, bytes_y, output + bytes_x_len);
 
-        return (G1POINT_BYTES_LEN * 2, output, GAS_COST_EC_ADD);
+        return (G1POINT_BYTES_LEN * 2, output, GAS_COST_EC_ADD, 0);
     }
 }

--- a/src/kakarot/precompiles/ecmul.cairo
+++ b/src/kakarot/precompiles/ecmul.cairo
@@ -33,7 +33,7 @@ namespace PrecompileEcMul {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(_address: felt, input_len: felt, input: felt*) -> (
-        output_len: felt, output: felt*, gas_used: felt
+        output_len: felt, output: felt*, gas_used: felt, reverted: felt
     ) {
         alloc_locals;
 
@@ -50,6 +50,6 @@ namespace PrecompileEcMul {
         // We fill `output + bytes_x_len` ptr with `bytes_y` elements
         Helpers.fill_array(bytes_y_len, bytes_y, output + bytes_x_len);
 
-        return (G1POINT_BYTES_LEN * 2, output, GAS_COST_EC_MUL);
+        return (G1POINT_BYTES_LEN * 2, output, GAS_COST_EC_MUL, 0);
     }
 }

--- a/src/kakarot/precompiles/modexp.cairo
+++ b/src/kakarot/precompiles/modexp.cairo
@@ -32,7 +32,7 @@ namespace PrecompileModExpUint256 {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(_address: felt, input_len: felt, input: felt*) -> (
-        output_len: felt, output: felt*, gas_used: felt
+        output_len: felt, output: felt*, gas_used: felt, reverted: felt
     ) {
         alloc_locals;
 
@@ -63,6 +63,6 @@ namespace PrecompileModExpUint256 {
             b_size, m_size, e_size, b, e, m
         );
 
-        return (output_len=bytes_len, output=bytes, gas_used=gas_cost);
+        return (bytes_len, bytes, gas_cost, 0);
     }
 }

--- a/src/kakarot/precompiles/ripemd160.cairo
+++ b/src/kakarot/precompiles/ripemd160.cairo
@@ -43,7 +43,7 @@ namespace PrecompileRIPEMD160 {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(_address: felt, input_len: felt, input: felt*) -> (
-        output_len: felt, output: felt*, gas_used: felt
+        output_len: felt, output: felt*, gas_used: felt, reverted: felt
     ) {
         alloc_locals;
         let (local buf: felt*) = alloc();
@@ -76,7 +76,7 @@ namespace PrecompileRIPEMD160 {
 
         // 5. return bytes hash code.
         let (minimum_word_size) = Helpers.minimum_word_count(input_len);
-        return (32, arr_x - 12, 120 * minimum_word_size + GAS_COST_RIPEMD160);
+        return (32, arr_x - 12, 120 * minimum_word_size + GAS_COST_RIPEMD160, 0);
     }
 }
 

--- a/src/kakarot/precompiles/sha256.cairo
+++ b/src/kakarot/precompiles/sha256.cairo
@@ -43,7 +43,7 @@ namespace PrecompileSHA256 {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(_address: felt, input_len: felt, input: felt*) -> (
-        output_len: felt, output: felt*, gas_used: felt
+        output_len: felt, output: felt*, gas_used: felt, reverted: felt
     ) {
         alloc_locals;
 
@@ -82,7 +82,7 @@ namespace PrecompileSHA256 {
             8, hash, 0, hash_bytes_array
         );
         let (minimum_word_size) = Helpers.minimum_word_count(input_len);
-        return (32, hash_bytes_array, 12 * minimum_word_size + GAS_COST_SHA256);
+        return (32, hash_bytes_array, 12 * minimum_word_size + GAS_COST_SHA256, 0);
     }
 }
 

--- a/tests/src/kakarot/precompiles/test_blake2f.cairo
+++ b/tests/src/kakarot/precompiles/test_blake2f.cairo
@@ -9,32 +9,25 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 // Local dependencies
 from utils.utils import Helpers
 from kakarot.precompiles.blake2f import PrecompileBlake2f
-from kakarot.model import model
-from kakarot.memory import Memory
-from kakarot.constants import Constants
-from kakarot.stack import Stack
-from kakarot.execution_context import ExecutionContext
-from kakarot.instructions.memory_operations import MemoryOperations
-from kakarot.instructions.system_operations import SystemOperations, CallHelper, CreateHelper
 from tests.utils.helpers import TestHelpers
 
 @external
 func test_should_fail_when_input_is_not_213{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
+}() -> (output_len: felt, output: felt*) {
     // Given
     alloc_locals;
     let (input) = alloc();
     let input_len = 212;
 
-    PrecompileBlake2f.run(0x09, input_len, input);
-    return ();
+    let result = PrecompileBlake2f.run(0x09, input_len, input);
+    return (result.output_len, result.output);
 }
 
 @external
 func test_should_fail_when_flag_is_not_0_or_1{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
+}() -> (output_len: felt, output: felt*) {
     // Given
     alloc_locals;
     let (input) = alloc();
@@ -42,8 +35,8 @@ func test_should_fail_when_flag_is_not_0_or_1{
     TestHelpers.array_fill(input, input_len - 1, 0x00);
     assert input[212] = 0x02;
 
-    PrecompileBlake2f.run(0x09, input_len, input);
-    return ();
+    let result = PrecompileBlake2f.run(0x09, input_len, input);
+    return (result.output_len, result.output);
 }
 
 @external
@@ -61,7 +54,7 @@ func test_should_return_blake2f_compression{
     Helpers.split_word_little(t1, 8, input + 196 + 8);
     assert input[212] = f;
 
-    let (output_len, output, _) = PrecompileBlake2f.run(0x09, 213, input);
+    let (output_len, output, gas, reverted) = PrecompileBlake2f.run(0x09, 213, input);
 
     return (output_len=output_len, output=output);
 }

--- a/tests/src/kakarot/precompiles/test_blake2f.py
+++ b/tests/src/kakarot/precompiles/test_blake2f.py
@@ -6,7 +6,6 @@ import pytest_asyncio
 from eth._utils.blake2.compression import TMessageBlock, blake2b_compress
 from starkware.starknet.testing.starknet import Starknet
 
-from tests.utils.errors import cairo_error
 from tests.utils.helpers import pack_64_bits_little
 
 
@@ -24,16 +23,16 @@ async def blake2f(starknet: Starknet):
 @pytest.mark.BLAKE2F
 class TestBlake2f:
     async def test_should_fail_when_input_len_is_not_213(self, blake2f):
-        with cairo_error(
-            "Kakarot: blake2f failed with incorrect input_len: 212 instead of 213"
-        ):
+        (output,) = (
             await blake2f.test_should_fail_when_input_is_not_213().call()
+        ).result
+        assert bytes(output).decode() == "Precompile: wrong input_len"
 
     async def test_should_fail_when_flag_is_not_0_or_1(self, blake2f):
-        with cairo_error(
-            "Kakarot: blake2f failed with incorrect flag: 2 instead of 0 or 1"
-        ):
+        (output,) = (
             await blake2f.test_should_fail_when_flag_is_not_0_or_1().call()
+        ).result
+        assert bytes(output).decode() == "Precompile: flag error"
 
     @pytest.mark.parametrize("f", [0, 1])
     @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])

--- a/tests/src/kakarot/precompiles/test_datacopy.cairo
+++ b/tests/src/kakarot/precompiles/test_datacopy.cairo
@@ -3,22 +3,11 @@
 %lang starknet
 
 // Starkware dependencies
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
-from starkware.cairo.common.math import split_felt, assert_nn
-from starkware.starknet.common.syscalls import get_block_number, get_block_timestamp
 
 // Local dependencies
 from utils.utils import Helpers
 from kakarot.precompiles.datacopy import PrecompileDataCopy
-from kakarot.model import model
-from kakarot.memory import Memory
-from kakarot.constants import Constants
-from kakarot.stack import Stack
-from kakarot.execution_context import ExecutionContext
-from kakarot.instructions.memory_operations import MemoryOperations
-from kakarot.instructions.system_operations import SystemOperations, CallHelper, CreateHelper
 from tests.utils.helpers import TestHelpers
 
 @external
@@ -38,59 +27,5 @@ func test__datacopy_impl{
         array_1_len=result.output_len,
         array_1=result.output,
     );
-    return ();
-}
-
-@external
-func test__datacopy_via_staticcall{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
-    // Given
-    alloc_locals;
-
-    let (bytecode) = alloc();
-    local bytecode_len = 0;
-
-    // Fill the stack with input data, following the evm.codes playground example for this opcode
-    let stack: model.Stack* = Stack.init();
-    let gas = Helpers.to_uint256(Constants.TRANSACTION_GAS_LIMIT);
-    let (address_high, address_low) = split_felt(PrecompileDataCopy.PRECOMPILE_ADDRESS);
-    tempvar address = new Uint256(address_low, address_high);
-    tempvar args_offset = new Uint256(31, 0);
-    tempvar args_size = new Uint256(1, 0);
-
-    tempvar ret_offset = new Uint256(63, 0);
-    tempvar ret_size = new Uint256(1, 0);
-
-    let stack = Stack.push(stack, ret_size);
-    let stack = Stack.push(stack, ret_offset);
-    let stack = Stack.push(stack, args_size);
-    let stack = Stack.push(stack, args_offset);
-    let stack = Stack.push(stack, address);
-    let stack = Stack.push(stack, gas);
-
-    tempvar preset_memory = new Uint256(low=0xFF, high=0);
-    tempvar memory_offset = new Uint256(0, 0);
-    let stack = Stack.push(stack, preset_memory);
-
-    let stack = Stack.push(stack, memory_offset);
-    let ctx = TestHelpers.init_context_with_stack(bytecode_len, bytecode, stack);
-    let ctx = MemoryOperations.exec_mstore(ctx);
-
-    // When
-    let result = SystemOperations.exec_staticcall(ctx);
-    let summary = ExecutionContext.finalize(result);
-    let result = CallHelper.finalize_calling_context(summary);
-
-    // Put the result alone on the stack
-    let result = MemoryOperations.exec_pop(result);
-    let stack = Stack.push_uint128(result.stack, 32);
-    let result = ExecutionContext.update_stack(result, stack);
-    let result = MemoryOperations.exec_mload(result);
-    let (stack, stack_result) = Stack.peek(result.stack, 0);
-
-    // Then
-    assert stack_result.low = preset_memory.low;
-
     return ();
 }

--- a/tests/src/kakarot/precompiles/test_datacopy.py
+++ b/tests/src/kakarot/precompiles/test_datacopy.py
@@ -17,14 +17,9 @@ async def datacopy(starknet: Starknet):
 
 @pytest.mark.asyncio
 class TestDataCopy:
-    @pytest.mark.parametrize(
-        "calldata_len",
-        [32],
-        ids=["calldata_len32"],
-    )
+    @pytest.mark.parametrize("calldata_len", [32])
     async def test_datacopy(self, datacopy, calldata_len):
         random.seed(0)
         calldata = [random.randint(0, 255) for _ in range(calldata_len)]
 
         await datacopy.test__datacopy_impl(calldata=calldata).call()
-        await datacopy.test__datacopy_via_staticcall().call()

--- a/tests/src/kakarot/precompiles/test_ec_add.cairo
+++ b/tests/src/kakarot/precompiles/test_ec_add.cairo
@@ -3,7 +3,6 @@
 %lang starknet
 
 // Starkware dependencies
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.cairo_secp.bigint import BigInt3, bigint_to_uint256, uint256_to_bigint
 from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
@@ -50,7 +49,7 @@ func test__ecadd_impl{
     Helpers.fill_array(
         bytes_expected_y_len, bytes_expected_y, bytes_expected_result + bytes_expected_x_len
     );
-    let (output_len, output: felt*, gas_used) = PrecompileEcAdd.run(
+    let (output_len, output: felt*, gas_used, reverted) = PrecompileEcAdd.run(
         PrecompileEcAdd.PRECOMPILE_ADDRESS, calldata_len, calldata
     );
 

--- a/tests/src/kakarot/precompiles/test_ec_mul.cairo
+++ b/tests/src/kakarot/precompiles/test_ec_mul.cairo
@@ -56,7 +56,7 @@ func test__ecmul_impl{
     Helpers.fill_array(x_bytes_len, x_bytes, input);
     Helpers.fill_array(y_bytes_len, y_bytes, input + 32);
     Helpers.fill_array(scalar_bytes_len, scalar_bytes, input + 64);
-    let (output_len, output: felt*, gas_used) = PrecompileEcMul.run(
+    let (output_len, output: felt*, gas_used, reverted) = PrecompileEcMul.run(
         PrecompileEcMul.PRECOMPILE_ADDRESS, input_len, input
     );
 

--- a/tests/src/kakarot/precompiles/test_ec_recover.cairo
+++ b/tests/src/kakarot/precompiles/test_ec_recover.cairo
@@ -15,24 +15,24 @@ from tests.utils.helpers import TestHelpers
 @external
 func test_should_fail_when_input_len_is_not_128{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
+}() -> (output_len: felt, output: felt*) {
     alloc_locals;
     let (input) = alloc();
     let input_len = 0;
-    PrecompileEcRecover.run(PrecompileEcRecover.PRECOMPILE_ADDRESS, input_len, input);
-    return ();
+    let result = PrecompileEcRecover.run(PrecompileEcRecover.PRECOMPILE_ADDRESS, input_len, input);
+    return (result.output_len, result.output);
 }
 
 @external
 func test_should_fail_when_recovery_identifier_is_neither_27_nor_28{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
+}() -> (output_len: felt, output: felt*) {
     alloc_locals;
     let (input) = alloc();
     let input_len = 128;
     TestHelpers.array_fill(input, input_len, 1);
-    PrecompileEcRecover.run(PrecompileEcRecover.PRECOMPILE_ADDRESS, input_len, input);
-    return ();
+    let result = PrecompileEcRecover.run(PrecompileEcRecover.PRECOMPILE_ADDRESS, input_len, input);
+    return (result.output_len, result.output);
 }
 
 @external
@@ -50,7 +50,7 @@ func test_should_return_evm_address_in_bytes32{
     // fill r, s
     TestHelpers.array_fill(input + 64, 64, 1);
 
-    let (output_len, output, gas) = PrecompileEcRecover.run(
+    let (output_len, output, gas, reverted) = PrecompileEcRecover.run(
         PrecompileEcRecover.PRECOMPILE_ADDRESS, input_len, input
     );
     assert output_len = 32;
@@ -203,7 +203,7 @@ func test_should_return_evm_address_for_playground_example{
     assert input[127] = 218;
     let input_len = 128;
 
-    let (output_len, output, gas) = PrecompileEcRecover.run(
+    let (output_len, output, gas, reverted) = PrecompileEcRecover.run(
         PrecompileEcRecover.PRECOMPILE_ADDRESS, input_len, input
     );
 

--- a/tests/src/kakarot/precompiles/test_ec_recover.py
+++ b/tests/src/kakarot/precompiles/test_ec_recover.py
@@ -2,8 +2,6 @@ import pytest
 import pytest_asyncio
 from starkware.starknet.testing.starknet import Starknet
 
-from tests.utils.errors import cairo_error
-
 
 @pytest_asyncio.fixture(scope="module")
 async def ec_recover(starknet: Starknet):
@@ -19,16 +17,18 @@ async def ec_recover(starknet: Starknet):
 @pytest.mark.EC_RECOVER
 class TestEcRecover:
     async def test_should_fail_when_input_len_is_not_128(self, ec_recover):
-        with cairo_error(
-            "EcRecover: received wrong number of bytes in input: 0 instead of 4*32"
-        ):
+        (output,) = (
             await ec_recover.test_should_fail_when_input_len_is_not_128().call()
+        ).result
+        assert bytes(output).decode() == "Precompile: wrong input_len"
 
     async def test_should_fail_when_recovery_identifier_is_neither_27_nor_28(
         self, ec_recover
     ):
-        with cairo_error("EcRecover: Recovery identifier should be either 27 or 28"):
+        (output,) = (
             await ec_recover.test_should_fail_when_recovery_identifier_is_neither_27_nor_28().call()
+        ).result
+        assert bytes(output).decode() == "Precompile: flag error"
 
     async def test_should_return_evm_address_in_bytes32(self, ec_recover):
         await ec_recover.test_should_return_evm_address_in_bytes32().call()

--- a/tests/src/kakarot/precompiles/test_modexp.cairo
+++ b/tests/src/kakarot/precompiles/test_modexp.cairo
@@ -26,7 +26,7 @@ func test__modexp_impl{
 }(data_len: felt, data: felt*) -> (result: felt, gas_cost: felt) {
     alloc_locals;
 
-    let (output_len, output, gas_used) = PrecompileModExpUint256.run(
+    let (output_len, output, gas_used, reverted) = PrecompileModExpUint256.run(
         PrecompileModExpUint256.PRECOMPILE_ADDRESS, data_len, data
     );
 

--- a/tests/src/kakarot/precompiles/test_precompiles.cairo
+++ b/tests/src/kakarot/precompiles/test_precompiles.cairo
@@ -3,37 +3,12 @@
 %lang starknet
 
 // Starkware dependencies
-from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
-from starkware.cairo.common.math import split_felt, assert_nn
-from starkware.cairo.common.bool import FALSE, TRUE
 
 // Local dependencies
-from utils.utils import Helpers
-from kakarot.constants import Constants
 from kakarot.model import model
-from kakarot.stack import Stack
 from kakarot.execution_context import ExecutionContext
-from kakarot.instructions.system_operations import SystemOperations
 from kakarot.precompiles.precompiles import Precompiles
-from tests.utils.helpers import TestHelpers
-
-@external
-func test__precompiles_should_throw_on_out_of_bounds{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(address: felt) {
-    // When
-    let result = Precompiles.run(
-        evm_address=address,
-        calldata_len=0,
-        calldata=cast(0, felt*),
-        value=0,
-        calling_context=cast(0, model.ExecutionContext*),
-    );
-
-    return ();
-}
 
 @external
 func test__is_precompile{range_check_ptr}(address: felt) -> (is_precompile: felt) {
@@ -41,21 +16,9 @@ func test__is_precompile{range_check_ptr}(address: felt) -> (is_precompile: felt
 }
 
 @external
-func test__not_implemented_precompile_should_raise_with_detailed_error_message{
+func test__precompiles_run{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(address: felt) {
-    // When
-    let result = Precompiles.not_implemented_precompile(
-        evm_address=address, _input_len=0, _input=cast(0, felt*)
-    );
-
-    return ();
-}
-
-@external
-func test__run_should_return_a_stopped_execution_context{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(address: felt) {
+}(address: felt) -> (return_data_len: felt, return_data: felt*, reverted: felt) {
     // When
     tempvar call_context = new model.CallContext(
         bytecode=cast(0, felt*),
@@ -80,16 +43,5 @@ func test__run_should_return_a_stopped_execution_context{
         calling_context=calling_context,
     );
 
-    assert result.stopped = 1;
-
-    return ();
-}
-
-@external
-func test__exec_precompiles_should_throw_non_implemented_precompiler_message{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}(address: felt) {
-    let result = Precompiles._exec_precompile(address, 0, cast(0, felt*));
-
-    return ();
+    return (result.return_data_len, result.return_data, result.reverted);
 }

--- a/tests/src/kakarot/precompiles/test_ripemd160.cairo
+++ b/tests/src/kakarot/precompiles/test_ripemd160.cairo
@@ -23,7 +23,7 @@ func test__ripemd160{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(msg_len: felt, msg: felt*) -> (hash_len: felt, hash: felt*) {
     alloc_locals;
-    let (hash_len, hash, _) = PrecompileRIPEMD160.run(
+    let (hash_len, hash, gas, reverted) = PrecompileRIPEMD160.run(
         PrecompileRIPEMD160.PRECOMPILE_ADDRESS, msg_len, msg
     );
 

--- a/tests/src/kakarot/precompiles/test_sha256.cairo
+++ b/tests/src/kakarot/precompiles/test_sha256.cairo
@@ -17,7 +17,7 @@ func test__sha256{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(data_len: felt, data: felt*) -> (hash_len: felt, hash: felt*) {
     alloc_locals;
-    let (hash_len, hash, gas_used) = PrecompileSHA256.run(
+    let (hash_len, hash, gas_used, reverted) = PrecompileSHA256.run(
         PrecompileSHA256.PRECOMPILE_ADDRESS, data_len, data
     );
     let (minimum_word_size) = Helpers.minimum_word_count(data_len);


### PR DESCRIPTION
Time spent on this PR: 0.2

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Some Cairo VM errors in precompiles

## What is the new behavior?

Returns a reverted context as in other errors.
