### PR TITLE
Optimize get_jumpdests

### DIFF
--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -904,4 +904,29 @@ namespace Helpers {
             data_len=data_len - 1, data=data + 1, bytes_len=bytes_len + 4, bytes=res
         );
     }
+    // Returns 1 if lhs <= rhs (or more precisely 0 <= rhs - lhs < RANGE_CHECK_BOUND).
+    // Returns 0 otherwise.
+    // Soundness assumptions (caller responsibility to ensure those) :
+    // - 0 <= lhs < RANGE_CHECK_BOUND
+    // - 0 <= rhs < RANGE_CHECK_BOUND
+    @known_ap_change
+    func is_le_unchecked{range_check_ptr}(lhs: felt, rhs: felt) -> felt {
+        tempvar a = rhs - lhs;  // reference (rhs-lhs) as "a" to use already whitelisted hint
+        %{ memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1 %}
+        jmp false if [ap] != 0, ap++;
+
+        // Ensure lhs <= rhs
+        assert [range_check_ptr] = a;
+        ap += 2;  // Two memory holes for known_ap_change in case of false case: Two instructions more: -1*a, and (-1*a) - 1.
+        tempvar range_check_ptr = range_check_ptr + 1;
+        tempvar res = 1;
+        ret;
+
+        false:
+        // Ensure rhs < lhs
+        assert [range_check_ptr] = (-a) - 1;
+        tempvar range_check_ptr = range_check_ptr + 1;
+        tempvar res = 0;
+        ret;
+    }
 }

--- a/tests/fixtures/starknet.py
+++ b/tests/fixtures/starknet.py
@@ -232,8 +232,8 @@ def cairo_run(request) -> list:
             output_path = (
                 str(
                     request.node.path.parent
-                    / f"{request.node.path.stem}.{entrypoint}({(json.dumps(kwargs) if kwargs else '')})"
-                )[:220]
+                    / f"{request.node.path.stem}.{entrypoint}_{(json.dumps(kwargs) if kwargs else '')}"
+                )[:180]
                 + ".pb.gz"
             )
             with open(output_path, "wb") as fp:


### PR DESCRIPTION
- add `is_le_unchecked` function
- exit the loop without using `is_le` at each iteration. Only done once at exit. 

Before : 
![image](https://github.com/kkrt-labs/kakarot/assets/96737978/63b78a9e-9723-45b3-9b70-099f48e13b1b)


After : 
![image](https://github.com/kkrt-labs/kakarot/assets/96737978/4810afe2-d457-4db1-8126-1f082c8d75f7)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1034)
<!-- Reviewable:end -->
