### PR TITLE
Allow cairo_run to be used with %lang starknet cairo files

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -6,3 +6,4 @@
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,10 +1,10 @@
 version: 0.1
 cli:
-  version: 1.17.2
+  version: 1.19.0
 plugins:
   sources:
     - id: trunk
-      ref: v1.2.3
+      ref: v1.4.2
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
@@ -28,22 +28,22 @@ lint:
           run_linter_from: workspace
   enabled:
     - cairo@SYSTEM
-    - actionlint@1.6.25
-    - black@23.9.1
-    - checkov@2.4.9
-    - codespell@2.2.5
+    - actionlint@1.6.26
+    - black@23.12.1
+    - checkov@3.1.61
+    - codespell@2.2.6
     - git-diff-check
     - hadolint@2.12.0
-    - isort@5.12.0
-    - markdownlint@0.36.0
-    - oxipng@8.0.0
-    - prettier@3.0.3
-    - ruff@0.0.290
+    - isort@5.13.2
+    - markdownlint@0.38.0
+    - oxipng@9.0.0
+    - prettier@3.2.2
+    - ruff@0.1.13
     - shellcheck@0.9.0
     - shfmt@3.6.0
     - taplo@0.8.1
     - terrascan@1.18.11
-    - yamllint@1.32.0
+    - yamllint@1.33.0
   disabled:
     - trufflehog
     - bandit

--- a/src/kakarot/state.cairo
+++ b/src/kakarot/state.cairo
@@ -244,9 +244,7 @@ namespace State {
     // @notice Check whether an account is both in the state and non empty.
     // @param address Address of the account that needs to be checked.
     // @return is_alive TRUE if the account is alive.
-    func is_account_alive{
-        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, state: model.State*
-    }(evm_address: felt) -> felt {
+    func is_account_alive{state: model.State*}(evm_address: felt) -> felt {
         alloc_locals;
         let accounts = state.accounts;
         let (pointer) = dict_read{dict_ptr=accounts}(key=evm_address);

--- a/tests/src/kakarot/test_state.cairo
+++ b/tests/src/kakarot/test_state.cairo
@@ -33,10 +33,7 @@ func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     return (Uint256(0, 0),);
 }
 
-@external
-func test__init__should_return_state_with_default_dicts{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() {
+func test__init__should_return_state_with_default_dicts() {
     // When
     let state = State.init();
 
@@ -126,6 +123,7 @@ func test__copy__should_return_new_state_with_same_attributes{
 func test__is_account_alive__existing_account{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }(nonce, code_len, code: felt*, balance_low) -> (is_alive: felt) {
+    alloc_locals;
     let evm_address = 'alive';
     let starknet_address = Account.compute_starknet_address(evm_address);
     tempvar address = new model.Address(starknet_address, evm_address);
@@ -141,14 +139,12 @@ func test__is_account_alive__existing_account{
     return (is_alive=is_alive);
 }
 
-@external
-func test__is_account_alive__not_in_state{
-    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
-}() -> (is_alive: felt) {
+func test__is_account_alive__not_in_state() {
     let state = State.init();
     with state {
         let is_alive = State.is_account_alive(0xdead);
     }
 
-    return (is_alive=is_alive);
+    assert is_alive = 0;
+    return ();
 }

--- a/tests/src/kakarot/test_state.py
+++ b/tests/src/kakarot/test_state.py
@@ -3,7 +3,7 @@ import pytest_asyncio
 from starkware.starknet.testing.starknet import Starknet
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="session")
 async def state(starknet: Starknet):
     class_hash = await starknet.deprecated_declare(
         source="./tests/src/kakarot/test_state.cairo",
@@ -16,8 +16,8 @@ async def state(starknet: Starknet):
 @pytest.mark.asyncio
 class TestState:
     class TestInit:
-        async def test_should_return_state_with_default_dicts(self, state):
-            await state.test__init__should_return_state_with_default_dicts().call()
+        async def test_should_return_state_with_default_dicts(self, cairo_run):
+            cairo_run("test__init__should_return_state_with_default_dicts")
 
     class TestCopy:
         async def test_should_return_new_state_with_same_attributes(self, state):
@@ -43,8 +43,5 @@ class TestState:
             ).result.is_alive
             assert result == expected_result
 
-        async def test_not_in_state(self, state):
-            result = (
-                await state.test__is_account_alive__not_in_state().call()
-            ).result.is_alive
-            assert result == 0
+        async def test_not_in_state(self, cairo_run):
+            cairo_run("test__is_account_alive__not_in_state")


### PR DESCRIPTION
Time spent on this PR: 0.2

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `cairo_run` fixture cannot compile `%lang starknet` files.

## What is the new behavior?

Works, see for example [test_state](./tests/src/kakarot/test_state.py)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/883)
<!-- Reviewable:end -->
