### PR TITLE
feat: take chain_id mod 64

### DIFF
--- a/src/backend/starknet.cairo
+++ b/src/backend/starknet.cairo
@@ -7,6 +7,7 @@ from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.memset import memset
 from starkware.starknet.common.syscalls import (
     emit_event,
@@ -122,11 +123,12 @@ namespace Starknet {
 
         // No idea why this is required - but trying to pass prev_randao_ directly causes bugs.
         let prev_randao_ = Uint256(low=prev_randao_.low, high=prev_randao_.high);
+        let (_, chain_id) = unsigned_div_rem(tx_info.chain_id, 2 ** 64);
 
         return new model.Environment(
             origin=origin,
             gas_price=gas_price,
-            chain_id=tx_info.chain_id,
+            chain_id=chain_id,
             prev_randao=prev_randao_,
             block_number=block_number,
             block_gas_limit=block_gas_limit_,

--- a/src/kakarot/accounts/eoa/library.cairo
+++ b/src/kakarot/accounts/eoa/library.cairo
@@ -7,7 +7,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.math_cmp import is_le
-from starkware.cairo.common.math import split_felt
+from starkware.cairo.common.math import split_felt, unsigned_div_rem
 
 from kakarot.account import Account
 from kakarot.errors import Errors
@@ -118,10 +118,12 @@ namespace ExternallyOwnedAccount {
         let s = Uint256(tx_info.signature[2], tx_info.signature[3]);
         let v = tx_info.signature[4];
 
+        let (_, chain_id) = unsigned_div_rem(tx_info.chain_id, 2 ** 64);
+
         EthTransaction.validate(
             address,
             tx_info.nonce,
-            tx_info.chain_id,
+            chain_id,
             r,
             s,
             v,

--- a/tests/src/kakarot/instructions/test_block_information.cairo
+++ b/tests/src/kakarot/instructions/test_block_information.cairo
@@ -35,3 +35,28 @@ func test__exec_block_information{
     // Then
     return result;
 }
+
+func test__exec_chain_id{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() -> Uint256* {
+    // Given
+    alloc_locals;
+    tempvar opcode: felt;
+    %{ ids.opcode = program_input["chain_id"] %}
+
+    let stack = Stack.init();
+    let memory = Memory.init();
+    let state = State.init();
+    let (bytecode) = alloc();
+    assert [bytecode] = opcode;
+    let evm = TestHelpers.init_evm_with_bytecode(1, bytecode);
+
+    // When
+    with stack, memory, state {
+        let evm = BlockInformation.exec_block_information(evm);
+        let (result) = Stack.peek(0);
+    }
+
+    // Then
+    return result;
+}

--- a/tests/src/kakarot/instructions/test_block_information.py
+++ b/tests/src/kakarot/instructions/test_block_information.py
@@ -1,8 +1,9 @@
+from collections import OrderedDict
 from unittest.mock import patch
 
 import pytest
 
-from tests.utils.constants import BLOCK_GAS_LIMIT, CHAIN_ID, Opcodes
+from tests.utils.constants import BIG_CHAIN_ID, BLOCK_GAS_LIMIT, CHAIN_ID, Opcodes
 from tests.utils.syscall_handler import SyscallHandler
 
 
@@ -30,3 +31,24 @@ class TestBlockInformation:
     def test__exec_block_information(self, cairo_run, opcode, expected_result):
         output = cairo_run("test__exec_block_information", opcode=opcode)
         assert output == hex(expected_result)
+
+    @patch.object(
+        SyscallHandler,
+        "tx_info",
+        OrderedDict(
+            {
+                "version": 1,
+                "account_contract_address": 0xABDE1,
+                "max_fee": int(1e17),
+                # Signature len will be set later based on the signature.
+                "signature_len": None,
+                "signature": [],
+                "transaction_hash": 0xABDE1,
+                "chain_id": BIG_CHAIN_ID,
+                "nonce": 1,
+            }
+        ),
+    )
+    def test__exec_chain_id__should_return_mod_64(self, cairo_run):
+        output = cairo_run("test__exec_block_information", opcode=Opcodes.CHAINID)
+        assert output == hex(BIG_CHAIN_ID % 2**64)

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -6,6 +6,7 @@ from kakarot_scripts.constants import BLOCK_GAS_LIMIT
 BLOCK_GAS_LIMIT = BLOCK_GAS_LIMIT
 
 CHAIN_ID = int.from_bytes(b"KKRT", "big")  # KKRT (0x4b4b5254) in ASCII
+BIG_CHAIN_ID = int.from_bytes(b"SN_SEPOLIA", "big")
 
 # Amount of funds to pre-fund the account with
 PRE_FUND_AMOUNT = int(1e17)  # 0.01 ETH


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.1d

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Take chain_id mod 64, as EVM tools don't accept chain_id with values > 64 bits. For example, "SN_SEPOLIA" takes 10 bytes, thus doesn't fit in 64 bits, and cannot be used as a valid CHAIN_ID in wallets. Both the wallets and Kakarot will take CHAIN_ID modulo 64
-
-

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1048)
<!-- Reviewable:end -->
