### PR TITLE
Fix segments order in cairo runner

### DIFF
--- a/tests/src/kakarot/test_gas.cairo
+++ b/tests/src/kakarot/test_gas.cairo
@@ -4,12 +4,13 @@ from kakarot.gas import Gas
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 
-func test__memory_cost{range_check_ptr}() {
+func test__memory_cost{range_check_ptr}(output_ptr: felt*) {
     tempvar words_len: felt;
     %{ ids.words_len = program_input["words_len"]; %}
     let cost = Gas.memory_cost(words_len);
 
-    %{ segments.write_arg(output, [ids.cost]); %}
+    assert [output_ptr] = cost;
+
     return ();
 }
 

--- a/tests/src/kakarot/test_gas.cairo
+++ b/tests/src/kakarot/test_gas.cairo
@@ -14,7 +14,7 @@ func test__memory_cost{range_check_ptr}(output_ptr: felt*) {
     return ();
 }
 
-func test__memory_expansion_cost{range_check_ptr}() {
+func test__memory_expansion_cost{range_check_ptr}(output_ptr: felt*) {
     tempvar words_len: felt;
     tempvar max_offset: felt;
     %{
@@ -23,11 +23,11 @@ func test__memory_expansion_cost{range_check_ptr}() {
     %}
     let cost = Gas.calculate_gas_extend_memory(words_len, max_offset);
 
-    %{ segments.write_arg(output, [ids.cost]); %}
+    assert [output_ptr] = cost;
     return ();
 }
 
-func test__max_memory_expansion_cost{range_check_ptr}() {
+func test__max_memory_expansion_cost{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     let fp_and_pc = get_fp_and_pc();
     local __fp__: felt* = fp_and_pc.fp_val;
@@ -49,11 +49,11 @@ func test__max_memory_expansion_cost{range_check_ptr}() {
     %}
     let cost = Gas.max_memory_expansion_cost(words_len, &offset_1, &size_1, &offset_2, &size_2);
 
-    %{ segments.write_arg(output, [ids.cost]); %}
+    assert [output_ptr] = cost;
     return ();
 }
 
-func test__compute_message_call_gas{range_check_ptr}() {
+func test__compute_message_call_gas{range_check_ptr}(output_ptr: felt*) {
     tempvar gas_param: Uint256;
     tempvar gas_left: felt;
     %{
@@ -63,6 +63,6 @@ func test__compute_message_call_gas{range_check_ptr}() {
     %}
     let gas = Gas.compute_message_call_gas(gas_param, gas_left);
 
-    %{ segments.write_arg(output, [ids.gas]); %}
+    assert [output_ptr] = gas;
     return ();
 }

--- a/tests/src/utils/test_array.cairo
+++ b/tests/src/utils/test_array.cairo
@@ -6,7 +6,7 @@ from starkware.cairo.common.alloc import alloc
 
 from utils.array import reverse, count_not_zero, slice, contains
 
-func test__reverse() {
+func test__reverse(output_ptr: felt*) {
     alloc_locals;
     tempvar arr_len: felt;
     let (arr) = alloc();
@@ -15,14 +15,11 @@ func test__reverse() {
         segments.write_arg(ids.arr, program_input["arr"])
     %}
 
-    tempvar rev: felt*;
-    %{ ids.rev = output %}
-
-    reverse(rev, arr_len, arr);
+    reverse(output_ptr, arr_len, arr);
     return ();
 }
 
-func test__count_not_zero() {
+func test__count_not_zero(output_ptr: felt*) {
     tempvar arr_len: felt;
     let (arr) = alloc();
     %{
@@ -31,11 +28,11 @@ func test__count_not_zero() {
     %}
 
     let count = count_not_zero(arr_len, arr);
-    %{ segments.write_arg(output, [ids.count]) %}
+    assert [output_ptr] = count;
     return ();
 }
 
-func test__slice{range_check_ptr}() {
+func test__slice{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     tempvar arr_len: felt;
     let (arr) = alloc();
@@ -48,13 +45,11 @@ func test__slice{range_check_ptr}() {
         ids.size = program_input["size"]
     %}
 
-    tempvar sliced: felt*;
-    %{ ids.sliced = output %}
-    slice(sliced, arr_len, arr, offset, size);
+    slice(output_ptr, arr_len, arr, offset, size);
     return ();
 }
 
-func test_contains{range_check_ptr}() {
+func test_contains{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     tempvar arr_len: felt;
     let (arr) = alloc();
@@ -66,6 +61,6 @@ func test_contains{range_check_ptr}() {
     %}
 
     let result = contains(arr_len, arr, value);
-    %{ segments.write_arg(output, [ids.result]) %}
+    assert [output_ptr] = result;
     return ();
 }

--- a/tests/src/utils/test_bytes.cairo
+++ b/tests/src/utils/test_bytes.cairo
@@ -14,54 +14,43 @@ from utils.bytes import (
     bytes_to_bytes8_little_endian,
 )
 
-func test__felt_to_ascii{range_check_ptr}() {
+func test__felt_to_ascii{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     tempvar n: felt;
     %{ ids.n = program_input["n"] %}
 
-    tempvar ascii: felt*;
-    %{ ids.ascii = output %}
-    felt_to_ascii(ascii, n);
+    felt_to_ascii(output_ptr, n);
     return ();
 }
 
-func test__felt_to_bytes_little() {
+func test__felt_to_bytes_little(output_ptr: felt*) {
     alloc_locals;
     tempvar n: felt;
     %{ ids.n = program_input["n"] %}
 
-    tempvar bytes: felt*;
-    %{ ids.bytes = output %}
-
-    felt_to_bytes_little(bytes, n);
+    felt_to_bytes_little(output_ptr, n);
     return ();
 }
 
-func test__felt_to_bytes() {
+func test__felt_to_bytes(output_ptr: felt*) {
     alloc_locals;
     tempvar n: felt;
     %{ ids.n = program_input["n"] %}
 
-    tempvar bytes: felt*;
-    %{ ids.bytes = output %}
-
-    felt_to_bytes(bytes, n);
+    felt_to_bytes(output_ptr, n);
     return ();
 }
 
-func test__felt_to_bytes20{range_check_ptr}() {
+func test__felt_to_bytes20{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     tempvar n: felt;
     %{ ids.n = program_input["n"] %}
 
-    tempvar bytes20: felt*;
-    %{ ids.bytes20 = output %}
-
-    felt_to_bytes20(bytes20, n);
+    felt_to_bytes20(output_ptr, n);
     return ();
 }
 
-func test__uint256_to_bytes_little{range_check_ptr}() {
+func test__uint256_to_bytes_little{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     tempvar n: Uint256;
     %{
@@ -69,14 +58,11 @@ func test__uint256_to_bytes_little{range_check_ptr}() {
         ids.n.high = program_input["n"][1]
     %}
 
-    tempvar bytes: felt*;
-    %{ ids.bytes = output %}
-
-    uint256_to_bytes_little(bytes, n);
+    uint256_to_bytes_little(output_ptr, n);
     return ();
 }
 
-func test__uint256_to_bytes{range_check_ptr}() {
+func test__uint256_to_bytes{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     tempvar n: Uint256;
     %{
@@ -84,14 +70,11 @@ func test__uint256_to_bytes{range_check_ptr}() {
         ids.n.high = program_input["n"][1]
     %}
 
-    tempvar bytes: felt*;
-    %{ ids.bytes = output %}
-
-    uint256_to_bytes(bytes, n);
+    uint256_to_bytes(output_ptr, n);
     return ();
 }
 
-func test__uint256_to_bytes32{range_check_ptr}() {
+func test__uint256_to_bytes32{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     tempvar n: Uint256;
     %{
@@ -99,14 +82,11 @@ func test__uint256_to_bytes32{range_check_ptr}() {
         ids.n.high = program_input["n"][1]
     %}
 
-    tempvar bytes: felt*;
-    %{ ids.bytes = output %}
-
-    uint256_to_bytes32(bytes, n);
+    uint256_to_bytes32(output_ptr, n);
     return ();
 }
 
-func test__bytes_to_bytes8_little_endian() {
+func test__bytes_to_bytes8_little_endian(output_ptr: felt*) {
     alloc_locals;
     tempvar bytes_len: felt;
     let (bytes) = alloc();
@@ -115,9 +95,7 @@ func test__bytes_to_bytes8_little_endian() {
         segments.write_arg(ids.bytes, program_input["bytes"])
     %}
 
-    tempvar res: felt*;
-    %{ ids.res = output %}
-    bytes_to_bytes8_little_endian(res, bytes_len, bytes);
+    bytes_to_bytes8_little_endian(output_ptr, bytes_len, bytes);
 
     return ();
 }

--- a/tests/src/utils/test_eth_transaction.cairo
+++ b/tests/src/utils/test_eth_transaction.cairo
@@ -6,7 +6,7 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 
-func test__decode{bitwise_ptr: BitwiseBuiltin*, range_check_ptr}() {
+func test__decode{bitwise_ptr: BitwiseBuiltin*, range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     // Given
     tempvar data_len: felt;
@@ -28,18 +28,16 @@ func test__decode{bitwise_ptr: BitwiseBuiltin*, range_check_ptr}() {
         payload: felt*,
     ) = EthTransaction.decode(data_len, data);
 
-    tempvar output: felt*;
-    %{ ids.output = output %}
-    assert [output] = msg_hash.low;
-    assert [output + 1] = msg_hash.high;
-    assert [output + 2] = nonce;
-    assert [output + 3] = gas_price;
-    assert [output + 4] = gas_limit;
-    assert [output + 5] = destination;
-    assert [output + 6] = amount;
-    assert [output + 7] = chain_id;
-    assert [output + 8] = payload_len;
-    memcpy(output + 9, payload, payload_len);
+    assert [output_ptr] = msg_hash.low;
+    assert [output_ptr + 1] = msg_hash.high;
+    assert [output_ptr + 2] = nonce;
+    assert [output_ptr + 3] = gas_price;
+    assert [output_ptr + 4] = gas_limit;
+    assert [output_ptr + 5] = destination;
+    assert [output_ptr + 6] = amount;
+    assert [output_ptr + 7] = chain_id;
+    assert [output_ptr + 8] = payload_len;
+    memcpy(output_ptr + 9, payload, payload_len);
 
     return ();
 }

--- a/tests/src/utils/test_rlp.cairo
+++ b/tests/src/utils/test_rlp.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 
-func test__decode{range_check_ptr}() {
+func test__decode{range_check_ptr}(output_ptr: felt*) {
     alloc_locals;
     // Given
     tempvar data_len: felt;
@@ -25,9 +25,7 @@ func test__decode{range_check_ptr}() {
     %{ ids.is_list = program_input["is_list"] %}
     assert item.is_list = is_list;
 
-    tempvar output: felt*;
-    %{ ids.output = output %}
-    memcpy(output, item.data, item.data_len);
+    memcpy(output_ptr, item.data, item.data_len);
 
     return ();
 }


### PR DESCRIPTION
I didn't realize first that calling a test entrypoint is like calling any function in cairo, meaning that one has
- args up to `[fp - 3]`
- return `fp`
- return `pc`

and that it's precisely what's done in the runner initialization. By just updating the order of the segment, the `output` segment is just accessed as the last (and only currently as we yet don't parse input args) argument.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/893)
<!-- Reviewable:end -->
