### PR TITLE
feat: kakarot signature length

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kkrt-labs/ef-tests
+          ref: feat/kakarot-signature-length
       - name: Checkout local skip file
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kkrt-labs/ef-tests
-          ref: feat/kakarot-signature-length
       - name: Checkout local skip file
         uses: actions/checkout@v4
         with:

--- a/kakarot_scripts/utils/kakarot.py
+++ b/kakarot_scripts/utils/kakarot.py
@@ -366,7 +366,7 @@ async def eth_send_transaction(
     prepared_invoke = InvokeV1(
         version=prepared_invoke.version,
         max_fee=prepared_invoke.max_fee,
-        signature=[*int_to_uint256(evm_tx.r), *int_to_uint256(evm_tx.s), evm_tx.v],
+        signature=[*int_to_uint256(evm_tx.r), *int_to_uint256(evm_tx.s), evm_tx.v, 0],
         nonce=prepared_invoke.nonce,
         sender_address=prepared_invoke.sender_address,
         calldata=prepared_invoke.calldata,

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -182,8 +182,8 @@ namespace AccountContract {
         let (address) = Account_evm_address.read();
         let (tx_info) = get_tx_info();
 
-        // Assert signature field is of length 5: r_low, r_high, s_low, s_high, v
-        assert tx_info.signature_len = 5;
+        // Assert signature field is of length 6: r_low, r_high, s_low, s_high, v, retry field
+        assert tx_info.signature_len = 6;
         let r = Uint256(tx_info.signature[0], tx_info.signature[1]);
         let s = Uint256(tx_info.signature[2], tx_info.signature[3]);
         let v = tx_info.signature[4];


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.1 day

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The signature length of the EOA is limited to 5 (r_low, r_high, s_low, s_high, v). 

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #NA

## What is the new behavior?
In order to allow for a retry mechanism to the Starkware appchain, a retry field is added to the signature, extending its length to 6. 

This extra field gives the RPC control over the Starknet transaction hash, allowing the RPC to modify the Starknet hash and bypass the `DuplicateTx` error from the Starkware appchain.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1162)
<!-- Reviewable:end -->
