### PR TITLE
ci: use ef-tests main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: kkrt-labs/ef-tests
-          ref: feat/move-signature-location
       - name: Checkout local skip file
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
ci: use ef-tests main branch since signature location change has been merged