### PR TITLE
fast uint256_add | uint256_sub

### DIFF
--- a/src/kakarot/instructions/stop_and_math_operations.cairo
+++ b/src/kakarot/instructions/stop_and_math_operations.cairo
@@ -78,7 +78,7 @@ func uint256_add{range_check_ptr}(a: Uint256, b: Uint256) -> (res: Uint256, carr
     }
 }
 
-// Substracts two integers. Returns the result as a 256-bit integer.
+// Subtracts two integers. Returns the result as a 256-bit integer.
 // Strictly equivalent and faster version of common.uint256.uint256_sub using uint256_add's whitelisted hint.
 func uint256_sub{range_check_ptr}(a: Uint256, b: Uint256) -> (res: Uint256) {
     alloc_locals;

--- a/src/kakarot/instructions/stop_and_math_operations.cairo
+++ b/src/kakarot/instructions/stop_and_math_operations.cairo
@@ -7,7 +7,6 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import (
-    uint256_add,
     uint256_and,
     uint256_eq,
     uint256_lt,
@@ -19,10 +18,11 @@ from starkware.cairo.common.uint256 import (
     uint256_shr,
     uint256_signed_div_rem,
     uint256_signed_lt,
-    uint256_sub,
     uint256_unsigned_div_rem,
     uint256_xor,
     Uint256,
+    SHIFT,
+    ALL_ONES,
 )
 
 from kakarot.constants import opcodes_label
@@ -34,6 +34,96 @@ from kakarot.state import State
 from utils.uint256 import uint256_fast_exp, uint256_signextend
 from utils.utils import Helpers
 
+// Adds two integers. Returns the result as a 256-bit integer and the (1-bit) carry.
+// Strictly equivalent and faster version of common.uint256.uint256_add using the same whitelisted hint.
+func uint256_add{range_check_ptr}(a: Uint256, b: Uint256) -> (res: Uint256, carry: felt) {
+    alloc_locals;
+    local carry_low: felt;
+    local carry_high: felt;
+    %{
+        sum_low = ids.a.low + ids.b.low
+        ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
+        sum_high = ids.a.high + ids.b.high + ids.carry_low
+        ids.carry_high = 1 if sum_high >= ids.SHIFT else 0
+    %}
+
+    if (carry_low != 0) {
+        if (carry_high != 0) {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low - SHIFT, high=a.high + b.high + 1 - SHIFT);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res, 1);
+        } else {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low - SHIFT, high=a.high + b.high + 1);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res, 0);
+        }
+    } else {
+        if (carry_high != 0) {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low, high=a.high + b.high - SHIFT);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res, 1);
+        } else {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low, high=a.high + b.high);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res, 0);
+        }
+    }
+}
+
+// Substracts two integers. Returns the result as a 256-bit integer.
+// Strictly equivalent and faster version of common.uint256.uint256_sub using uint256_add's whitelisted hint.
+func uint256_sub{range_check_ptr}(a: Uint256, b: Uint256) -> (res: Uint256) {
+    alloc_locals;
+    // Reference "b" as -b.
+    local b: Uint256 = Uint256(ALL_ONES - b.low + 1, ALL_ONES - b.high);
+    // Computes a + (-b)
+    local carry_low: felt;
+    local carry_high: felt;
+    %{
+        sum_low = ids.a.low + ids.b.low
+        ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
+        sum_high = ids.a.high + ids.b.high + ids.carry_low
+        ids.carry_high = 1 if sum_high >= ids.SHIFT else 0
+    %}
+
+    if (carry_low != 0) {
+        if (carry_high != 0) {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low - SHIFT, high=a.high + b.high + 1 - SHIFT);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res,);
+        } else {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low - SHIFT, high=a.high + b.high + 1);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res,);
+        }
+    } else {
+        if (carry_high != 0) {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low, high=a.high + b.high - SHIFT);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res,);
+        } else {
+            tempvar range_check_ptr = range_check_ptr + 2;
+            tempvar res = Uint256(low=a.low + b.low, high=a.high + b.high);
+            assert [range_check_ptr - 2] = res.low;
+            assert [range_check_ptr - 1] = res.high;
+            return (res,);
+        }
+    }
+}
 // @title Stop and Math operations opcodes.
 // @notice Math operations gathers Arithmetic and Comparison operations
 namespace StopAndMathOperations {


### PR DESCRIPTION
Using whitelisted hints:
uint256_add : 22 steps -> 10 steps
uint256_sub : ~60 steps -> 13 steps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1049)
<!-- Reviewable:end -->
