### PR TITLE
Fix print helpers based on new hints

### DIFF
--- a/scripts/utils/starknet.py
+++ b/scripts/utils/starknet.py
@@ -264,11 +264,7 @@ def compile_contract(contract):
             str(SOURCE_DIR),
             *(["--no_debug_info"] if not NETWORK["devnet"] else []),
             *(["--account_contract"] if contract["is_account_contract"] else []),
-            *(
-                ["--disable_hint_validation"]
-                if NETWORK["name"] == "starknet-devnet"
-                else []
-            ),
+            *(["--disable_hint_validation"] if NETWORK["devnet"] else []),
         ],
         capture_output=True,
     )

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -146,6 +146,11 @@ namespace TestHelpers {
         return ();
     }
 
+    func print_felt(x: felt) {
+        %{ print(ids.x) %}
+        return ();
+    }
+
     func print_uint256(val: Uint256) {
         %{
             low = ids.val.low
@@ -176,36 +181,24 @@ namespace TestHelpers {
     }
 
     func print_message(message: model.Message*) {
-        %{ print("print_message") %}
         print_array('calldata', message.calldata_len, message.calldata);
         print_array('bytecode', message.bytecode_len, message.bytecode);
-        %{
-            print(f"{ids.message.env.gas_price=}")
-            print(f"{ids.message.env.origin.evm=:040x}")
-            print(f"{ids.message.env.origin.starknet=:064x}")
-            print(f"{ids.message.address.evm=:040x}")
-            print(f"{ids.message.address.starknet=:064x}")
-            print(f"{ids.message.read_only=}")
-            print(f"{ids.message.is_create=}")
-        %}
+        print_felt(message.env.gas_price);
+        print_felt(message.env.origin);
+        print_felt(message.address.evm);
+        print_felt(message.address.starknet);
+        print_felt(message.read_only);
+        print_felt(message.is_create);
         return ();
     }
 
-    func print_execution_context(execution_context: model.EVM*) {
-        %{ print("print_execution_context") %}
-
-        print_message(execution_context.message);
-        print_dict('stack', execution_context.stack.dict_ptr, Uint256.SIZE);
-
-        print_array(
-            'return_data', execution_context.return_data_len, execution_context.return_data
-        );
-        %{
-            print(f"{ids.execution_context.program_counter=}")
-            print(f"{ids.execution_context.stopped=}")
-            print(f"{ids.execution_context.gas_left=}")
-            print(f"{ids.execution_context.reverted=}")
-        %}
+    func print_execution_context(evm: model.EVM*) {
+        print_message(evm.message);
+        print_array('return_data', evm.return_data_len, evm.return_data);
+        print_felt(evm.program_counter);
+        print_felt(evm.stopped);
+        print_felt(evm.gas_left);
+        print_felt(evm.reverted);
         return ();
     }
 }


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `print_XXX` hints in `tests/utils/helpers.cairo` still use some non implemented hints.
The `print_felt` hint is missing.

## What is the new behavior?

Fixed these utils, such that they can be used as is with the ef-test runner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/901)
<!-- Reviewable:end -->
