### PR TITLE
add more rlp cases for long bytes for profiling

### DIFF
--- a/tests/src/utils/test_rlp.py
+++ b/tests/src/utils/test_rlp.py
@@ -58,7 +58,9 @@ class TestRLP:
             assert output[2] == expected_len
 
     class TestDecode:
-        @pytest.mark.parametrize("payload_len", [55, 56])
+        @pytest.mark.parametrize(
+            "payload_len", [32, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
+        )
         async def test_should_match_decode_reference_implementation(
             self, cairo_run, payload_len
         ):


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:0.01day




- added more cases to the rlp decode test, to help profile edge cases of large contracts (~24kb and even more) -> can we limit the cairo_run function to a certain numbers of steps? that way it'll fail the test if it takes too many steps? to replicate appchain behaviour?
- maybe good idea to also add a test in end-to-end tests to replicate more accurately appchain behaviour -> try to deploy an enormous chunk of bytecode

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1097)
<!-- Reviewable:end -->
