### PR TITLE
dev: enforce katana in make test-end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,6 @@
 # Used for fetching resources in the kakarot_scripts
 GITHUB_TOKEN=
 
-# Starkent Network
-STARKNET_NETWORK=katana
-
 # An infura RPC key for mainnet/testnet
 INFURA_KEY=
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test: build-sol deploy
 test-unit: build-sol
 	poetry run pytest tests/src -m "not NoCI" -n logical
 
+test-end-to-end: export STARKNET_NETWORK := katana
 test-end-to-end: build-sol deploy
 	poetry run pytest tests/end_to_end
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ test: build-sol deploy
 test-unit: build-sol
 	poetry run pytest tests/src -m "not NoCI" -n logical
 
-test-end-to-end: export STARKNET_NETWORK := katana
 test-end-to-end: build-sol deploy
 	poetry run pytest tests/end_to_end
 

--- a/kakarot_scripts/constants.py
+++ b/kakarot_scripts/constants.py
@@ -95,14 +95,7 @@ if os.getenv("STARKNET_NETWORK") is not None:
             f"STARKNET_NETWORK {os.environ['STARKNET_NETWORK']} given in env variable unknown"
         )
 else:
-    NETWORK = {
-        "name": os.getenv("RPC_NAME", "custom-rpc"),
-        "rpc_url": os.getenv("RPC_URL"),
-        "explorer_url": "",
-        "devnet": False,
-        "check_interval": float(os.getenv("CHECK_INTERVAL", 0.1)),
-        "max_wait": float(os.getenv("MAX_WAIT", 30)),
-    }
+    NETWORK = NETWORKS["katana"]
 
 prefix = NETWORK["name"].upper().replace("-", "_")
 NETWORK["account_address"] = os.environ.get(f"{prefix}_ACCOUNT_ADDRESS")

--- a/kakarot_scripts/constants.py
+++ b/kakarot_scripts/constants.py
@@ -94,6 +94,15 @@ if os.getenv("STARKNET_NETWORK") is not None:
         raise ValueError(
             f"STARKNET_NETWORK {os.environ['STARKNET_NETWORK']} given in env variable unknown"
         )
+elif os.getenv("RPC_URL") is not None:
+    NETWORK = {
+        "name": os.getenv("RPC_NAME", "custom-rpc"),
+        "rpc_url": os.getenv("RPC_URL"),
+        "explorer_url": "",
+        "devnet": False,
+        "check_interval": float(os.getenv("CHECK_INTERVAL", 0.1)),
+        "max_wait": float(os.getenv("MAX_WAIT", 30)),
+    }
 else:
     NETWORK = NETWORKS["katana"]
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 45 -50 mins 

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

from .env file, the variable STARKNET_NETWORK is used to both:

- decide on which network to deploy kakarot
- decide on which network to run the integration tests

Resolves #1100 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- make test-end-to-end forces STARKNET_NETWORK to be katana

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1106)
<!-- Reviewable:end -->
