### PR TITLE
Add debug_info hint util

### DIFF
--- a/tests/fixtures/starknet.py
+++ b/tests/fixtures/starknet.py
@@ -27,6 +27,7 @@ from starkware.starknet.testing.starknet import Starknet
 
 from tests.utils.constants import BLOCK_NUMBER, BLOCK_TIMESTAMP
 from tests.utils.coverage import VmWithCoverage, report_runs
+from tests.utils.hints import debug_info
 from tests.utils.reporting import (
     dump_coverage,
     dump_reports,
@@ -235,7 +236,8 @@ def cairo_run(request) -> list:
             hint_locals={
                 "program_input": kwargs,
                 "syscall_handler": SyscallHandler(),
-            }
+            },
+            static_locals={"debug_info": debug_info(program)},
         )
         runner.run_until_pc(stack[-1])
         runner.original_steps = runner.vm.current_step

--- a/tests/utils/hints.py
+++ b/tests/utils/hints.py
@@ -1,0 +1,9 @@
+def debug_info(program):
+    def _debug_info(pc):
+        print(
+            program.debug_info.instruction_locations.get(
+                pc.offset
+            ).inst.to_string_with_content("")
+        )
+
+    return _debug_info


### PR DESCRIPTION
Time spent on this PR: 0.15

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When running a cairo program, there is no easy way to locate the corresponding cairo code.

## What is the new behavior?

Added a `debug_info` util that can be called directly from a hint with `debug_info(pc)` to
print the corresponding `debug_info` (cairo source code).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/915)
<!-- Reviewable:end -->
