### PR TITLE
Use true corresponding starknet address for precompiles

### DIFF
--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -337,7 +337,7 @@ async def eth_send_transaction(
     return receipt, response, success
 
 
-async def _compute_starknet_address(address: Union[str, int]):
+async def compute_starknet_address(address: Union[str, int]):
     evm_address = int(address, 16) if isinstance(address, str) else address
     kakarot_contract = await _get_starknet_contract("kakarot")
     return (
@@ -364,7 +364,7 @@ async def deploy_and_fund_evm_address(evm_address: str, amount: float):
 
 
 async def fund_address(address: Union[str, int], amount: float):
-    starknet_address = await _compute_starknet_address(address)
+    starknet_address = await compute_starknet_address(address)
     logger.info(
         f"ℹ️  Funding EVM address {address} at Starknet address {hex(starknet_address)}"
     )
@@ -421,7 +421,7 @@ async def store_bytecode(bytecode: Union[str, bytes], **kwargs):
 
 
 async def get_bytecode(address: Union[int, str]):
-    starknet_address = await _compute_starknet_address(address)
+    starknet_address = await compute_starknet_address(address)
     return bytes(
         (
             await _call_starknet(

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -10,7 +10,7 @@ from starkware.cairo.common.cairo_keccak.keccak import cairo_keccak_bigend, fina
 from starkware.cairo.common.math import split_felt, unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le, is_not_zero, is_nn
 from starkware.cairo.common.memcpy import memcpy
-from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.uint256 import Uint256, uint256_eq
 from starkware.starknet.common.syscalls import (
     deploy as deploy_syscall,
     get_contract_address,
@@ -234,6 +234,11 @@ namespace SystemOperations {
 
         let (value_high, value_low) = split_felt(sub_ctx.call_context.value);
         tempvar value = Uint256(value_low, value_high);
+        let (is_zero) = uint256_eq(value, Uint256(0, 0));
+        if (is_zero != 0) {
+            return sub_ctx;
+        }
+
         let calling_context = sub_ctx.call_context.calling_context;
         let transfer = model.Transfer(
             calling_context.call_context.address, sub_ctx.call_context.address, value

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -10,6 +10,7 @@ from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.math_cmp import is_le, is_not_zero
 
 // Internal dependencies
+from kakarot.account import Account
 from kakarot.constants import Constants
 from kakarot.execution_context import ExecutionContext
 from kakarot.errors import Errors
@@ -52,7 +53,8 @@ namespace Precompiles {
         // Build returned execution context
         let stack = Stack.init();
         let memory = Memory.init();
-        tempvar address = new model.Address(0, evm_address);
+        let (starknet_address) = Account.compute_starknet_address(evm_address);
+        tempvar address = new model.Address(starknet_address, evm_address);
         tempvar call_context = new model.CallContext(
             bytecode=cast(0, felt*),
             bytecode_len=0,


### PR DESCRIPTION
Time spent on this PR: 0.15

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Some ef tests are crashing the Cairo VM with errors likes `Error message: ERC20 cannot send to address 0`.

## What is the new behavior?

The precompile sub_ctx uses the true corresponding starknet address.
Transfer is added in a CALL only if value > 0.
