### PR TITLE
feat: valid jumpdests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/blockchain-tests-skip.yml
+++ b/blockchain-tests-skip.yml
@@ -57,8 +57,6 @@ testname:
   vmIOandFlowOperations:
     - gas_d1g0v0_Shanghai
     - gas_d0g0v0_Shanghai
-    - jump_d9g0v0_Shanghai
-    - jumpi_d14g0v0_Shanghai
   vmTests:
     - blockInfo_d1g0v0_Shanghai
     - blockInfo_d0g0v0_Shanghai

--- a/blockchain-tests-skip.yml
+++ b/blockchain-tests-skip.yml
@@ -4214,57 +4214,76 @@ testname:
     - returndatacopy_following_successful_create_d0g0v0_Shanghai
     - returndatasize_following_successful_create_d0g0v0_Shanghai
   stCreateTest:
-    - CREATE_EmptyContractAndCallIt_0wei_d0g0v0_Shanghai
-    - CREATE_EmptyContractWithBalance_d0g0v0_Shanghai
     - CREATE_EContract_ThenCALLToNonExistentAcc_d0g0v0_Shanghai
-    - CREATE_EmptyContractAndCallIt_1wei_d0g0v0_Shanghai
-    - CREATE_EmptyContractWithStorageAndCallIt_0wei_d0g0v0_Shanghai
     - CREATE_EmptyContract_d0g0v0_Shanghai
-    - CREATE_EmptyContractWithStorageAndCallIt_1wei_d0g0v0_Shanghai
+    - CREATE_EmptyContractAndCallIt_0wei_d0g0v0_Shanghai
+    - CREATE_EmptyContractAndCallIt_1wei_d0g0v0_Shanghai
+    - CREATE_EmptyContractWithBalance_d0g0v0_Shanghai
     - CREATE_EmptyContractWithStorage_d0g0v0_Shanghai
+    - CREATE_EmptyContractWithStorageAndCallIt_0wei_d0g0v0_Shanghai
+    - CREATE_EmptyContractWithStorageAndCallIt_1wei_d0g0v0_Shanghai
     - CREATE_HighNonce_d0g0v0_Shanghai
     - CreateAddressWarmAfterFail_d0g0v0_Shanghai
     - CreateAddressWarmAfterFail_d0g0v1_Shanghai
     - CreateAddressWarmAfterFail_d10g0v0_Shanghai
-    - CreateAddressWarmAfterFail_d11g0v0_Shanghai
     - CreateAddressWarmAfterFail_d10g0v1_Shanghai
+    - CreateAddressWarmAfterFail_d11g0v0_Shanghai
     - CreateAddressWarmAfterFail_d11g0v1_Shanghai
     - CreateAddressWarmAfterFail_d12g0v0_Shanghai
     - CreateAddressWarmAfterFail_d12g0v1_Shanghai
-    - CreateAddressWarmAfterFail_d14g0v0_Shanghai
     - CreateAddressWarmAfterFail_d13g0v0_Shanghai
     - CreateAddressWarmAfterFail_d13g0v1_Shanghai
-    - CreateAddressWarmAfterFail_d1g0v0_Shanghai
+    - CreateAddressWarmAfterFail_d14g0v0_Shanghai
     - CreateAddressWarmAfterFail_d14g0v1_Shanghai
+    - CreateAddressWarmAfterFail_d1g0v0_Shanghai
     - CreateAddressWarmAfterFail_d1g0v1_Shanghai
-    - CreateAddressWarmAfterFail_d4g0v0_Shanghai
     - CreateAddressWarmAfterFail_d2g0v0_Shanghai
-    - CreateAddressWarmAfterFail_d3g0v0_Shanghai
-    - CreateAddressWarmAfterFail_d5g0v0_Shanghai
     - CreateAddressWarmAfterFail_d2g0v1_Shanghai
-    - CreateAddressWarmAfterFail_d4g0v1_Shanghai
-    - CreateCollisionToEmpty_d0g0v0_Shanghai
+    - CreateAddressWarmAfterFail_d3g0v0_Shanghai
     - CreateAddressWarmAfterFail_d3g0v1_Shanghai
-    - CreateCollisionToEmpty_d0g0v1_Shanghai
-    - CreateAddressWarmAfterFail_d6g0v0_Shanghai
+    - CreateAddressWarmAfterFail_d4g0v0_Shanghai
+    - CreateAddressWarmAfterFail_d4g0v1_Shanghai
+    - CreateAddressWarmAfterFail_d5g0v0_Shanghai
     - CreateAddressWarmAfterFail_d5g0v1_Shanghai
+    - CreateAddressWarmAfterFail_d6g0v0_Shanghai
     - CreateAddressWarmAfterFail_d6g0v1_Shanghai
+    - CreateAddressWarmAfterFail_d7g0v0_Shanghai
+    - CreateAddressWarmAfterFail_d7g0v1_Shanghai
     - CreateAddressWarmAfterFail_d8g0v0_Shanghai
-    - CreateCollisionToEmpty_d1g0v0_Shanghai
     - CreateAddressWarmAfterFail_d8g0v1_Shanghai
+    - CreateAddressWarmAfterFail_d9g0v0_Shanghai
+    - CreateAddressWarmAfterFail_d9g0v1_Shanghai
+    - CreateCollisionToEmpty_d0g0v0_Shanghai
+    - CreateCollisionToEmpty_d0g0v1_Shanghai
+    - CreateCollisionToEmpty_d1g0v0_Shanghai
     - CreateCollisionToEmpty_d1g0v1_Shanghai
     - CreateCollisionToEmpty_d2g0v0_Shanghai
     - CreateCollisionToEmpty_d2g0v1_Shanghai
-    - CreateAddressWarmAfterFail_d7g0v0_Shanghai
-    - CreateAddressWarmAfterFail_d9g0v0_Shanghai
-    - CreateAddressWarmAfterFail_d7g0v1_Shanghai
-    - CreateAddressWarmAfterFail_d9g0v1_Shanghai
+    - createFailResult_d0g0v0_Shanghai
+    - createFailResult_d1g0v0_Shanghai
+    - createLargeResult_d0g0v0_Shanghai
+    - createLargeResult_d10g0v0_Shanghai
+    - createLargeResult_d11g0v0_Shanghai
+    - createLargeResult_d12g0v0_Shanghai
+    - createLargeResult_d13g0v0_Shanghai
+    - createLargeResult_d14g0v0_Shanghai
+    - createLargeResult_d15g0v0_Shanghai
+    - createLargeResult_d1g0v0_Shanghai
+    - createLargeResult_d2g0v0_Shanghai
+    - createLargeResult_d3g0v0_Shanghai
+    - createLargeResult_d4g0v0_Shanghai
+    - createLargeResult_d5g0v0_Shanghai
+    - createLargeResult_d6g0v0_Shanghai
+    - createLargeResult_d7g0v0_Shanghai
+    - createLargeResult_d8g0v0_Shanghai
+    - createLargeResult_d9g0v0_Shanghai
     - CreateOOGafterInitCodeReturndata_d0g1v0_Shanghai
     - CreateOOGafterInitCodeReturndata3_d0g0v0_Shanghai
     - CreateOOGafterInitCodeRevert2_d1g0v0_Shanghai
+    - CreateOOGafterMaxCodesize_d2g0v0_Shanghai
+    - CreateOOGafterMaxCodesize_d3g0v0_Shanghai
+    - CreateOOGafterMaxCodesize_d5g0v0_Shanghai
     - CreateResults_d0g0v0_Shanghai
