### PR TITLE
Fix stack output casting

### DIFF
--- a/src/kakarot/errors.cairo
+++ b/src/kakarot/errors.cairo
@@ -75,7 +75,7 @@ namespace Errors {
 
     func invalidJumpDestError() -> (error_len: felt, error: felt*) {
         let (error) = get_label_location(invalid_jump_dest_message);
-        return (34, error);
+        return (29, error);
 
         invalid_jump_dest_message:
         dw 'K';
@@ -87,67 +87,26 @@ namespace Errors {
         dw 't';
         dw ':';
         dw ' ';
-        dw 'P';
-        dw 'r';
-        dw 'o';
-        dw 'g';
-        dw 'r';
+        dw 'i';
+        dw 'n';
+        dw 'v';
         dw 'a';
+        dw 'l';
+        dw 'i';
+        dw 'd';
+        dw 'J';
+        dw 'u';
         dw 'm';
-        dw 'C';
-        dw 'o';
-        dw 'u';
-        dw 'n';
-        dw 't';
+        dw 'p';
+        dw 'D';
         dw 'e';
+        dw 's';
+        dw 't';
+        dw 'E';
         dw 'r';
-        dw 'O';
+        dw 'r';
         dw 'o';
-        dw 'u';
-        dw 't';
-        dw 'O';
-        dw 'f';
-        dw 'R';
-        dw 'a';
-        dw 'n';
-        dw 'g';
-        dw 'e';
-    }
-
-    func jumpToNonJumpdest() -> (error_len: felt, error: felt*) {
-        let (error) = get_label_location(jumpdest_error_message);
-        return (29, error);
-
-        jumpdest_error_message:
-        dw 75;  // K
-        dw 97;  // a
-        dw 107;  // k
-        dw 97;  // a
-        dw 114;  // r
-        dw 111;  // o
-        dw 116;  // t
-        dw 58;  // :
-        dw 32;  //
-        dw 74;  // J
-        dw 85;  // U
-        dw 77;  // M
-        dw 80;  // P
-        dw 32;  //
-        dw 116;  // t
-        dw 111;  // o
-        dw 32;  //
-        dw 110;  // n
-        dw 111;  // o
-        dw 110;  // n
-        dw 32;  //
-        dw 74;  // J
-        dw 85;  // U
-        dw 77;  // M
-        dw 80;  // P
-        dw 68;  // D
-        dw 69;  // E
-        dw 83;  // S
-        dw 84;  // T
+        dw 'r';
     }
 
     func callerNotKakarotAccount() -> (error_len: felt, error: felt*) {

--- a/src/kakarot/errors.cairo
+++ b/src/kakarot/errors.cairo
@@ -73,44 +73,45 @@ namespace Errors {
         dw 101;  // e'
     }
 
-    func programCounterOutOfRange() -> (error_len: felt, error: felt*) {
-        let (error) = get_label_location(pc_oor_error_message);
-        return (33, error);
+    func invalidJumpDestError() -> (error_len: felt, error: felt*) {
+        let (error) = get_label_location(invalid_jump_dest_message);
+        return (34, error);
 
-        pc_oor_error_message:
-        dw 75;  // K
-        dw 97;  // a
-        dw 107;  // k
-        dw 97;  // a
-        dw 114;  // r
-        dw 111;  // o
-        dw 116;  // t
-        dw 58;  // :
-        dw 32;  //
-        dw 80;  // P
-        dw 114;  // r
-        dw 111;  // o
-        dw 103;  // g
-        dw 114;  // r
-        dw 97;  // a
-        dw 109;  // m
-        dw 67;  // C
-        dw 111;  // o
-        dw 117;  // u
-        dw 110;  // n
-        dw 116;  // t
-        dw 101;  // e
-        dw 114;  // r
-        dw 79;  // O
-        dw 117;  // u
-        dw 116;  // t
-        dw 79;  // O
-        dw 102;  // f
-        dw 82;  // R
-        dw 97;  // a
-        dw 110;  // n
-        dw 103;  // g
-        dw 101;  // e
+        invalid_jump_dest_message:
+        dw 'K';
+        dw 'a';
+        dw 'k';
+        dw 'a';
+        dw 'r';
+        dw 'o';
+        dw 't';
+        dw ':';
+        dw ' ';
+        dw 'P';
+        dw 'r';
+        dw 'o';
+        dw 'g';
+        dw 'r';
+        dw 'a';
+        dw 'm';
+        dw 'C';
+        dw 'o';
+        dw 'u';
+        dw 'n';
+        dw 't';
+        dw 'e';
+        dw 'r';
+        dw 'O';
+        dw 'o';
+        dw 'u';
+        dw 't';
+        dw 'O';
+        dw 'f';
+        dw 'R';
+        dw 'a';
+        dw 'n';
+        dw 'g';
+        dw 'e';
     }
 
     func jumpToNonJumpdest() -> (error_len: felt, error: felt*) {

--- a/src/kakarot/evm.cairo
+++ b/src/kakarot/evm.cairo
@@ -170,7 +170,7 @@ namespace EVM {
         }
 
         if ([self.message.bytecode + new_pc_offset] != 0x5b) {
-            let (revert_reason_len, revert_reason) = Errors.jumpToNonJumpdest();
+            let (revert_reason_len, revert_reason) = Errors.invalidJumpDestError();
             let evm = EVM.stop(self, revert_reason_len, revert_reason, TRUE);
             return evm;
         }

--- a/src/kakarot/evm.cairo
+++ b/src/kakarot/evm.cairo
@@ -164,7 +164,7 @@ namespace EVM {
     func jump{range_check_ptr}(self: model.EVM*, new_pc_offset: felt) -> model.EVM* {
         let out_of_range = is_le(self.message.bytecode_len, new_pc_offset);
         if (out_of_range != FALSE) {
-            let (revert_reason_len, revert_reason) = Errors.programCounterOutOfRange();
+            let (revert_reason_len, revert_reason) = Errors.invalidJumpDestError();
             let evm = EVM.stop(self, revert_reason_len, revert_reason, TRUE);
             return evm;
         }

--- a/src/kakarot/gas.cairo
+++ b/src/kakarot/gas.cairo
@@ -85,7 +85,7 @@ namespace Gas {
     }
 
     // @notive A proxy function for memory_expansion_cost that matches the actual computation
-    //         when words_len and max_offset are within range_check and returns a factor of the given
+    //         when offset and size are within range_check and returns a factor of the given
     //         oog_cost otherwise, so as to trigger an OOG in any case but to avoid the more expensive
     //         Uint256 based computing.
     // @param words_len The current length of the memory as Uint256.

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -6,6 +6,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.cairo_keccak.keccak import cairo_keccak_bigend, finalize_keccak
+from starkware.cairo.common.memset import memset
 
 from kakarot.account import Account
 from kakarot.evm import EVM
@@ -162,38 +163,35 @@ namespace EnvironmentalInformation {
         let offset = popped[1];
         let size = popped[2];
 
-        let (sliced_calldata: felt*) = alloc();
-        slice(
-            sliced_calldata, evm.message.calldata_len, evm.message.calldata, offset.low, size.low
-        );
-
-        // Write caldata slice to memory at dest_offset
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, dest_offset.low + size.low
+        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
+            memory.words_len, dest_offset, size, evm.gas_left
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
             return evm;
         }
+
+        let (sliced_calldata: felt*) = alloc();
+        if (offset.high != 0) {
+            memset(sliced_calldata, 0, size.low);
+            tempvar range_check_ptr = range_check_ptr;
+        } else {
+            slice(
+                sliced_calldata,
+                evm.message.calldata_len,
+                evm.message.calldata,
+                offset.low,
+                size.low,
+            );
+        }
+        let range_check_ptr = [ap - 1];
+
         Memory.store_n(size.low, sliced_calldata, dest_offset.low);
 
         return evm;
     }
 
-    func exec_codesize{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-        stack: model.Stack*,
-        memory: model.Memory*,
-        state: model.State*,
-    }(evm: model.EVM*) -> model.EVM* {
-        Stack.push_uint128(evm.message.bytecode_len);
-        return evm;
-    }
-
-    func exec_codecopy{
+    func exec_copy{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
@@ -209,19 +207,56 @@ namespace EnvironmentalInformation {
         let offset = popped[1];
         let size = popped[2];
 
-        let (local sliced_code: felt*) = alloc();
-        slice(sliced_code, evm.message.bytecode_len, evm.message.bytecode, offset.low, size.low);
-
-        // Write bytecode slice to memory at dest_offset
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, dest_offset.low + size.low
+        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
+            memory.words_len, dest_offset, size, evm.gas_left
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
             return evm;
         }
-        Memory.store_n(size.low, sliced_code, dest_offset.low);
 
+        let (sliced_data: felt*) = alloc();
+        if (offset.high != 0) {
+            memset(sliced_data, 0, size.low);
+            tempvar range_check_ptr = range_check_ptr;
+        } else {
+            // 0x37: calldatacopy
+            // 0x39: codecopy
+            // 0x3e: returndatacopy
+            local data_len;
+            local data: felt*;
+            let opcode_number = [evm.message.bytecode + evm.program_counter];
+            if (opcode_number == 0x37) {
+                assert data_len = evm.message.calldata_len;
+                assert data = evm.message.calldata;
+            } else {
+                if (opcode_number == 0x39) {
+                    assert data_len = evm.message.bytecode_len;
+                    assert data = evm.message.bytecode;
+                } else {
+                    assert data_len = evm.return_data_len;
+                    assert data = evm.return_data;
+                }
+            }
+            slice(sliced_data, data_len, data, offset.low, size.low);
+        }
+        let range_check_ptr = [ap - 1];
+
+        Memory.store_n(size.low, sliced_data, dest_offset.low);
+
+        return evm;
+    }
+
+    func exec_codesize{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+        stack: model.Stack*,
+        memory: model.Memory*,
+        state: model.State*,
+    }(evm: model.EVM*) -> model.EVM* {
+        Stack.push_uint128(evm.message.bytecode_len);
         return evm;
     }
 
@@ -281,23 +316,28 @@ namespace EnvironmentalInformation {
         let offset = popped[2];
         let size = popped[3];
 
-        let evm_address = uint256_to_uint160(popped[0]);
-        let (starknet_address) = Account.compute_starknet_address(evm_address);
-        tempvar address = new model.Address(starknet_address, evm_address);
-        let account = State.get_account(address);
-
-        let (sliced_bytecode: felt*) = alloc();
-        slice(sliced_bytecode, account.code_len, account.code, offset.low, size.low);
-
-        // Write bytecode slice to memory at dest_offset
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, dest_offset.low + size.low
+        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
+            memory.words_len, dest_offset, size, evm.gas_left
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
             return evm;
         }
-        Memory.store_n(size.low, sliced_bytecode, dest_offset.low);
+
+        let (sliced_data: felt*) = alloc();
+        if (offset.high != 0) {
+            memset(sliced_data, 0, size.low);
+            tempvar range_check_ptr = range_check_ptr;
+        } else {
+            let evm_address = uint256_to_uint160(popped[0]);
+            let (starknet_address) = Account.compute_starknet_address(evm_address);
+            tempvar address = new model.Address(starknet_address, evm_address);
+            let account = State.get_account(address);
+            slice(sliced_data, account.code_len, account.code, offset.low, size.low);
+        }
+        let range_check_ptr = [ap - 1];
+
+        Memory.store_n(size.low, sliced_data, dest_offset.low);
 
         return evm;
     }
@@ -312,36 +352,6 @@ namespace EnvironmentalInformation {
         state: model.State*,
     }(evm: model.EVM*) -> model.EVM* {
         Stack.push_uint128(evm.return_data_len);
-        return evm;
-    }
-
-    func exec_returndatacopy{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-        stack: model.Stack*,
-        memory: model.Memory*,
-        state: model.State*,
-    }(evm: model.EVM*) -> model.EVM* {
-        alloc_locals;
-
-        let (popped) = Stack.pop_n(3);
-        let dest_offset = popped[0];
-        let offset = popped[1];
-        let size = popped[2];
-
-        let sliced_return_data: felt* = alloc();
-        slice(sliced_return_data, evm.return_data_len, evm.return_data, offset.low, size.low);
-
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, dest_offset.low + size.low
-        );
-        let evm = EVM.charge_gas(evm, memory_expansion_cost);
-        if (evm.reverted != FALSE) {
-            return evm;
-        }
-        Memory.store_n(size.low, sliced_return_data, dest_offset.low);
         return evm;
     }
 

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -163,8 +163,8 @@ namespace EnvironmentalInformation {
         let offset = popped[1];
         let size = popped[2];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, dest_offset, size, evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, dest_offset, size
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
@@ -272,8 +272,8 @@ namespace EnvironmentalInformation {
         let offset = popped[2];
         let size = popped[3];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, dest_offset, size, evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, dest_offset, size
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -120,6 +120,11 @@ namespace EnvironmentalInformation {
 
         let (offset) = Stack.pop();
 
+        if (offset.high != 0) {
+            Stack.push_uint128(0);
+            return evm;
+        }
+
         let (sliced_calldata: felt*) = alloc();
         slice(sliced_calldata, evm.message.calldata_len, evm.message.calldata, offset.low, 32);
         let calldata = Helpers.bytes32_to_uint256(sliced_calldata);

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -325,17 +325,11 @@ namespace EnvironmentalInformation {
         }
 
         let (sliced_data: felt*) = alloc();
-        if (offset.high != 0) {
-            memset(sliced_data, 0, size.low);
-            tempvar range_check_ptr = range_check_ptr;
-        } else {
-            let evm_address = uint256_to_uint160(popped[0]);
-            let (starknet_address) = Account.compute_starknet_address(evm_address);
-            tempvar address = new model.Address(starknet_address, evm_address);
-            let account = State.get_account(address);
-            slice(sliced_data, account.code_len, account.code, offset.low, size.low);
-        }
-        let range_check_ptr = [ap - 1];
+        let evm_address = uint256_to_uint160(popped[0]);
+        let (starknet_address) = Account.compute_starknet_address(evm_address);
+        tempvar address = new model.Address(starknet_address, evm_address);
+        let account = State.get_account(address);
+        slice(sliced_data, account.code_len, account.code, offset.low, size.low);
 
         Memory.store_n(size.low, sliced_data, dest_offset.low);
 

--- a/src/kakarot/instructions/logging_operations.cairo
+++ b/src/kakarot/instructions/logging_operations.cairo
@@ -50,8 +50,8 @@ namespace LoggingOperations {
         let offset = popped[0];
         let size = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, offset, size, evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, offset, size
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -110,7 +110,7 @@ namespace MemoryOperations {
         let (offset) = Stack.pop();
 
         if (offset.high != 0) {
-            let (revert_reason_len, revert_reason) = Errors.programCounterOutOfRange();
+            let (revert_reason_len, revert_reason) = Errors.invalidJumpDestError();
             let evm = EVM.stop(evm, revert_reason_len, revert_reason, TRUE);
             return evm;
         }
@@ -140,7 +140,7 @@ namespace MemoryOperations {
         }
 
         if (offset.high != 0) {
-            let (revert_reason_len, revert_reason) = Errors.programCounterOutOfRange();
+            let (revert_reason_len, revert_reason) = Errors.invalidJumpDestError();
             let evm = EVM.stop(evm, revert_reason_len, revert_reason, TRUE);
             return evm;
         }

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -30,8 +30,8 @@ namespace MemoryOperations {
 
         let (offset) = Stack.pop();
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, [offset], Uint256(32, 0), evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, [offset], Uint256(32, 0)
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
@@ -59,8 +59,8 @@ namespace MemoryOperations {
         let offset = popped[0];
         let value = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, offset, Uint256(32, 0), evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, offset, Uint256(32, 0)
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
@@ -191,8 +191,8 @@ namespace MemoryOperations {
         let offset = popped[0];
         let value = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, offset, Uint256(1, 0), evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, offset, Uint256(1, 0)
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {

--- a/src/kakarot/instructions/push_operations.cairo
+++ b/src/kakarot/instructions/push_operations.cairo
@@ -26,7 +26,6 @@ namespace PushOperations {
     }(evm: model.EVM*) -> model.EVM* {
         alloc_locals;
 
-        // See evm.cairo, pc is increased before entering the opcode
         let opcode_number = [evm.message.bytecode + evm.program_counter];
         let i = opcode_number - 0x5f;
 

--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -29,10 +29,10 @@ namespace Sha3 {
 
         let (popped) = Stack.pop_n(2);
         let offset = popped[0];
-        let length = popped[1];
+        let size = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, offset.low + length.low
+        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
+            memory.words_len, offset, size, evm.gas_left
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
@@ -40,16 +40,16 @@ namespace Sha3 {
         }
 
         let (bigendian_data: felt*) = alloc();
-        Memory.load_n(length.low, bigendian_data, offset.low);
+        Memory.load_n(size.low, bigendian_data, offset.low);
 
         let (local dst: felt*) = alloc();
-        bytes_to_bytes8_little_endian(dst, length.low, bigendian_data);
+        bytes_to_bytes8_little_endian(dst, size.low, bigendian_data);
 
         let (keccak_ptr: felt*) = alloc();
         local keccak_ptr_start: felt* = keccak_ptr;
 
         with keccak_ptr {
-            let (result) = cairo_keccak_bigend(dst, length.low);
+            let (result) = cairo_keccak_bigend(dst, size.low);
         }
         finalize_keccak(keccak_ptr_start=keccak_ptr_start, keccak_ptr_end=keccak_ptr);
 

--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -31,8 +31,8 @@ namespace Sha3 {
         let offset = popped[0];
         let size = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, offset, size, evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, offset, size
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -585,6 +585,7 @@ namespace CallHelper {
 
         // Pop ret_offset and ret_size
         // See init_sub_context, the Stack here is guaranteed to have enough items
+        // values are checked there as Memory expansion cost is computed there.
         let (popped) = Stack.pop_n(n=2);
         let ret_offset = popped[0];
         let ret_size = popped[1];

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -211,8 +211,8 @@ namespace SystemOperations {
         let offset = popped[0];
         let size = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, offset.low + size.low
+        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
+            memory.words_len, offset, size, evm.gas_left
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
@@ -250,8 +250,8 @@ namespace SystemOperations {
         let offset = popped[0];
         let size = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, offset.low + size.low
+        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
+            memory.words_len, offset, size, evm.gas_left
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -57,14 +57,9 @@ namespace SystemOperations {
         // + extend_memory.cost
         // + init_code_gas
         // + is_create2 * GAS_KECCAK256_WORD * call_data_words
-        let memory_expansion_cost = Gas.memory_expansion_cost(
-            memory.words_len, offset.low + size.low
+        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
+            memory.words_len, offset, size, evm.gas_left
         );
-        // If .high != 0, OOG is surely triggered. So we only use the .low part for the
-        // actual computation, and add evm.gas_left * .high which would
-        // either be 0 or evm.gas_left * k, thus triggering OOG.
-        let memory_expansion_cost = evm.gas_left * (offset.high + size.high) +
-            memory_expansion_cost;
         let (calldata_words, _) = unsigned_div_rem(size.low + 31, 31);
         let init_code_gas = Gas.INIT_CODE_WORD_COST * calldata_words;
         let calldata_word_gas = is_create2 * Gas.KECCAK256_WORD * calldata_words;

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -57,8 +57,8 @@ namespace SystemOperations {
         // + extend_memory.cost
         // + init_code_gas
         // + is_create2 * GAS_KECCAK256_WORD * call_data_words
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, offset, size, evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, offset, size
         );
         let (calldata_words, _) = unsigned_div_rem(size.low + 31, 31);
         let init_code_gas = Gas.INIT_CODE_WORD_COST * calldata_words;
@@ -211,8 +211,8 @@ namespace SystemOperations {
         let offset = popped[0];
         let size = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, offset, size, evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, offset, size
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
@@ -250,8 +250,8 @@ namespace SystemOperations {
         let offset = popped[0];
         let size = popped[1];
 
-        let memory_expansion_cost = Gas.memory_expansion_cost_proxy(
-            memory.words_len, offset, size, evm.gas_left
+        let memory_expansion_cost = Gas.memory_expansion_cost_saturated(
+            memory.words_len, offset, size
         );
         let evm = EVM.charge_gas(evm, memory_expansion_cost);
         if (evm.reverted != FALSE) {
@@ -489,10 +489,10 @@ namespace CallHelper {
             1 - max_expansion_is_ret
         ) * (args_offset.low + args_size.low);
         let memory_expansion_cost = Gas.memory_expansion_cost(memory.words_len, max_expansion);
-        // See Gas.memory_expansion_cost_proxy for more details
+        // See Gas.memory_expansion_cost_saturated for more details
         let memory_expansion_cost = memory_expansion_cost + (
             args_offset.high + args_size.high + ret_offset.high + ret_size.high
-        ) * evm.gas_left;
+        ) * Gas.MEMORY_COST_U128;
 
         // Access list
         // TODO

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -469,27 +469,30 @@ namespace CallHelper {
         // See finalize_parent
         // Pop ret_offset and ret_size
         let (popped) = Stack.pop_n(4 + with_value);
-        let (ret_offset_uint256) = Stack.peek(0);
-        let (ret_size_uint256) = Stack.peek(1);
-
         let gas = popped[0];
         let address = uint256_to_uint160(popped[1]);
-        let stack_value = (2 ** 128 * popped[2].high + popped[2].low) * with_value;
-        // If the call op expects value to be on the stack, we return it
-        // Otherwise, the value is the calling call context value
-        let value = with_value * stack_value + (1 - with_value) * evm.message.value;
-        let args_offset = 2 ** 128 * popped[2 + with_value].high + popped[2 + with_value].low;
-        let args_size = 2 ** 128 * popped[3 + with_value].high + popped[3 + with_value].low;
-        let ret_offset = 2 ** 128 * ret_offset_uint256.high + ret_offset_uint256.low;
-        let ret_size = 2 ** 128 * ret_size_uint256.high + ret_size_uint256.low;
+        let stack_value = popped[2];
+        let args_offset = popped[2 + with_value];
+        let args_size = popped[3 + with_value];
+        let (ret_offset) = Stack.peek(0);
+        let (ret_size) = Stack.peek(1);
+
+        // TODO: fix value when refactoring CALLs for proper gas accounting
+        let value = with_value * stack_value.low + (1 - with_value) * evm.message.value;
 
         // 2. Gas
         // Memory expansion cost
-        let max_expansion_is_ret = is_le(args_offset + args_size, ret_offset + ret_size);
-        let max_expansion = max_expansion_is_ret * (ret_offset + ret_size) + (
+        let max_expansion_is_ret = is_le(
+            args_offset.low + args_size.low, ret_offset.low + ret_size.low
+        );
+        let max_expansion = max_expansion_is_ret * (ret_offset.low + ret_size.low) + (
             1 - max_expansion_is_ret
-        ) * (args_offset + args_size);
+        ) * (args_offset.low + args_size.low);
         let memory_expansion_cost = Gas.memory_expansion_cost(memory.words_len, max_expansion);
+        // See Gas.memory_expansion_cost_proxy for more details
+        let memory_expansion_cost = memory_expansion_cost + (
+            args_offset.high + args_size.high + ret_offset.high + ret_size.high
+        ) * evm.gas_left;
 
         // Access list
         // TODO
@@ -518,7 +521,7 @@ namespace CallHelper {
 
         // 3. Calldata
         let (calldata: felt*) = alloc();
-        Memory.load_n(args_size, calldata, args_offset);
+        Memory.load_n(args_size.low, calldata, args_offset.low);
 
         // 4. Build child_evm
         // Check if the called address is a precompiled contract
@@ -527,7 +530,7 @@ namespace CallHelper {
             tempvar parent = new model.Parent(evm, stack, memory, state);
             let child_evm = Precompiles.run(
                 evm_address=address,
-                calldata_len=args_size,
+                calldata_len=args_size.low,
                 calldata=calldata,
                 value=value,
                 parent=parent,
@@ -554,7 +557,7 @@ namespace CallHelper {
             bytecode=account.code,
             bytecode_len=account.code_len,
             calldata=calldata,
-            calldata_len=args_size,
+            calldata_len=args_size.low,
             value=value,
             parent=parent,
             address=message_address,
@@ -583,16 +586,16 @@ namespace CallHelper {
         // Pop ret_offset and ret_size
         // See init_sub_context, the Stack here is guaranteed to have enough items
         let (popped) = Stack.pop_n(n=2);
-        let ret_offset = 2 ** 128 * popped[0].high + popped[0].low;
-        let ret_size = 2 ** 128 * popped[1].high + popped[1].low;
+        let ret_offset = popped[0];
+        let ret_size = popped[1];
 
         // Put status in stack
         Stack.push_uint128(1 - evm.reverted);
 
         // Store RETURN_DATA in memory
         let (return_data: felt*) = alloc();
-        slice(return_data, evm.return_data_len, evm.return_data, 0, ret_size);
-        Memory.store_n(ret_size, return_data, ret_offset);
+        slice(return_data, evm.return_data_len, evm.return_data, 0, ret_size.low);
+        Memory.store_n(ret_size.low, return_data, ret_offset.low);
 
         // Gas not used is returned when evm is not reverted
         local gas_left;

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -223,11 +223,11 @@ namespace Interpreter {
         jmp end;
         call EnvironmentalInformation.exec_calldatasize;  // 0x36
         jmp end;
-        call EnvironmentalInformation.exec_calldatacopy;  // 0x37
+        call EnvironmentalInformation.exec_copy;  // 0x37
         jmp end;
         call EnvironmentalInformation.exec_codesize;  // 0x38
         jmp end;
-        call EnvironmentalInformation.exec_codecopy;  // 0x39
+        call EnvironmentalInformation.exec_copy;  // 0x39
         jmp end;
         call EnvironmentalInformation.exec_gasprice;  // 0x3a
         jmp end;
@@ -237,7 +237,7 @@ namespace Interpreter {
         jmp end;
         call EnvironmentalInformation.exec_returndatasize;  // 0x3d
         jmp end;
-        call EnvironmentalInformation.exec_returndatacopy;  // 0x3e
+        call EnvironmentalInformation.exec_copy;  // 0x3e
         jmp end;
         call EnvironmentalInformation.exec_extcodehash;  // 0x3f
         jmp end;

--- a/tests/src/kakarot/test_execution_context.py
+++ b/tests/src/kakarot/test_execution_context.py
@@ -18,9 +18,9 @@ class TestExecutionContext:
     @pytest.mark.parametrize(
         "jumpdest,new_pc,expected_return_data",
         [
-            (0, 0, list(b"Kakarot: JUMP to non JUMPDEST")),
+            (0, 0, list(b"Kakarot: invalidJumpDestError")),
             (1, 1, []),
-            (2, 0, list(b"Kakarot: ProgramCounterOutOfRange")),
+            (2, 0, list(b"Kakarot: invalidJumpDestError")),
         ],
     )
     async def test_jump(


### PR DESCRIPTION
Time spent on this PR: 1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Stack outputs are Uint256 and they are sometimes casted without checks (either keeping only `.low` or `low + high * 2 ** 128`).

Resolves #855

## What is the new behavior?

Stack values are handled before using `.low`.
