### PR TITLE
Fetch ssj artifacts for end to end in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,14 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-      - name: Retrieve cached dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Load cached katana
+        id: cached-katana
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin
+          key: katana-fe8f233
       - name: Install Katana
+        if: steps.cached-katana.outputs.cache-hit != 'true'
         run: make install-katana
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
         run: make install-katana
       - name: Run tests
         run: |
+          make fetch-ssj-artifacts
           cp .env.example .env
           make run-katana & make test-end-to-end
 


### PR DESCRIPTION
`make setup` does fetch them but may be skipped if no deps changed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/991)
<!-- Reviewable:end -->