-    - CreateTransactionHighNonce_d0g0v0_Shanghai
-    - CreateTransactionHighNonce_d0g0v1_Shanghai
     - CreateResults_d18g0v0_Shanghai
     - CreateResults_d19g0v0_Shanghai
     - CreateResults_d1g0v0_Shanghai
@@ -4274,36 +4293,18 @@ testname:
     - CreateResults_d23g0v0_Shanghai
     - CreateResults_d24g0v0_Shanghai
     - CreateResults_d25g0v0_Shanghai
-    - CreateResults_d3g0v0_Shanghai
-    - TransactionCollisionToEmpty_d0g0v0_Shanghai
     - CreateResults_d2g0v0_Shanghai
+    - CreateResults_d3g0v0_Shanghai
+    - CreateResults_d4g0v0_Shanghai
+    - CreateResults_d5g0v0_Shanghai
     - CreateResults_d6g0v0_Shanghai
     - CreateResults_d7g0v0_Shanghai
     - CreateResults_d8g0v0_Shanghai
     - CreateResults_d9g0v0_Shanghai
-    - CreateResults_d5g0v0_Shanghai
-    - CreateResults_d4g0v0_Shanghai
+    - CreateTransactionHighNonce_d0g0v0_Shanghai
+    - CreateTransactionHighNonce_d0g0v1_Shanghai
+    - TransactionCollisionToEmpty_d0g0v0_Shanghai
     - TransactionCollisionToEmpty_d0g0v1_Shanghai
-    - createFailResult_d0g0v0_Shanghai
-    - createFailResult_d1g0v0_Shanghai
-    - createLargeResult_d0g0v0_Shanghai
-    - createLargeResult_d1g0v0_Shanghai
-    - createLargeResult_d2g0v0_Shanghai
-    - createLargeResult_d3g0v0_Shanghai
-    - createLargeResult_d10g0v0_Shanghai
-    - createLargeResult_d11g0v0_Shanghai
-    - createLargeResult_d6g0v0_Shanghai
-    - createLargeResult_d12g0v0_Shanghai
-    - createLargeResult_d13g0v0_Shanghai
-    - createLargeResult_d14g0v0_Shanghai
-    - createLargeResult_d7g0v0_Shanghai
-    - createLargeResult_d15g0v0_Shanghai
-    - createLargeResult_d8g0v0_Shanghai
-    - createLargeResult_d9g0v0_Shanghai
-    - createLargeResult_d4g0v0_Shanghai
-    - createLargeResult_d5g0v0_Shanghai
-    - CreateOOGafterMaxCodesize_d3g0v0_Shanghai
-    - CreateOOGafterMaxCodesize_d5g0v0_Shanghai
   stDelegatecallTestHomestead:
     - callOutput3_d0g0v0_Shanghai
     - callOutput3partialFail_d0g0v0_Shanghai
@@ -7347,17 +7348,19 @@ testname:
     - TestCryptographicFunctions_d0g0v0_Shanghai
     - RecursiveCreateContracts_d0g0v0_Shanghai
   stSpecialTest:
+    - block504980_d0g0v0_Shanghai
     - eoaEmpty_d0g0v0_Shanghai
     - eoaEmpty_d0g0v1_Shanghai
     - eoaEmpty_d0g1v0_Shanghai
     - eoaEmpty_d0g1v1_Shanghai
-    - sha3_deja_d0g0v0_Shanghai
     - eoaEmpty_d1g0v0_Shanghai
     - eoaEmpty_d1g0v1_Shanghai
     - eoaEmpty_d1g1v0_Shanghai
     - eoaEmpty_d1g1v1_Shanghai
+    - JUMPDEST_Attack_d0g0v0_Shanghai
+    - JUMPDEST_AttackwithJump_d0g0v0_Shanghai
+    - sha3_deja_d0g0v0_Shanghai
     - tx_e1c174e2_d0g0v0_Shanghai
-    - block504980_d0g0v0_Shanghai
   stStackTests:
     - stackOverflowM1DUP_d0g0v0_Shanghai
     - stackOverflowM1DUP_d10g0v0_Shanghai
@@ -7427,24 +7430,58 @@ testname:
   stShift:
     - shiftCombinations_d0g0v0_Shanghai
   stStaticCall:
-    - StaticcallToPrecompileFromCalledContract_d0g0v0_Shanghai
-    - StaticcallToPrecompileFromTransaction_d0g0v0_Shanghai
-    - StaticcallToPrecompileFromContractInitialization_d0g0v0_Shanghai
-    - static_CREATE_EmptyContractAndCallIt_0wei_d0g0v0_Shanghai
-    - static_CREATE_EmptyContractWithStorageAndCallIt_0wei_d0g0v0_Shanghai
+    - static_call_value_inherit_d0g0v0_Shanghai
+    - static_call_value_inherit_from_call_d0g0v0_Shanghai
+    - static_Call1024PreCalls_d1g0v0_Shanghai
+    - static_Call1024PreCalls2_d0g0v0_Shanghai
+    - static_Call1024PreCalls2_d1g0v0_Shanghai
+    - static_Call1024PreCalls3_d1g0v0_Shanghai
+    - static_Call1MB1024Calldepth_d1g0v0_Shanghai
+    - static_Call50000_d0g0v0_Shanghai
+    - static_Call50000_d1g0v0_Shanghai
+    - static_Call50000_ecrec_d0g0v0_Shanghai
+    - static_Call50000_ecrec_d1g0v0_Shanghai
+    - static_Call50000_identity_d0g0v0_Shanghai
+    - static_Call50000_identity_d1g0v0_Shanghai
+    - static_Call50000_identity2_d0g0v0_Shanghai
+    - static_Call50000_identity2_d1g0v0_Shanghai
+    - static_Call50000_rip160_d0g0v0_Shanghai
+    - static_Call50000_rip160_d1g0v0_Shanghai
+    - static_Call50000bytesContract50_1_d0g0v0_Shanghai
+    - static_Call50000bytesContract50_1_d1g0v0_Shanghai
+    - static_Call50000bytesContract50_2_d0g0v0_Shanghai
+    - static_Call50000bytesContract50_2_d1g0v0_Shanghai
+    - static_Call50000bytesContract50_3_d0g0v0_Shanghai
+    - static_Call50000bytesContract50_3_d1g0v0_Shanghai
+    - static_callcallcall_000_OOGMAfter2_d0g0v0_Shanghai
+    - static_callcallcallcode_001_OOGMAfter_3_d1g0v0_Shanghai
+    - static_callcallcallcode_001_OOGMAfter_d1g0v0_Shanghai
+    - static_callcallcallcode_001_OOGMAfter2_d1g0v0_Shanghai
+    - static_callcallcodecall_010_OOGMAfter_2_d1g0v0_Shanghai
+    - static_callcallcodecall_010_OOGMAfter_3_d1g0v0_Shanghai
+    - static_callcallcodecall_010_OOGMAfter_d1g0v0_Shanghai
+    - static_callcodecallcall_100_OOGMAfter_2_d0g0v0_Shanghai
+    - static_callcodecallcall_100_OOGMAfter2_d0g0v0_Shanghai
+    - static_callcodecallcall_100_OOGMAfter2_d0g0v1_Shanghai
+    - static_callcodecallcallcode_101_OOGMAfter_1_d0g0v0_Shanghai
     - static_CallContractToCreateContractOOGBonusGas_d0g1v0_Shanghai
     - static_CallEcrecover0_0input_d1g0v0_Shanghai
     - static_CallEcrecover0_0input_d2g0v0_Shanghai
     - static_CallEcrecover0_0input_d5g0v0_Shanghai
