### PR TITLE
feat: blobhash (0x49)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ markers = [
   "CHAINID:        Opcode Value 0x46 - Get the chain ID",
   "SELFBALANCE:    Opcode Value 0x47 - Get the balance of the current contract",
   "BASEFEE:        Opcode Value 0x48 - Get the base fee of the current block",
+  "BLOBHASH:       Opcode Value 0x49 - Get the versioned hash at the requested index",
   "BLOBBASEFEE:    Opcode Value 0x4a - Get the blob base-fee of the current block",
   "StackMemoryStorageFlowOperations",
   "MLOAD:          Opcode Value 0x51 - Load word from memory",

--- a/src/kakarot/constants.cairo
+++ b/src/kakarot/constants.cairo
@@ -470,11 +470,11 @@ dw Gas.BASE;
 dw 0;
 dw 0;
 dw 1;
-// INVALID
+// BLOBHASH
 dw 0x49;
-dw 0;
-dw 0;
-dw 0;
+dw Gas.BLOBHASH;
+dw 1;
+dw 1;
 dw 0;
 // BLOBBASEFEE
 dw 0x4a;

--- a/src/kakarot/gas.cairo
+++ b/src/kakarot/gas.cairo
@@ -52,6 +52,7 @@ namespace Gas {
     const TX_BASE_COST = 21000;
     const TX_ACCESS_LIST_ADDRESS_COST = 2400;
     const TX_ACCESS_LIST_STORAGE_KEY_COST = 1900;
+    const BLOBHASH = 3;
 
     // @notice Compute the cost of the memory for a given words length.
     // @dev To avoid range_check overflow, we compute words_len / 512

--- a/src/kakarot/instructions/block_information.cairo
+++ b/src/kakarot/instructions/block_information.cairo
@@ -41,7 +41,7 @@ namespace BlockInformation {
         jmp chainid;
         jmp selfbalance;
         jmp basefee;
-        jmp invalid_opcode_0x49;
+        jmp blobhash;
         jmp blobbasefee;
 
         blockhash:
@@ -124,7 +124,10 @@ namespace BlockInformation {
         Stack.push_uint128(evm.message.env.base_fee);
         jmp end;
 
-        invalid_opcode_0x49:
+        blobhash:
+        let stack = cast([fp - 6], model.Stack*);
+        Stack.pop();
+        Stack.push_uint128(0);
         jmp end;
 
         blobbasefee:

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -275,7 +275,7 @@ namespace Interpreter {
         jmp end;
         call BlockInformation.exec_block_information;  // 0x48
         jmp end;
-        call unknown_opcode;  // 0x49
+        call BlockInformation.exec_block_information;  // 0x49
         jmp end;
         call BlockInformation.exec_block_information;  // 0x4a
         jmp end;

--- a/tests/end_to_end/bytecodes.py
+++ b/tests/end_to_end/bytecodes.py
@@ -984,6 +984,22 @@ test_cases = [
     {
         "params": {
             "value": 0,
+            "code": "60004900",
+            "calldata": "",
+            "stack": "0",
+            "memory": "",
+            "return_data": "",
+            "success": 1,
+        },
+        "id": "Get blob versioned hash",
+        "marks": [
+            pytest.mark.BLOBHASH,
+            pytest.mark.BlockInformation,
+        ],
+    },
+    {
+        "params": {
+            "value": 0,
             "code": "4a00",
             "calldata": "",
             "stack": "0",

--- a/tests/src/kakarot/instructions/test_block_information.py
+++ b/tests/src/kakarot/instructions/test_block_information.py
@@ -20,6 +20,7 @@ class TestBlockInformation:
             (Opcodes.GASLIMIT, BLOCK_GAS_LIMIT),
             (Opcodes.CHAINID, CHAIN_ID),
             (Opcodes.BASEFEE, 0),
+            (Opcodes.BLOBHASH, 0),
             (Opcodes.BLOBBASEFEE, 0),
         ],
     )

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -232,6 +232,7 @@ class Opcodes(IntEnum):
     CHAINID = 0x46
     SELFBALANCE = 0x47
     BASEFEE = 0x48
+    BLOBHASH = 0x49
     BLOBBASEFEE = 0x4A
     POP = 0x50
     MLOAD = 0x51


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds support for the blobhash opcode.

> the blobhash opcode reads index from the top of the stack as big-endian uint256, and replaces it on the stack with tx.blob_versioned_hashes[index] if index < len(tx.blob_versioned_hashes), and otherwise with a zeroed bytes32 value. The opcode has a gas cost of HASH_OPCODE_GAS.

As we don't support blob transactions, we would be in thecase where `index < len(tx.blob_versioned_hashes)` holds at all times. Thus, we simply push 0 to the stack.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1036)
<!-- Reviewable:end -->
