### PR TITLE
fix: create finalization on REVERT opcode

### DIFF
--- a/blockchain-tests-skip.yml
+++ b/blockchain-tests-skip.yml
@@ -43,9 +43,6 @@ testname:
   stChainId:
     - chainId_d0g0v0_Shanghai
   stCreate2:
-    - Create2OOGafterInitCodeReturndataSize_d0g0v0_Shanghai
-    - Create2OOGafterInitCodeRevert_d0g0v0_Shanghai
-    - RevertOpcodeCreate_d0g0v0_Shanghai
     - create2callPrecompiles_d6g0v0_Shanghai
     - create2callPrecompiles_d7g0v0_Shanghai
     - create2collisionBalance_d0g0v0_Shanghai
@@ -62,25 +59,13 @@ testname:
     - CreateAddressWarmAfterFail_d3g0v1_Shanghai
     - CreateCollisionToEmpty_d0g0v0_Shanghai
     - CreateCollisionToEmpty_d0g0v1_Shanghai
-    - CreateOOGafterInitCodeReturndataSize_d0g0v0_Shanghai
-    - CreateOOGafterInitCodeRevert_d0g0v0_Shanghai
     - CreateOOGafterMaxCodesize_d2g0v0_Shanghai
     - CreateOOGafterMaxCodesize_d3g0v0_Shanghai
     - CreateOOGafterMaxCodesize_d5g0v0_Shanghai
-    - CreateResults_d8g0v0_Shanghai
-    - CreateResults_d9g0v0_Shanghai
     - CreateTransactionHighNonce_d0g0v0_Shanghai
     - CreateTransactionHighNonce_d0g0v1_Shanghai
     - TransactionCollisionToEmpty_d0g0v0_Shanghai
     - TransactionCollisionToEmpty_d0g0v1_Shanghai
-    - createLargeResult_d10g0v0_Shanghai
-    - createLargeResult_d11g0v0_Shanghai
-    - createLargeResult_d14g0v0_Shanghai
-    - createLargeResult_d15g0v0_Shanghai
-    - createLargeResult_d2g0v0_Shanghai
-    - createLargeResult_d3g0v0_Shanghai
-    - createLargeResult_d6g0v0_Shanghai
-    - createLargeResult_d7g0v0_Shanghai
   stCallCreateCallCodeTest:
     - Call1024BalanceTooLow_d0g0v0_Shanghai
     - Call1024PreCalls_d0g0v0_Shanghai


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes the finalization of a parent context in a CREATE execution. We need to handle the case where the EVM has errored (exceptional or classic revert) before anything else.
-
-