-    - static_CallEcrecover0_0input_d7g0v0_Shanghai
     - static_CallEcrecover0_0input_d6g0v0_Shanghai
-    - static_CallEcrecover80_d0g0v0_Shanghai
+    - static_CallEcrecover0_0input_d7g0v0_Shanghai
     - static_CallEcrecover1_d0g0v0_Shanghai
     - static_CallEcrecover2_d0g0v0_Shanghai
+    - static_CallEcrecover80_d0g0v0_Shanghai
     - static_CallEcrecoverCheckLengthWrongV_d0g0v0_Shanghai
     - static_CallEcrecoverR_prefixed0_d0g0v0_Shanghai
     - static_CallIdentity_1_nonzeroValue_d0g0v0_Shanghai
+    - static_callOutput3_d0g0v0_Shanghai
+    - static_callOutput3Fail_d0g0v0_Shanghai
+    - static_callOutput3partial_d0g0v0_Shanghai
+    - static_callOutput3partialFail_d0g0v0_Shanghai
     - static_CallRipemd160_4_gas719_d0g0v0_Shanghai
+    - static_CallRipemd160_5_d0g0v0_Shanghai
     - static_CallSha256_1_d0g0v0_Shanghai
     - static_CallSha256_1_nonzeroValue_d0g0v0_Shanghai
     - static_CallSha256_2_d0g0v0_Shanghai
@@ -7453,77 +7490,44 @@ testname:
     - static_CallSha256_3_prefix0_d0g0v0_Shanghai
     - static_CallSha256_4_d0g0v0_Shanghai
     - static_CallSha256_4_gas99_d0g0v0_Shanghai
+    - static_CallSha256_5_d0g0v0_Shanghai
+    - static_callToDelCallOpCodeCheck_d0g0v0_Shanghai
+    - static_callToStaticOpCodeCheck_d0g0v0_Shanghai
+    - static_callWithHighValueAndGasOOG_d1g0v0_Shanghai
+    - static_CheckOpcodes_d0g0v1_Shanghai
+    - static_CheckOpcodes_d0g1v1_Shanghai
+    - static_CheckOpcodes_d1g0v1_Shanghai
     - static_CheckOpcodes2_d4g0v0_Shanghai
     - static_CheckOpcodes2_d4g0v1_Shanghai
     - static_CheckOpcodes3_d3g0v0_Shanghai
     - static_CheckOpcodes3_d3g0v1_Shanghai
     - static_CheckOpcodes3_d4g0v1_Shanghai
-    - static_Call50000_rip160_d0g0v0_Shanghai
     - static_CheckOpcodes4_d0g1v1_Shanghai
     - static_CheckOpcodes5_d0g0v1_Shanghai
-    - static_Call1024PreCalls2_d1g0v0_Shanghai
     - static_CheckOpcodes5_d1g0v0_Shanghai
     - static_CheckOpcodes5_d1g0v1_Shanghai
-    - static_Call50000_rip160_d1g0v0_Shanghai
     - static_CheckOpcodes5_d1g1v0_Shanghai
-    - static_Call1024PreCalls3_d1g0v0_Shanghai
     - static_CheckOpcodes5_d1g1v1_Shanghai
     - static_CheckOpcodes5_d2g0v1_Shanghai
-    - static_CheckOpcodes5_d3g1v0_Shanghai
     - static_CheckOpcodes5_d3g0v1_Shanghai
+    - static_CheckOpcodes5_d3g1v0_Shanghai
     - static_CheckOpcodes5_d3g1v1_Shanghai
-    - static_Call1024PreCalls_d1g0v0_Shanghai
-    - static_Call1024PreCalls2_d0g0v0_Shanghai
-    - static_CheckOpcodes_d0g0v1_Shanghai
     - static_CheckOpcodes5_d4g0v1_Shanghai
-    - static_CheckOpcodes_d0g1v1_Shanghai
-    - static_CheckOpcodes_d1g0v1_Shanghai
-    - static_Call50000bytesContract50_1_d0g0v0_Shanghai
-    - static_RawCallGasAsk_d1g0v0_Shanghai
+    - static_CREATE_EmptyContractAndCallIt_0wei_d0g0v0_Shanghai
+    - static_CREATE_EmptyContractWithStorageAndCallIt_0wei_d0g0v0_Shanghai
+    - static_InternalCallHittingGasLimit2_d0g0v0_Shanghai
+    - static_LoopCallsThenRevert_d0g0v0_Shanghai
+    - static_LoopCallsThenRevert_d0g1v0_Shanghai
     - static_RawCallGasAsk_d0g0v0_Shanghai
+    - static_RawCallGasAsk_d1g0v0_Shanghai
+    - static_RawCallGasAsk_d2g0v0_Shanghai
+    - static_RawCallGasAsk_d3g0v0_Shanghai
     - static_RETURN_Bounds_d0g0v0_Shanghai
     - static_RETURN_BoundsOOG_d1g0v0_Shanghai
-    - static_RawCallGasAsk_d2g0v0_Shanghai
-    - static_Call50000bytesContract50_1_d1g0v0_Shanghai
-    - static_Call50000bytesContract50_2_d0g0v0_Shanghai
-    - static_RawCallGasAsk_d3g0v0_Shanghai
-    - static_InternalCallHittingGasLimit2_d0g0v0_Shanghai
-    - static_Call50000bytesContract50_2_d1g0v0_Shanghai
-    - static_Call50000bytesContract50_3_d1g0v0_Shanghai
-    - static_callOutput3Fail_d0g0v0_Shanghai
-    - static_callOutput3_d0g0v0_Shanghai
-    - static_callOutput3partialFail_d0g0v0_Shanghai
-    - static_callOutput3partial_d0g0v0_Shanghai
-    - static_callToDelCallOpCodeCheck_d0g0v0_Shanghai
-    - static_callToStaticOpCodeCheck_d0g0v0_Shanghai
-    - static_callWithHighValueAndGasOOG_d1g0v0_Shanghai
-    - static_call_value_inherit_d0g0v0_Shanghai
-    - static_call_value_inherit_from_call_d0g0v0_Shanghai
-    - static_Call50000_identity2_d0g0v0_Shanghai
-    - static_Call50000_identity2_d1g0v0_Shanghai
-    - static_Call50000_ecrec_d0g0v0_Shanghai
-    - static_Call50000_identity_d0g0v0_Shanghai
-    - static_Call50000_ecrec_d1g0v0_Shanghai
-    - static_Call50000_identity_d1g0v0_Shanghai
-    - static_Call50000_d0g0v0_Shanghai
-    - static_CallSha256_5_d0g0v0_Shanghai
-    - static_Call50000_d1g0v0_Shanghai
-    - static_Call1MB1024Calldepth_d1g0v0_Shanghai
-    - static_CallRipemd160_5_d0g0v0_Shanghai
-    - static_LoopCallsThenRevert_d0g1v0_Shanghai
-    - static_LoopCallsThenRevert_d0g0v0_Shanghai
-    - static_callcallcall_000_OOGMAfter2_d0g0v0_Shanghai
-    - static_callcallcallcode_001_OOGMAfter2_d1g0v0_Shanghai
-    - static_callcallcallcode_001_OOGMAfter_3_d1g0v0_Shanghai
-    - static_callcallcallcode_001_OOGMAfter_d1g0v0_Shanghai
-    - static_callcallcodecall_010_OOGMAfter_2_d1g0v0_Shanghai
-    - static_callcallcodecall_010_OOGMAfter_3_d1g0v0_Shanghai
-    - static_callcallcodecall_010_OOGMAfter_d1g0v0_Shanghai
     - static_Return50000_2_d0g0v0_Shanghai
