### PR TITLE
Tests/improve auth tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ make run-katana
 make test
 
 # Run only unit tests
-make test-units
+make test-unit
 
 # Run only integration tests
 make test-integration

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -950,7 +950,35 @@ namespace SystemOperations {
 
         if (calculated_eth_address != authority) {
             Stack.push_uint128(0);
-            return evm;
+            tempvar authorized = new model.Option(is_some=0, value=0);
+            tempvar message = new model.Message(
+                bytecode=evm.message.bytecode,
+                bytecode_len=evm.message.bytecode_len,
+                valid_jumpdests_start=evm.message.valid_jumpdests_start,
+                valid_jumpdests=evm.message.valid_jumpdests,
+                calldata=evm.message.calldata,
+                calldata_len=evm.message.calldata_len,
+                value=evm.message.value,
+                caller=evm.message.caller,
+                parent=evm.message.parent,
+                address=evm.message.address,
+                code_address=evm.message.code_address,
+                read_only=evm.message.read_only,
+                is_create=evm.message.is_create,
+                authorized=authorized,
+                depth=evm.message.depth,
+                env=evm.message.env,
+            );
+            return new model.EVM(
+                message=message,
+                return_data_len=evm.return_data_len,
+                return_data=evm.return_data,
+                program_counter=evm.program_counter,
+                stopped=evm.stopped,
+                gas_left=evm.gas_left,
+                gas_refund=evm.gas_refund,
+                reverted=evm.reverted,
+            );
         }
 
         Stack.push_uint128(1);

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -68,7 +68,9 @@ func test__auth_with_initial_authority_set{
     let state = State.init();
 
     let (bytecode) = alloc();
-    let evm = TestHelpers.init_evm_at_address_with_authority_set(0, bytecode, 0x1234, invoker_address);
+    let evm = TestHelpers.init_evm_at_address_with_authority_set(
+        0, bytecode, 0x1234, invoker_address
+    );
 
     with stack, state, memory {
         let evm = SystemOperations.exec_auth(evm);

--- a/tests/src/kakarot/instructions/test_system_operations.cairo
+++ b/tests/src/kakarot/instructions/test_system_operations.cairo
@@ -13,7 +13,7 @@ from kakarot.instructions.system_operations import SystemOperations
 
 from tests.utils.helpers import TestHelpers
 
-func test__auth{
+func test__auth_with_initial_authority_unset{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
 }() -> (model.Stack*, model.EVM*) {
     alloc_locals;
@@ -37,6 +37,38 @@ func test__auth{
 
     let (bytecode) = alloc();
     let evm = TestHelpers.init_evm_at_address(0, bytecode, 0x1234, invoker_address);
+
+    with stack, state, memory {
+        let evm = SystemOperations.exec_auth(evm);
+    }
+
+    return (stack, evm);
+}
+
+func test__auth_with_initial_authority_set{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() -> (model.Stack*, model.EVM*) {
+    alloc_locals;
+    local auth_stack_len;
+    local auth_memory_len;
+    local invoker_address;
+    let (auth_stack_ptr) = alloc();
+    let (auth_memory) = alloc();
+    let auth_stack = cast(auth_stack_ptr, Uint256*);
+    %{
+        from itertools import chain
+        ids.auth_stack_len = len(program_input["stack"])
+        segments.write_arg(ids.auth_stack_ptr, list(chain.from_iterable(program_input["stack"])))
+        ids.auth_memory_len = len(program_input["memory"])
+        segments.write_arg(ids.auth_memory, program_input["memory"])
+        ids.invoker_address = program_input["invoker_address"]
+    %}
+    let stack = TestHelpers.init_stack_with_values(auth_stack_len, auth_stack);
+    let memory = TestHelpers.init_memory_with_values(auth_memory_len, auth_memory);
+    let state = State.init();
+
+    let (bytecode) = alloc();
+    let evm = TestHelpers.init_evm_at_address_with_authority_set(0, bytecode, 0x1234, invoker_address);
 
     with stack, state, memory {
         let evm = SystemOperations.exec_auth(evm);

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -103,7 +103,7 @@ class TestSystemOperations:
                 "Kakarot_evm_to_starknet_address", invoker_address, 0x1234
             ):
                 stack, evm = cairo_run(
-                    "test__auth_with_initial_authority_unset",
+                    "test__auth_with_initial_authority_set",
                     stack=stack,
                     memory=memory,
                     invoker_address=invoker_address,

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -74,7 +74,7 @@ class TestSystemOperations:
                 "Kakarot_evm_to_starknet_address", invoker_address, 0x1234
             ):
                 stack, evm = cairo_run(
-                    "test__auth",
+                    "test__auth_with_initial_authority_unset",
                     stack=stack,
                     memory=memory,
                     invoker_address=invoker_address,
@@ -103,7 +103,7 @@ class TestSystemOperations:
                 "Kakarot_evm_to_starknet_address", invoker_address, 0x1234
             ):
                 stack, evm = cairo_run(
-                    "test__auth",
+                    "test__auth_with_initial_authority_unset",
                     stack=stack,
                     memory=memory,
                     invoker_address=invoker_address,
@@ -119,7 +119,7 @@ class TestSystemOperations:
             self, cairo_run, private_key, invoker_address, message
         ):
             invoker_address += 1
-            _, msg_hash, stack, memory = prepare_stack_and_memory(
+            _, _, stack, memory = prepare_stack_and_memory(
                 invoker_address, message, private_key
             )
 
@@ -127,7 +127,30 @@ class TestSystemOperations:
                 "Kakarot_evm_to_starknet_address", invoker_address, 0x1234
             ):
                 stack, evm = cairo_run(
-                    "test__auth",
+                    "test__auth_with_initial_authority_unset",
+                    stack=stack,
+                    memory=memory,
+                    invoker_address=invoker_address,
+                )
+
+            assert stack == ["0x0"]
+            assert evm["message"]["authorized"] == {"is_some": 0, "value": 0}
+
+        @SyscallHandler.patch("IERC20.balanceOf", lambda addr, data: [0, 1])
+        @SyscallHandler.patch("IAccount.get_nonce", lambda addr, data: [NONCE])
+        @SyscallHandler.patch("IAccount.bytecode", lambda addr, data: [3, 0x1, 0x2, 0x3])
+        def test__should_fail_authority_has_code(
+            self, cairo_run, private_key, invoker_address, message
+        ):
+            _, _, stack, memory = prepare_stack_and_memory(
+                invoker_address, message, private_key
+            )
+
+            with SyscallHandler.patch(
+                "Kakarot_evm_to_starknet_address", invoker_address, 0x1234
+            ):
+                stack, evm = cairo_run(
+                    "test__auth_with_initial_authority_set",
                     stack=stack,
                     memory=memory,
                     invoker_address=invoker_address,

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -138,7 +138,9 @@ class TestSystemOperations:
 
         @SyscallHandler.patch("IERC20.balanceOf", lambda addr, data: [0, 1])
         @SyscallHandler.patch("IAccount.get_nonce", lambda addr, data: [NONCE])
-        @SyscallHandler.patch("IAccount.bytecode", lambda addr, data: [3, 0x1, 0x2, 0x3])
+        @SyscallHandler.patch(
+            "IAccount.bytecode", lambda addr, data: [3, 0x1, 0x2, 0x3]
+        )
         def test__should_fail_authority_has_code(
             self, cairo_run, private_key, invoker_address, message
         ):

--- a/tests/src/kakarot/instructions/test_system_operations.py
+++ b/tests/src/kakarot/instructions/test_system_operations.py
@@ -127,7 +127,7 @@ class TestSystemOperations:
                 "Kakarot_evm_to_starknet_address", invoker_address, 0x1234
             ):
                 stack, evm = cairo_run(
-                    "test__auth_with_initial_authority_unset",
+                    "test__auth_with_initial_authority_set",
                     stack=stack,
                     memory=memory,
                     invoker_address=invoker_address,

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -72,7 +72,9 @@ namespace TestHelpers {
         return init_evm_at_address(bytecode_len, bytecode, 0, 0);
     }
 
-    func init_evm_at_address_with_authority_set{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    func init_evm_at_address_with_authority_set{
+        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+    }(
         bytecode_len: felt,
         bytecode: felt*,
         starknet_contract_address: felt,

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -72,6 +72,46 @@ namespace TestHelpers {
         return init_evm_at_address(bytecode_len, bytecode, 0, 0);
     }
 
+    func init_evm_at_address_with_authority_set{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        bytecode_len: felt,
+        bytecode: felt*,
+        starknet_contract_address: felt,
+        evm_contract_address: felt,
+    ) -> model.EVM* {
+        alloc_locals;
+
+        let (calldata) = alloc();
+        let env = Starknet.get_env(0, 0);
+        tempvar address = new model.Address(
+            starknet=starknet_contract_address, evm=evm_contract_address
+        );
+        let (valid_jumpdests_start, valid_jumpdests) = Account.get_jumpdests(
+            bytecode_len=bytecode_len, bytecode=bytecode
+        );
+        tempvar zero = new Uint256(0, 0);
+        tempvar authorized = new model.Option(is_some=1, value=evm_contract_address);
+        local message: model.Message* = new model.Message(
+            bytecode=bytecode,
+            bytecode_len=bytecode_len,
+            valid_jumpdests_start=valid_jumpdests_start,
+            valid_jumpdests=valid_jumpdests,
+            calldata=calldata,
+            calldata_len=0,
+            value=zero,
+            caller=env.origin,
+            parent=cast(0, model.Parent*),
+            address=address,
+            code_address=evm_contract_address,
+            read_only=FALSE,
+            is_create=FALSE,
+            authorized=authorized,
+            depth=0,
+            env=env,
+        );
+        let evm: model.EVM* = EVM.init(message, 1000000);
+        return evm;
+    }
+
     func init_stack_with_values(stack_len: felt, stack: Uint256*) -> model.Stack* {
         let stack_ = Stack.init();
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 3-4 days

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The authority is unset in the initial frame when the exec_auth is being called.
<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #1121 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The test__auth method has been divided into two methods:
  - One with authority set in the initial evm frame
  - Another with the authority unset
- A new test with authority having some code is introduced
- To get an evm frame with the authority set, a new helper method is also introduced in the helper.cairo file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1139)
<!-- Reviewable:end -->
