### PR TITLE
Fix ERC20 error due to newly deployed SELFDESTRUCT contracts

### DIFF
--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -120,11 +120,6 @@ namespace Account {
 
         // Case new Account
         if (starknet_account_exists == 0) {
-            // If SELFDESTRUCT, just do nothing
-            if (self.selfdestruct != 0) {
-                return ();
-            }
-
             // Just casting the Summary into an Account to apply has_code_or_nonce
             // cf Summary note: like an Account, but frozen after squashing all dicts
             // There is no reason to have has_code_or_nonce available in the public API
@@ -135,6 +130,11 @@ namespace Account {
                 // Deploy accounts
                 let (class_hash) = contract_account_class_hash.read();
                 deploy(class_hash, self.address);
+                // If SELFDESTRUCT, stops here to leave the account empty
+                if (self.selfdestruct != 0) {
+                    return ();
+                }
+
                 // Write bytecode
                 IContractAccount.write_bytecode(starknet_address, self.code_len, self.code);
                 // Set nonce

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -356,9 +356,7 @@ namespace SystemOperations {
 
         let (recipient_starknet_address) = Account.compute_starknet_address(recipient_evm_address);
         tempvar recipient = new model.Address(recipient_starknet_address, recipient_evm_address);
-        // Touching recipient to load its account in the state for final eth transfer
-        let (state, _) = State.get_account(ctx.state, recipient);
-        let (state, balance) = State.read_balance(state, ctx.call_context.address);
+        let (state, balance) = State.read_balance(ctx.state, ctx.call_context.address);
         let transfer = model.Transfer(
             sender=ctx.call_context.address, recipient=recipient, amount=balance
         );

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -356,7 +356,9 @@ namespace SystemOperations {
 
         let (recipient_starknet_address) = Account.compute_starknet_address(recipient_evm_address);
         tempvar recipient = new model.Address(recipient_starknet_address, recipient_evm_address);
-        let (state, balance) = State.read_balance(ctx.state, ctx.call_context.address);
+        // Touching recipient to load its account in the state for final eth transfer
+        let (state, _) = State.get_account(ctx.state, recipient);
+        let (state, balance) = State.read_balance(state, ctx.call_context.address);
         let transfer = model.Transfer(
             sender=ctx.call_context.address, recipient=recipient, amount=balance
         );

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -132,11 +132,8 @@ namespace Kakarot {
         let is_registered = Account.is_registered(address.evm);
         let is_collision = is_registered * is_deploy_tx;
 
-        // Handle accounts
-        let origin_account = Account.fetch_or_create(origin);
-        let state = State.set_account(state, origin, origin_account);
-        let account = Account.fetch_or_create(address);
         // Nonce is set to 1 in case of deploy_tx
+        let account = Account.fetch_or_create(address);
         let nonce = account.nonce * (1 - is_deploy_tx) + is_deploy_tx;
         let account = Account.set_nonce(account, nonce);
         let state = State.set_account(state, address, account);

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -126,16 +126,17 @@ namespace Kakarot {
         // Handle value
         let amount = Helpers.to_uint256(value);
         let transfer = model.Transfer(origin, address, [amount]);
-        let origin_account = Account.fetch_or_create(origin);
-        let state = State.set_account(state, origin, origin_account);
         let (state, success) = State.add_transfer(state, transfer);
 
         // Check collision
         let is_registered = Account.is_registered(address.evm);
         let is_collision = is_registered * is_deploy_tx;
 
-        // Nonce is set to 1 in case of deploy_tx
+        // Handle accounts
+        let origin_account = Account.fetch_or_create(origin);
+        let state = State.set_account(state, origin, origin_account);
         let account = Account.fetch_or_create(address);
+        // Nonce is set to 1 in case of deploy_tx
         let nonce = account.nonce * (1 - is_deploy_tx) + is_deploy_tx;
         let account = Account.set_nonce(account, nonce);
         let state = State.set_account(state, address, account);

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -126,6 +126,8 @@ namespace Kakarot {
         // Handle value
         let amount = Helpers.to_uint256(value);
         let transfer = model.Transfer(origin, address, [amount]);
+        let origin_account = Account.fetch_or_create(origin);
+        let state = State.set_account(state, origin, origin_account);
         let (state, success) = State.add_transfer(state, transfer);
 
         // Check collision

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -129,11 +129,10 @@ namespace Kakarot {
         let (state, success) = State.add_transfer(state, transfer);
 
         // Check collision
-        let is_registered = Account.is_registered(address.evm);
-        let is_collision = is_registered * is_deploy_tx;
-
-        // Nonce is set to 1 in case of deploy_tx
         let account = Account.fetch_or_create(address);
+        let code_or_nonce = Account.has_code_or_nonce(account);
+        let is_collision = code_or_nonce * is_deploy_tx;
+        // Nonce is set to 1 in case of deploy_tx
         let nonce = account.nonce * (1 - is_deploy_tx) + is_deploy_tx;
         let account = Account.set_nonce(account, nonce);
         let state = State.set_account(state, address, account);

--- a/src/kakarot/state.cairo
+++ b/src/kakarot/state.cairo
@@ -5,7 +5,7 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
-from starkware.cairo.common.dict import dict_read, dict_write
+from starkware.cairo.common.dict import dict_read, dict_write, dict_squash
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.hash_state import hash_finalize, hash_init, hash_update, hash_felts
 from starkware.cairo.common.math import assert_not_zero
@@ -13,8 +13,7 @@ from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_add, uint256_sub, uint256_le
 from starkware.starknet.common.storage import normalize_address
-from starkware.starknet.common.syscalls import call_contract
-from starkware.starknet.common.syscalls import emit_event
+from starkware.starknet.common.syscalls import call_contract, emit_event, get_contract_address
 
 from kakarot.account import Account
 from kakarot.storages import native_token_address, contract_account_class_hash
@@ -122,6 +121,7 @@ namespace State {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(self: Summary*) {
+        alloc_locals;
         // Accounts
         Internals._commit_accounts(self.accounts_start, self.accounts);
 
@@ -130,7 +130,11 @@ namespace State {
 
         // Transfers
         let (native_token_address_) = native_token_address.read();
-        Internals._transfer_eth(native_token_address_, self.transfers_len, self.transfers);
+        let accounts = self.accounts;
+        Internals._transfer_eth{accounts=accounts}(
+            native_token_address_, self.transfers_len, self.transfers
+        );
+        dict_squash(self.accounts_start, accounts);
 
         return ();
     }
@@ -435,17 +439,34 @@ namespace Internals {
     //      Kakarot is not authorized for accounts that are created and SELDESTRUCT in the same transaction
     // @param transfers_len The length of the transfers array.
     // @param transfers The array of Transfer.
-    func _transfer_eth{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        token_address: felt, transfers_len: felt, transfers: model.Transfer*
-    ) {
+    func _transfer_eth{
+        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, accounts: DictAccess*
+    }(token_address: felt, transfers_len: felt, transfers: model.Transfer*) {
         if (transfers_len == 0) {
             return ();
         }
 
         let transfer = [transfers];
-        IERC20.transferFrom(
-            token_address, transfer.sender.starknet, transfer.recipient.starknet, transfer.amount
-        );
+
+        let (kakarot_address) = get_contract_address();
+        let (pointer) = dict_read{dict_ptr=accounts}(key=transfer.recipient.starknet);
+        let recipient = cast(pointer, model.Account*);
+        let recipient_address = recipient.selfdestruct * kakarot_address + (
+            1 - recipient.selfdestruct
+        ) * transfer.recipient.starknet;
+        let (pointer) = dict_read{dict_ptr=accounts}(key=transfer.sender.starknet);
+        let sender = cast(pointer, model.Account*);
+        let sender_address = sender.selfdestruct * kakarot_address + (1 - sender.selfdestruct) *
+            transfer.sender.starknet;
+
+        // The default ERC20.transferFrom implementation raises even if sender = caller
+        // when there is no prior approval
+        if (sender_address == kakarot_address) {
+            IERC20.transfer(token_address, recipient_address, transfer.amount);
+            return _transfer_eth(token_address, transfers_len - 1, transfers + model.Transfer.SIZE);
+        }
+
+        IERC20.transferFrom(token_address, sender_address, recipient_address, transfer.amount);
         return _transfer_eth(token_address, transfers_len - 1, transfers + model.Transfer.SIZE);
     }
 }

--- a/src/kakarot/state.cairo
+++ b/src/kakarot/state.cairo
@@ -449,15 +449,22 @@ namespace Internals {
         let transfer = [transfers];
 
         let (kakarot_address) = get_contract_address();
+
         let (pointer) = dict_read{dict_ptr=accounts}(key=transfer.recipient.starknet);
         let recipient = cast(pointer, model.Account*);
-        let recipient_address = recipient.selfdestruct * kakarot_address + (
-            1 - recipient.selfdestruct
+        let is_recipient_registered = Account.is_registered(recipient.address);
+        let use_kakarot_for_recipient = recipient.selfdestruct * (1 - is_recipient_registered);
+        let recipient_address = use_kakarot_for_recipient * kakarot_address + (
+            1 - use_kakarot_for_recipient
         ) * transfer.recipient.starknet;
+
         let (pointer) = dict_read{dict_ptr=accounts}(key=transfer.sender.starknet);
         let sender = cast(pointer, model.Account*);
-        let sender_address = sender.selfdestruct * kakarot_address + (1 - sender.selfdestruct) *
-            transfer.sender.starknet;
+        let is_sender_registered = Account.is_registered(sender.address);
+        let use_kakarot_for_sender = sender.selfdestruct * (1 - is_sender_registered);
+        let sender_address = use_kakarot_for_sender * kakarot_address + (
+            1 - use_kakarot_for_sender
+        ) * transfer.sender.starknet;
 
         // The default ERC20.transferFrom implementation raises even if sender = caller
         // when there is no prior approval


### PR DESCRIPTION
Time spent on this PR: 0.2

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When a newly deployed contract calls SELFDESTRUCT, it's never deployed on Starknet and consequently
Kakarot is not allowed to `transferFrom` its contract.

The Cairo VM hence raises in `state.commit`.

## What is the new behavior?

In `State.commit`, when executing transfer to a newly deployed selfdestructed contract, uses
the Kakarot contract instead as temporary ETH holders.

Note: I have eventually realized that separating the balance from the rest of the Account "to save on loading bytecode just to send ETH" is indeed a nonsense because there is only two ways to send ETH without requiring the bytecode:
- the initial `value` of a tx, hence the sender is an EOA and loading its bytecode is just loading empty code so cheap
- the recipient of SELFDESTRUCT

Consequently, I think that the balance would be better re-integrated into the Account, but I don't know if the refacto is worth it per se. Maybe if we remove completely the ERC20, then we can do it in the meantime.