-    - static_callcodecallcall_100_OOGMAfter2_d0g0v1_Shanghai
-    - static_callcodecallcall_100_OOGMAfter_2_d0g0v0_Shanghai
-    - static_callcodecallcall_100_OOGMAfter2_d0g0v0_Shanghai
-    - static_callcodecallcallcode_101_OOGMAfter_1_d0g0v0_Shanghai
+    - StaticcallToPrecompileFromCalledContract_d0g0v0_Shanghai
+    - StaticcallToPrecompileFromContractInitialization_d0g0v0_Shanghai
+    - StaticcallToPrecompileFromTransaction_d0g0v0_Shanghai
   stStaticFlagEnabled:
     - CallWithNOTZeroValueToPrecompileFromCalledContract_d1g0v0_Shanghai
     - CallWithNOTZeroValueToPrecompileFromCalledContract_d3g0v0_Shanghai

--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -386,6 +386,9 @@ namespace Account {
         let (local valid_jumpdests_start: DictAccess*) = default_dict_new(0);
         tempvar valid_jumpdests = valid_jumpdests_start;
         tempvar i = 0;
+        jmp body if bytecode_len != 0;
+        tempvar range_check_ptr = range_check_ptr;
+        jmp end;
 
         body:
         let bytecode_len = [fp - 4];
@@ -419,7 +422,10 @@ namespace Account {
         static_assert valid_jumpdests == [ap - 2];
         static_assert i == [ap - 1];
         jmp body if check_bound != 0;
+        tempvar range_check_ptr = range_check_ptr;
 
+        end:
+        tempvar range_check_ptr = [ap - 1];
         return (valid_jumpdests_start=valid_jumpdests_start, valid_jumpdests=valid_jumpdests);
     }
 }

--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -401,27 +401,27 @@ namespace Account {
         let is_opcode_ge_0x5f = is_le(0x5f, opcode);
         let is_opcode_le_0x7f = is_le(opcode, 0x7f);
         let is_push_opcode = is_opcode_ge_0x5f * is_opcode_le_0x7f;
-        let i = i + 1 + is_push_opcode * (opcode - 0x5f);
+        let next_i = i + 1 + is_push_opcode * (opcode - 0x5f);  // 0x5f is the first PUSHN opcode, opcode - 0x5f is the number of arguments.
 
         if (opcode == 0x5b) {
             dict_write{dict_ptr=valid_jumpdests}(i, TRUE);
             tempvar valid_jumpdests = valid_jumpdests;
-            tempvar i = i;
+            tempvar next_i = next_i;
             tempvar range_check_ptr = range_check_ptr;
         } else {
             tempvar valid_jumpdests = valid_jumpdests;
-            tempvar i = i;
+            tempvar next_i = next_i;
             tempvar range_check_ptr = range_check_ptr;
         }
 
-        tempvar check_bound = is_le(bytecode_len + 1, i);
+        tempvar is_not_done = is_le(next_i + 1, bytecode_len);
         tempvar range_check_ptr = range_check_ptr;
         tempvar valid_jumpdests = valid_jumpdests;
-        tempvar i = i;
+        tempvar i = next_i;
         static_assert range_check_ptr == [ap - 3];
         static_assert valid_jumpdests == [ap - 2];
         static_assert i == [ap - 1];
-        jmp body if check_bound != 0;
+        jmp body if is_not_done != 0;
 
         end:
         tempvar range_check_ptr = [ap - 3];

--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -9,7 +9,7 @@ from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict import dict_read, dict_write
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.hash import hash2
-from starkware.cairo.common.math_cmp import is_not_zero
+from starkware.cairo.common.math_cmp import is_not_zero, is_le
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.hash_state import (
@@ -365,6 +365,62 @@ namespace Account {
         let (local registered_starknet_account) = get_registered_starknet_address(address);
         let starknet_account_exists = is_not_zero(registered_starknet_account);
         return starknet_account_exists;
+    }
+
+    // @notice Initializes a dictionary of valid jump destinations in EVM bytecode.
+    // @param i The current index in the bytecode.
+    // @param bytecode_len The length of the bytecode.
+    // @param bytecode The EVM bytecode to analyze.
+    // @param valid_jumpdests A dictionary to be filled with valid jump destinations.
+    // @return valid_jumpdests The updated dictionary with valid jump destinations.
+    //
+    // @dev This function iterates over the bytecode from the current index 'i'.
+    // If the opcode at the current index is between 0x5f and 0x7f (PUSHN opcodes) (inclusive),
+    // it skips the next 'n_args' opcodes, where 'n_args' is the opcode minus 0x5f.
+    // If the opcode is 0x5b (JUMPDEST), it marks the current index as a valid jump destination.
+    // The function then increments the index and recursively calls itself until it has processed the entire bytecode.
+    func init_valid_jumpdests{range_check_ptr}(bytecode_len: felt, bytecode: felt*) -> (
+        valid_jumpdests_start: DictAccess*, valid_jumpdests: DictAccess*
+    ) {
+        alloc_locals;
+        let (local valid_jumpdests_start: DictAccess*) = default_dict_new(0);
+        tempvar valid_jumpdests = valid_jumpdests_start;
+        tempvar i = 0;
+
+        body:
+        let bytecode_len = [fp - 4];
+        let bytecode = cast([fp - 3], felt*);
+        let valid_jumpdests = cast([ap - 2], DictAccess*);
+        let i = [ap - 1];
+
+        let opcode = [bytecode + i];
+        let is_opcode_ge_0x5f = is_le(0x5f, opcode);
+        let is_opcode_le_0x7f = is_le(opcode, 0x7f);
+        let is_push_opcode = is_opcode_ge_0x5f * is_opcode_le_0x7f;
+        if (is_push_opcode != FALSE) {
+            let n_args = opcode - 0x5f;
+            tempvar i = i + 1 + n_args;
+        } else {
+            tempvar i = i + 1;
+        }
+
+        if (opcode == 0x5b) {
+            dict_write{dict_ptr=valid_jumpdests}(i, TRUE);
+            tempvar valid_jumpdests = valid_jumpdests;
+            tempvar i = i;
+        } else {
+            tempvar valid_jumpdests = valid_jumpdests;
+            tempvar i = i;
+        }
+
+        tempvar check_bound = is_le(bytecode_len, i);
+        tempvar valid_jumpdests = valid_jumpdests;
+        tempvar i = i;
+        static_assert valid_jumpdests == [ap - 2];
+        static_assert i == [ap - 1];
+        jmp body if check_bound != 0;
+
+        return (valid_jumpdests_start=valid_jumpdests_start, valid_jumpdests=valid_jumpdests);
     }
 }
 

--- a/src/kakarot/evm.cairo
+++ b/src/kakarot/evm.cairo
@@ -10,6 +10,7 @@ from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.registers import get_label_location
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.dict import dict_read
+from starkware.cairo.common.default_dict import default_dict_finalize
 
 from kakarot.errors import Errors
 from kakarot.model import model
@@ -35,6 +36,39 @@ namespace EVM {
             gas_left=gas_left,
             reverted=FALSE,
         );
+    }
+
+    func finalize{range_check_ptr, evm: model.EVM*}() {
+        let (squashed_start, squashed_end) = default_dict_finalize(
+            evm.message.valid_jumpdests_start, evm.message.valid_jumpdests, 0
+        );
+        tempvar message = new model.Message(
+            bytecode=evm.message.bytecode,
+            bytecode_len=evm.message.bytecode_len,
+            valid_jumpdests_start=squashed_start,
+            valid_jumpdests=squashed_end,
+            calldata=evm.message.calldata,
+            calldata_len=evm.message.calldata_len,
+            value=evm.message.value,
+            parent=evm.message.parent,
+            address=evm.message.address,
+            read_only=evm.message.read_only,
+            is_create=evm.message.is_create,
+            depth=evm.message.depth,
+            env=evm.message.env,
+        );
+
+        tempvar evm = new model.EVM(
+            message=message,
+            return_data_len=evm.return_data_len,
+            return_data=evm.return_data,
+            program_counter=evm.program_counter,
+            stopped=evm.stopped,
+            gas_left=evm.gas_left,
+            reverted=evm.reverted,
+        );
+
+        return ();
     }
 
     // @notice Stop the current execution context.

