### PR TITLE
Halt ctx in SELFDESTRUCT

### DIFF
--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -358,6 +358,10 @@ namespace SystemOperations {
         let account = Account.selfdestruct(account);
         let state = State.set_account(state, ctx.call_context.address, account);
 
+        // Halt context
+        let (return_data: felt*) = alloc();
+        let ctx = ExecutionContext.stop(ctx, 0, return_data, FALSE);
+
         let ctx = ExecutionContext.update_state(ctx, state);
         let ctx = ExecutionContext.update_stack(ctx, stack);
 


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`ctx` is returned but not halted

Resolves #816

## What is the new behavior?

Halted as per the https://github.com/ethereum/execution-specs/blob/3fe6514f2d9d234e760d11af883a47c1263eff51/src/ethereum/shanghai/vm/instructions/system.py#L533
