### PR TITLE
Fix bytecode is not written when starknet contract already exists

### DIFF
--- a/scripts/utils/kakarot.py
+++ b/scripts/utils/kakarot.py
@@ -415,12 +415,12 @@ async def store_bytecode(bytecode: Union[str, bytes], **kwargs):
     )
     assert success
     starknet_address, evm_address = response
-    stored_bytecode = await get_bytecode(evm_address)
+    stored_bytecode = await eth_get_code(evm_address)
     assert stored_bytecode == bytecode
     return evm_address
 
 
-async def get_bytecode(address: Union[int, str]):
+async def eth_get_code(address: Union[int, str]):
     starknet_address = await compute_starknet_address(address)
     return bytes(
         (

--- a/solidity_contracts/tests/PlainOpcodes.t.sol
+++ b/solidity_contracts/tests/PlainOpcodes.t.sol
@@ -79,7 +79,7 @@ contract PlainOpcodesTest is Test {
         assertEq(_address_1, address(0));
     }
 
-    function testSelfDestructAndCreateAgainCollision() public {
+    function testCreate2CollisionReturnsZeroAddress() public {
         bytes memory bytecode = type(ContractWithSelfdestructMethod).creationCode;
         uint256 salt = 1234;
         address _address_0;

--- a/solidity_contracts/tests/PlainOpcodes.t.sol
+++ b/solidity_contracts/tests/PlainOpcodes.t.sol
@@ -63,17 +63,35 @@ contract PlainOpcodesTest is Test {
         assert(keccak256(bytes(errorMessage)) == keccak256("FAIL"));
     }
 
-    function testSelfDestructAndCreateAgain() public {
+    function testSelfDestructAndCreateAgainCollisionAfterKill() public {
         bytes memory bytecode = type(ContractWithSelfdestructMethod).creationCode;
         uint256 salt = 1234;
-        address addr = plainOpcodes.create2(bytecode, salt);
-        ContractWithSelfdestructMethod contract_ = ContractWithSelfdestructMethod(addr);
-        contract_.inc();
+        address _address_0;
+        assembly {
+            _address_0 := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+        ContractWithSelfdestructMethod contract_ = ContractWithSelfdestructMethod(_address_0);
         contract_.kill();
-        plainOpcodes.create2(bytecode, salt);
-        contract_.inc();
-        uint256 count = contract_.count();
-        assertEq(count, 2);
+        address _address_1;
+        assembly {
+            _address_1 := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+        assertEq(_address_1, address(0));
+    }
+
+    function testSelfDestructAndCreateAgainCollision() public {
+        bytes memory bytecode = type(ContractWithSelfdestructMethod).creationCode;
+        uint256 salt = 1234;
+        address _address_0;
+        assembly {
+            _address_0 := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+        assertGt(uint160(_address_0), 0);
+        address _address_1;
+        assembly {
+            _address_1 := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+        assertEq(_address_1, address(0));
     }
 
     function testCreate() public {

--- a/src/data_availability/starknet.cairo
+++ b/src/data_availability/starknet.cairo
@@ -173,6 +173,13 @@ namespace Internals {
         // Save storages
         Internals._save_storage(starknet_address, self.storage_start, self.storage);
 
+        // Update bytecode if required (SELFDESTRUCTed contract, redeployed)
+        let (bytecode_len) = IAccount.bytecode_len(starknet_address);
+        if (bytecode_len != self.code_len) {
+            IContractAccount.write_bytecode(starknet_address, self.code_len, self.code);
+            return ();
+        }
+
         return ();
     }
 

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -334,3 +334,13 @@ def eth_send_transaction(max_fee, owner):
     return partial(
         eth_send_transaction, max_fee=max_fee, caller_eoa=owner.starknet_contract
     )
+
+
+@pytest.fixture
+def eth_get_code():
+    """
+    Send a decoded transaction to Kakarot.
+    """
+    from scripts.utils.kakarot import eth_get_code
+
+    return eth_get_code


### PR DESCRIPTION
Time spent on this PR: 0.3

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Resolves #821

## What is the new behavior?

Overwrite bytecode if stored bytecode len doesn't match account.code_len
