### PR TITLE
feat: estimate_gas

### DIFF
--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -85,7 +85,7 @@ namespace Kakarot {
         data: felt*,
         access_list_len: felt,
         access_list: felt*,
-    ) -> (model.EVM*, model.State*, felt) {
+    ) -> (model.EVM*, model.State*, felt, felt) {
         alloc_locals;
         let is_regular_tx = is_not_zero(to.is_some);
         let is_deploy_tx = 1 - is_regular_tx;
@@ -99,7 +99,7 @@ namespace Kakarot {
 
         let env = Starknet.get_env(origin, gas_price);
 
-        let (evm, stack, memory, state, gas_used) = Interpreter.execute(
+        let (evm, stack, memory, state, gas_used, required_gas) = Interpreter.execute(
             env,
             address,
             is_deploy_tx,
@@ -112,7 +112,7 @@ namespace Kakarot {
             access_list_len,
             access_list,
         );
-        return (evm, state, gas_used);
+        return (evm, state, gas_used, required_gas);
     }
 
     // @notice Set the native Starknet ERC20 token used by kakarot.

--- a/tests/fixtures/EVM.cairo
+++ b/tests/fixtures/EVM.cairo
@@ -63,7 +63,7 @@ func execute{
     let evm_address = 'target_evm_address';
     let starknet_address = Account.compute_starknet_address(evm_address);
     tempvar address = new model.Address(starknet_address, evm_address);
-    let (evm, stack, memory, state, gas_used) = Interpreter.execute(
+    let (evm, stack, memory, state, gas_used, _) = Interpreter.execute(
         env=env,
         address=address,
         is_deploy_tx=0,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.2d

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #1067

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds an eth_estimate_gas entrypoint that returns the required gas for the transaction to run successfully. This is different from gas_used, s.t. `required gas >= gas used`, as the EVM can reimburse gas after its execution.
-
-

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1074)
<!-- Reviewable:end -->