--- a/src/kakarot/evm.cairo
+++ b/src/kakarot/evm.cairo
@@ -172,7 +172,7 @@ namespace EVM {
 
         let valid_jumpdests = self.message.valid_jumpdests;
         let (is_valid_jumpdest) = dict_read{dict_ptr=valid_jumpdests}(new_pc_offset);
-        tempvar updated_message = new model.Message(
+        tempvar message = new model.Message(
             bytecode=self.message.bytecode,
             bytecode_len=self.message.bytecode_len,
             valid_jumpdests_start=self.message.valid_jumpdests_start,
@@ -190,21 +190,21 @@ namespace EVM {
 
         if (is_valid_jumpdest == FALSE) {
             let (revert_reason_len, revert_reason) = Errors.invalidJumpDestError();
-            tempvar self = new model.EVM(
-                message=updated_message,
-                return_data_len=self.return_data_len,
-                return_data=self.return_data,
+            // stop and revert the execution context with the updated `message`
+            tempvar evm = new model.EVM(
+                message=message,
+                return_data_len=revert_reason_len,
+                return_data=revert_reason,
                 program_counter=self.program_counter,
-                stopped=self.stopped,
+                stopped=TRUE,
                 gas_left=self.gas_left,
-                reverted=self.reverted,
+                reverted=TRUE,
             );
-            let evm = EVM.stop(self, revert_reason_len, revert_reason, TRUE);
             return evm;
         }
 
         return new model.EVM(
-            message=updated_message,
+            message=message,
             return_data_len=self.return_data_len,
             return_data=self.return_data,
             program_counter=new_pc_offset,

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -10,6 +10,8 @@ from starkware.cairo.common.math import split_felt, unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le, is_nn, is_not_zero
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256, uint256_lt
+from starkware.cairo.common.default_dict import default_dict_new
+from starkware.cairo.common.dict_access import DictAccess
 
 from kakarot.account import Account
 from kakarot.constants import Constants
@@ -21,6 +23,7 @@ from kakarot.model import model
 from kakarot.precompiles.precompiles import Precompiles
 from kakarot.stack import Stack
 from kakarot.state import State
+from utils.utils import Helpers
 from utils.array import slice
 from utils.bytes import (
     bytes_to_bytes8_little_endian,
@@ -133,9 +136,16 @@ namespace SystemOperations {
 
         // Create child message
         let (calldata: felt*) = alloc();
+        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
+        tempvar valid_jumpdests = valid_jumpdests_start;
+        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
+            i=0, bytecode_len=size.low, bytecode=bytecode
+        );
         tempvar message = new model.Message(
             bytecode=bytecode,
             bytecode_len=size.low,
+            valid_jumpdests_start=valid_jumpdests_start,
+            valid_jumpdests=valid_jumpdests,
             calldata=calldata,
             calldata_len=0,
             value=value.low + value.high * 2 ** 128,
@@ -544,18 +554,25 @@ namespace CallHelper {
         tempvar call_address = new model.Address(starknet_contract_address, address);
         let account = State.get_account(call_address);
 
+        tempvar parent = new model.Parent(evm, stack, memory, state);
+        let stack = Stack.init();
+        let memory = Memory.init();
+        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
+        tempvar valid_jumpdests = valid_jumpdests_start;
+        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
+            i=0, bytecode_len=account.code_len, bytecode=account.code
+        );
         if (self_call == FALSE) {
             tempvar message_address = call_address;
         } else {
             tempvar message_address = evm.message.address;
         }
 
-        tempvar parent = new model.Parent(evm, stack, memory, state);
-        let stack = Stack.init();
-        let memory = Memory.init();
         tempvar message = new model.Message(
             bytecode=account.code,
             bytecode_len=account.code_len,
+            valid_jumpdests_start=valid_jumpdests_start,
+            valid_jumpdests=valid_jumpdests,
             calldata=calldata,
             calldata_len=args_size.low,
             value=value,

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -136,10 +136,8 @@ namespace SystemOperations {
 
         // Create child message
         let (calldata: felt*) = alloc();
-        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
-        tempvar valid_jumpdests = valid_jumpdests_start;
-        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
-            i=0, bytecode_len=size.low, bytecode=bytecode
+        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+            bytecode_len=size.low, bytecode=bytecode
         );
         tempvar message = new model.Message(
             bytecode=bytecode,
@@ -557,10 +555,8 @@ namespace CallHelper {
         tempvar parent = new model.Parent(evm, stack, memory, state);
         let stack = Stack.init();
         let memory = Memory.init();
-        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
-        tempvar valid_jumpdests = valid_jumpdests_start;
-        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
-            i=0, bytecode_len=account.code_len, bytecode=account.code
+        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+            bytecode_len=account.code_len, bytecode=account.code
         );
         if (self_call == FALSE) {
             tempvar message_address = call_address;

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -136,7 +136,7 @@ namespace SystemOperations {
 
         // Create child message
         let (calldata: felt*) = alloc();
-        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+        let (valid_jumpdests_start, valid_jumpdests) = Account.get_jumpdests(
             bytecode_len=size.low, bytecode=bytecode
         );
         tempvar message = new model.Message(
@@ -555,7 +555,7 @@ namespace CallHelper {
         tempvar parent = new model.Parent(evm, stack, memory, state);
         let stack = Stack.init();
         let memory = Memory.init();
-        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+        let (valid_jumpdests_start, valid_jumpdests) = Account.get_jumpdests(
             bytecode_len=account.code_len, bytecode=account.code
         );
         if (self_call == FALSE) {

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -8,6 +8,8 @@ from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.math_cmp import is_le, is_not_zero, is_nn
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
+from starkware.cairo.common.default_dict import default_dict_new
+from starkware.cairo.common.dict_access import DictAccess
 
 // Internal dependencies
 from kakarot.account import Account
@@ -734,21 +736,34 @@ namespace Interpreter {
         // bytecode is data and data is empty
         // else, bytecode and data are kept as is
         let bytecode_len = calldata_len * is_deploy_tx + bytecode_len * (1 - is_deploy_tx);
-        let calldata_len = calldata_len * (1 - is_deploy_tx);
+
+        let tmp_bytecode = bytecode;
+        let tmp_calldata = calldata;
+        let tmp_intrinsic_gas = intrinsic_gas;
+        local bytecode: felt*;
+        local calldata: felt*;
+        local intrinsic_gas: felt;
         if (is_deploy_tx != 0) {
             let (empty: felt*) = alloc();
-            tempvar bytecode = calldata;
-            tempvar calldata = empty;
-            tempvar intrinsic_gas = intrinsic_gas + Gas.CREATE;
+            assert bytecode = tmp_calldata;
+            assert calldata = empty;
+            assert intrinsic_gas = tmp_intrinsic_gas + Gas.CREATE;
         } else {
-            tempvar bytecode = bytecode;
-            tempvar calldata = calldata;
-            tempvar intrinsic_gas = intrinsic_gas;
+            assert bytecode = tmp_bytecode;
+            assert calldata = tmp_calldata;
+            assert intrinsic_gas = tmp_intrinsic_gas;
         }
 
+        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
+        tempvar valid_jumpdests = valid_jumpdests_start;
+        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
+            i=0, bytecode_len=bytecode_len, bytecode=bytecode
+        );
         tempvar message = new model.Message(
             bytecode=bytecode,
             bytecode_len=bytecode_len,
+            valid_jumpdests_start=valid_jumpdests_start,
+            valid_jumpdests=valid_jumpdests,
             calldata=calldata,
             calldata_len=calldata_len,
             value=value,

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -752,7 +752,7 @@ namespace Interpreter {
             assert intrinsic_gas = tmp_intrinsic_gas;
         }
 
-        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+        let (valid_jumpdests_start, valid_jumpdests) = Account.get_jumpdests(
             bytecode_len=bytecode_len, bytecode=bytecode
         );
         tempvar message = new model.Message(

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -8,8 +8,6 @@ from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.math_cmp import is_le, is_not_zero, is_nn
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
-from starkware.cairo.common.default_dict import default_dict_new
-from starkware.cairo.common.dict_access import DictAccess
 
 // Internal dependencies
 from kakarot.account import Account
@@ -754,10 +752,8 @@ namespace Interpreter {
             assert intrinsic_gas = tmp_intrinsic_gas;
         }
 
-        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
-        tempvar valid_jumpdests = valid_jumpdests_start;
-        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
-            i=0, bytecode_len=bytecode_len, bytecode=bytecode
+        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+            bytecode_len=bytecode_len, bytecode=bytecode
         );
         tempvar message = new model.Message(
             bytecode=bytecode,

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -734,6 +734,7 @@ namespace Interpreter {
         // bytecode is data and data is empty
         // else, bytecode and data are kept as is
         let bytecode_len = calldata_len * is_deploy_tx + bytecode_len * (1 - is_deploy_tx);
+        let calldata_len = calldata_len * (1 - is_deploy_tx);
 
         let tmp_bytecode = bytecode;
         let tmp_calldata = calldata;

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -667,6 +667,9 @@ namespace Interpreter {
         Memory.finalize();
         Stack.finalize();
         State.finalize();
+        with evm {
+            EVM.finalize();
+        }
 
         if (evm.message.depth == 0) {
             if (evm.message.is_create != FALSE) {

--- a/src/kakarot/model.cairo
+++ b/src/kakarot/model.cairo
@@ -98,6 +98,8 @@ namespace model {
     struct Message {
         bytecode: felt*,
         bytecode_len: felt,
+        valid_jumpdests_start: DictAccess*,
+        valid_jumpdests: DictAccess*,
         calldata: felt*,
         calldata_len: felt,
         value: felt,

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -54,11 +54,12 @@ namespace Precompiles {
         // Build returned execution context
         let (starknet_address) = Account.compute_starknet_address(evm_address);
         tempvar address = new model.Address(starknet_address, evm_address);
+        let (valid_jumdests) = default_dict_new(0);
         tempvar message = new model.Message(
             bytecode=cast(0, felt*),
             bytecode_len=0,
-            valid_jumpdests_start=cast(0, DictAccess*),
-            valid_jumpdests=cast(0, DictAccess*),
+            valid_jumpdests_start=valid_jumdests,
+            valid_jumpdests=valid_jumdests,
             calldata=cast(0, felt*),
             calldata_len=0,
             value=0,

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -8,6 +8,7 @@ from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.math_cmp import is_le, is_not_zero
+from starkware.cairo.common.dict_access import DictAccess
 
 // Internal dependencies
 from kakarot.account import Account
@@ -56,6 +57,8 @@ namespace Precompiles {
         tempvar message = new model.Message(
             bytecode=cast(0, felt*),
             bytecode_len=0,
+            valid_jumpdests_start=cast(0, DictAccess*),
+            valid_jumpdests=cast(0, DictAccess*),
             calldata=cast(0, felt*),
             calldata_len=0,
             value=0,

--- a/src/utils/array.cairo
+++ b/src/utils/array.cairo
@@ -2,7 +2,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.memset import memset
 from starkware.cairo.common.math_cmp import is_not_zero, is_nn
-from starkware.cairo.common.bool import FALSE
+from starkware.cairo.common.bool import FALSE, TRUE
 
 func reverse(dst: felt*, arr_len: felt, arr: felt*) {
     alloc_locals;
@@ -80,4 +80,34 @@ func slice{range_check_ptr}(dst: felt*, data_len: felt, data: felt*, offset: fel
     memcpy(dst=dst, src=data + offset, len=max_len);
     memset(dst=dst + max_len, value=0, n=size - max_len);
     return ();
+}
+
+func contains{range_check_ptr}(arr_len: felt, arr: felt*, value: felt) -> felt {
+    alloc_locals;
+
+    if (arr_len == 0) {
+        return FALSE;
+    }
+
+    tempvar i = 0;
+    tempvar is_found = FALSE;
+
+    body:
+    let arr_len = [fp - 5];
+    let arr = cast([fp - 4], felt*);
+    let value = [fp - 3];
+    let i = [ap - 1];
+
+    tempvar check_value = ([arr + i] - value);
+    tempvar check_bound = (arr_len - (i + 1));
+    tempvar checks = check_value * check_bound;
+
+    tempvar i = i + 1;
+    static_assert i == [ap - 1];
+    jmp body if checks != 0;
+
+    if (check_value == 0) {
+        return TRUE;
+    }
+    return FALSE;
 }

--- a/src/utils/array.cairo
+++ b/src/utils/array.cairo
@@ -90,7 +90,6 @@ func contains{range_check_ptr}(arr_len: felt, arr: felt*, value: felt) -> felt {
     }
 
     tempvar i = 0;
-    tempvar is_found = FALSE;
 
     body:
     let arr_len = [fp - 5];
@@ -98,8 +97,8 @@ func contains{range_check_ptr}(arr_len: felt, arr: felt*, value: felt) -> felt {
     let value = [fp - 3];
     let i = [ap - 1];
 
-    tempvar check_value = ([arr + i] - value);
-    tempvar check_bound = (arr_len - (i + 1));
+    tempvar check_value = [arr + i] - value;
+    tempvar check_bound = arr_len - (i + 1);
     tempvar checks = check_value * check_bound;
 
     tempvar i = i + 1;

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -3,15 +3,16 @@
 // StarkWare dependencies
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import assert_le, split_felt, assert_nn_le, unsigned_div_rem
-from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.math_cmp import is_le, is_le_felt
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.pow import pow
 from starkware.cairo.common.uint256 import Uint256, uint256_check
 from starkware.cairo.common.registers import get_label_location
 from starkware.cairo.common.cairo_secp.bigint import BigInt3, bigint_to_uint256, uint256_to_bigint
-from starkware.cairo.common.bool import FALSE
+from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.hash_state import hash_finalize, hash_init, hash_update
+from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
 
 from utils.bytes import uint256_to_bytes32
 
@@ -589,5 +590,44 @@ namespace Helpers {
         return bytes4_array_to_bytes(
             data_len=data_len - 1, data=data + 1, bytes_len=bytes_len + 4, bytes=res
         );
+    }
+
+    // @notice Initializes a dictionary of valid jump destinations in EVM bytecode.
+    // @param i The current index in the bytecode.
+    // @param bytecode_len The length of the bytecode.
+    // @param bytecode The EVM bytecode to analyze.
+    // @param valid_jumpdests A dictionary to be filled with valid jump destinations.
+    // @return valid_jumpdests The updated dictionary with valid jump destinations.
+    //
+    // @dev This function iterates over the bytecode from the current index 'i'.
+    // If the opcode at the current index is between 0x5f and 0x7f (PUSHN opcodes) (inclusive),
+    // it skips the next 'n_args' opcodes, where 'n_args' is the opcode minus 0x5f.
+    // If the opcode is 0x5b (JUMPDEST), it marks the current index as a valid jump destination.
+    // The function then increments the index and recursively calls itself until it has processed the entire bytecode.
+    func init_valid_jumpdests{range_check_ptr, valid_jumpdests: DictAccess*}(
+        i: felt, bytecode_len: felt, bytecode: felt*
+    ) {
+        let is_done = is_le(bytecode_len, i);
+        if (is_done != FALSE) {
+            return ();
+        }
+
+        let opcode = [bytecode + i];
+        let is_opcode_ge_0x5f = is_le_felt(0x5f, opcode);
+        let is_opcode_le_0x7f = is_le_felt(opcode, 0x7f);
+
+        if ((is_opcode_ge_0x5f * is_opcode_le_0x7f) == TRUE) {
+            let n_args = opcode - 0x5f;
+            return init_valid_jumpdests(
+                i=i + 1 + n_args, bytecode_len=bytecode_len, bytecode=bytecode
+            );
+        }
+
+        if (opcode == 0x5b) {
+            dict_write{dict_ptr=valid_jumpdests}(i, TRUE);
+            return init_valid_jumpdests(i=i + 1, bytecode_len=bytecode_len, bytecode=bytecode);
+        }
+
+        return init_valid_jumpdests(i=i + 1, bytecode_len=bytecode_len, bytecode=bytecode);
     }
 }

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -3,16 +3,15 @@
 // StarkWare dependencies
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import assert_le, split_felt, assert_nn_le, unsigned_div_rem
-from starkware.cairo.common.math_cmp import is_le, is_le_felt
+from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.pow import pow
 from starkware.cairo.common.uint256 import Uint256, uint256_check
 from starkware.cairo.common.registers import get_label_location
 from starkware.cairo.common.cairo_secp.bigint import BigInt3, bigint_to_uint256, uint256_to_bigint
-from starkware.cairo.common.bool import FALSE, TRUE
+from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.hash_state import hash_finalize, hash_init, hash_update
-from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
 
 from utils.bytes import uint256_to_bytes32
 

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -591,43 +591,4 @@ namespace Helpers {
             data_len=data_len - 1, data=data + 1, bytes_len=bytes_len + 4, bytes=res
         );
     }
-
-    // @notice Initializes a dictionary of valid jump destinations in EVM bytecode.
-    // @param i The current index in the bytecode.
-    // @param bytecode_len The length of the bytecode.
-    // @param bytecode The EVM bytecode to analyze.
-    // @param valid_jumpdests A dictionary to be filled with valid jump destinations.
-    // @return valid_jumpdests The updated dictionary with valid jump destinations.
-    //
-    // @dev This function iterates over the bytecode from the current index 'i'.
-    // If the opcode at the current index is between 0x5f and 0x7f (PUSHN opcodes) (inclusive),
-    // it skips the next 'n_args' opcodes, where 'n_args' is the opcode minus 0x5f.
-    // If the opcode is 0x5b (JUMPDEST), it marks the current index as a valid jump destination.
-    // The function then increments the index and recursively calls itself until it has processed the entire bytecode.
-    func init_valid_jumpdests{range_check_ptr, valid_jumpdests: DictAccess*}(
-        i: felt, bytecode_len: felt, bytecode: felt*
-    ) {
-        let is_done = is_le(bytecode_len, i);
-        if (is_done != FALSE) {
-            return ();
-        }
-
-        let opcode = [bytecode + i];
-        let is_opcode_ge_0x5f = is_le_felt(0x5f, opcode);
-        let is_opcode_le_0x7f = is_le_felt(opcode, 0x7f);
-
-        if ((is_opcode_ge_0x5f * is_opcode_le_0x7f) == TRUE) {
-            let n_args = opcode - 0x5f;
-            return init_valid_jumpdests(
-                i=i + 1 + n_args, bytecode_len=bytecode_len, bytecode=bytecode
-            );
-        }
-
-        if (opcode == 0x5b) {
-            dict_write{dict_ptr=valid_jumpdests}(i, TRUE);
-            return init_valid_jumpdests(i=i + 1, bytecode_len=bytecode_len, bytecode=bytecode);
-        }
-
-        return init_valid_jumpdests(i=i + 1, bytecode_len=bytecode_len, bytecode=bytecode);
-    }
 }

--- a/tests/src/kakarot/precompiles/test_precompiles.cairo
+++ b/tests/src/kakarot/precompiles/test_precompiles.cairo
@@ -27,6 +27,8 @@ func test__precompiles_run{
     tempvar message = new model.Message(
         bytecode=cast(0, felt*),
         bytecode_len=0,
+        valid_jumpdests_start=cast(0, DictAccess*),
+        valid_jumpdests=cast(0, DictAccess*),
         calldata=cast(0, felt*),
         calldata_len=0,
         value=0,

--- a/tests/src/kakarot/precompiles/test_precompiles.cairo
+++ b/tests/src/kakarot/precompiles/test_precompiles.cairo
@@ -13,6 +13,7 @@ from kakarot.stack import Stack
 from kakarot.memory import Memory
 from kakarot.state import State
 from kakarot.precompiles.precompiles import Precompiles
+from starkware.cairo.common.dict_access import DictAccess
 
 @external
 func test__is_precompile{range_check_ptr}(address: felt) -> (is_precompile: felt) {

--- a/tests/src/kakarot/test_execution_context.py
+++ b/tests/src/kakarot/test_execution_context.py
@@ -16,17 +16,18 @@ async def execution_context(starknet: Starknet):
 @pytest.mark.asyncio
 class TestExecutionContext:
     @pytest.mark.parametrize(
-        "jumpdest,new_pc,expected_return_data",
+        "bytecode, jumpdest, new_pc, expected_return_data",
         [
-            (0, 0, list(b"Kakarot: invalidJumpDestError")),
-            (1, 1, []),
-            (2, 0, list(b"Kakarot: invalidJumpDestError")),
+            ([0,0x5B], 0, 0, list(b"Kakarot: invalidJumpDestError")), # not 0x5b
+            ([0,0x5B], 2, 0, list(b"Kakarot: invalidJumpDestError")), # out of bounds
+            ([0,0x5B], 1, 1, []),
+            ([0,0x60, 0x01, 0x5B], 3, 3, []), # post-push1 opcode
+            ([0,0x61, 0x5B, 0x02], 2, 0, list(b"Kakarot: invalidJumpDestError")), # post-push2 opcode
         ],
     )
     async def test_jump(
-        self, execution_context, jumpdest, new_pc, expected_return_data
+        self, bytecode, execution_context, jumpdest, new_pc, expected_return_data
     ):
-        bytecode = [0, 0x5B]
         (pc, return_data) = (
             await execution_context.test__jump(bytecode, jumpdest).call()
         ).result

--- a/tests/src/kakarot/test_execution_context.py
+++ b/tests/src/kakarot/test_execution_context.py
@@ -18,11 +18,16 @@ class TestExecutionContext:
     @pytest.mark.parametrize(
         "bytecode, jumpdest, new_pc, expected_return_data",
         [
-            ([0,0x5B], 0, 0, list(b"Kakarot: invalidJumpDestError")), # not 0x5b
-            ([0,0x5B], 2, 0, list(b"Kakarot: invalidJumpDestError")), # out of bounds
-            ([0,0x5B], 1, 1, []),
-            ([0,0x60, 0x01, 0x5B], 3, 3, []), # post-push1 opcode
-            ([0,0x61, 0x5B, 0x02], 2, 0, list(b"Kakarot: invalidJumpDestError")), # post-push2 opcode
+            ([0, 0x5B], 0, 0, list(b"Kakarot: invalidJumpDestError")),  # not 0x5b
+            ([0, 0x5B], 2, 0, list(b"Kakarot: invalidJumpDestError")),  # out of bounds
+            ([0, 0x5B], 1, 1, []),
+            ([0, 0x60, 0x01, 0x5B], 3, 3, []),  # post-push1 opcode
+            (
+                [0, 0x61, 0x5B, 0x02],
+                2,
+                0,
+                list(b"Kakarot: invalidJumpDestError"),
+            ),  # post-push2 opcode
         ],
     )
     async def test_jump(

--- a/tests/src/utils/test_array.cairo
+++ b/tests/src/utils/test_array.cairo
@@ -6,7 +6,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.alloc import alloc
 
-from utils.array import reverse, count_not_zero, slice
+from utils.array import reverse, count_not_zero, slice, contains
 
 @external
 func test__reverse{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
@@ -34,4 +34,13 @@ func test__slice{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     let (sliced: felt*) = alloc();
     slice(sliced, arr_len, arr, offset, size);
     return (slice_len=size, slice=sliced);
+}
+
+@external
+func test_contains{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    arr_len: felt, arr: felt*, value: felt
+) -> (is_contained: felt) {
+    alloc_locals;
+    let result = contains(arr_len, arr, value);
+    return (is_contained=result);
 }

--- a/tests/src/utils/test_array.py
+++ b/tests/src/utils/test_array.py
@@ -74,4 +74,6 @@ class TestArray:
             ],
         )
         async def test_should_return_if_contains(self, array_, arr, value, expected):
-            assert expected == ((await array_.test_contains(arr, value).call()).result.is_contained)
+            assert expected == (
+                (await array_.test_contains(arr, value).call()).result.is_contained
+            )

--- a/tests/src/utils/test_array.py
+++ b/tests/src/utils/test_array.py
@@ -61,3 +61,17 @@ class TestArray:
             assert (arr + (offset + size) * [0])[offset : offset + size] == (
                 (await array_.test__slice(arr, offset, size).call()).result.slice
             )
+
+    class TestContains:
+        @pytest.mark.parametrize(
+            "arr, value, expected",
+            [
+                ([0, 1, 2, 3, 4], 1, True),
+                ([0, 1, 2, 3], 5, False),
+                ([0, 1, 19], 19, True),
+                ([0], 0, True),
+                ([], 1, False),
+            ],
+        )
+        async def test_should_return_if_contains(self, array_, arr, value, expected):
+            assert expected == ((await array_.test_contains(arr, value).call()).result.is_contained)

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -29,7 +29,7 @@ from utils.utils import Helpers
 from backend.starknet import Starknet
 
 namespace TestHelpers {
-    func init_evm_at_address{syscall_ptr: felt*}(
+    func init_evm_at_address{syscall_ptr: felt*, range_check_ptr}(
         bytecode_len: felt,
         bytecode: felt*,
         starknet_contract_address: felt,

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -41,7 +41,7 @@ namespace TestHelpers {
         tempvar address_0 = new model.Address(0, 0);
         let env = Starknet.get_env(address_0, 0);
         tempvar address = new model.Address(starknet_contract_address, evm_contract_address);
-        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+        let (valid_jumpdests_start, valid_jumpdests) = Account.get_jumpdests(
             bytecode_len=bytecode_len, bytecode=bytecode
         );
         local message: model.Message* = new model.Message(
@@ -63,12 +63,12 @@ namespace TestHelpers {
         return evm;
     }
 
-    func init_evm{syscall_ptr: felt*}() -> model.EVM* {
+    func init_evm{syscall_ptr: felt*, range_check_ptr}() -> model.EVM* {
         let (bytecode) = alloc();
         return init_evm_at_address(0, bytecode, 0, 0);
     }
 
-    func init_evm_with_bytecode{syscall_ptr: felt*}(
+    func init_evm_with_bytecode{syscall_ptr: felt*, range_check_ptr}(
         bytecode_len: felt, bytecode: felt*
     ) -> model.EVM* {
         return init_evm_at_address(bytecode_len, bytecode, 0, 0);

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -40,9 +40,16 @@ namespace TestHelpers {
         tempvar address_0 = new model.Address(0, 0);
         let env = Starknet.get_env(address_0, 0);
         tempvar address = new model.Address(starknet_contract_address, evm_contract_address);
+        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
+        tempvar valid_jumpdests = valid_jumpdests_start;
+        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
+            i=0, bytecode_len=bytecode_len, bytecode=bytecode
+        );
         local message: model.Message* = new model.Message(
             bytecode=bytecode,
             bytecode_len=bytecode_len,
+            valid_jumpdests_start=valid_jumpdests_start,
+            valid_jumpdests=valid_jumpdests,
             calldata=calldata,
             calldata_len=1,
             value=0,

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -24,6 +24,7 @@ from kakarot.evm import EVM
 from kakarot.memory import Memory
 from kakarot.model import model
 from kakarot.stack import Stack
+from kakarot.account import Account
 from utils.utils import Helpers
 from backend.starknet import Starknet
 
@@ -40,10 +41,8 @@ namespace TestHelpers {
         tempvar address_0 = new model.Address(0, 0);
         let env = Starknet.get_env(address_0, 0);
         tempvar address = new model.Address(starknet_contract_address, evm_contract_address);
-        let (valid_jumpdests_start: DictAccess*) = default_dict_new(0);
-        tempvar valid_jumpdests = valid_jumpdests_start;
-        Helpers.init_valid_jumpdests{valid_jumpdests=valid_jumpdests}(
-            i=0, bytecode_len=bytecode_len, bytecode=bytecode
+        let (valid_jumpdests_start, valid_jumpdests) = Account.init_valid_jumpdests(
+            bytecode_len=bytecode_len, bytecode=bytecode
         );
         local message: model.Message* = new model.Message(
             bytecode=bytecode,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 1d

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #693 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- JUMP and JUMPI can only jump to valid jumpdests
- valid jumpdests are stored in the message struct once the bytecode to execute is known.
-
