### PR TITLE
Fix running profiling for Solmate

### DIFF
--- a/tests/src/kakarot/test_kakarot.cairo
+++ b/tests/src/kakarot/test_kakarot.cairo
@@ -39,6 +39,7 @@ func eth_call{
     %}
 
     let (evm, state, gas_used) = Kakarot.eth_call(
+        nonce=0,
         origin=origin,
         to=to,
         gas_limit=gas_limit,


### PR DESCRIPTION
Just adding a missing nonce argument in the `eth_call`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1026)
<!-- Reviewable:end -->
