### PR TITLE
Add workflow to PR kakarot RPC on release

### DIFF
--- a/.github/workflows/update-rpc.yml
+++ b/.github/workflows/update-rpc.yml
@@ -1,0 +1,40 @@
+name: Update Submodule
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  update-submodule:
+    # GH_TOKEN is a secret defined in the github repository settings and not the default GITHUB_TOKEN
+    # This token has write access to the kakarot-rpc repository unlike the default GITHUB_TOKEN
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout Kakarot-RPC Repository
+        uses: actions/checkout@v4
+        with:
+          repository: kkrt-labs/kakarot-rpc
+          token: ${{ secrets.GH_TOKEN }}
+          path: kakarot-rpc
+
+      - name: Update Submodule
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          cd kakarot-rpc
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git submodule update --recursive --init
+          cd lib/kakarot
+          git fetch --tags
+          export release_tag=$(git tag --sort=-creatordate | head -n 1)
+          git checkout $release_tag
+          cd ../..
+          git checkout -b kakarot-$release_tag
+          git add lib/kakarot
+          git commit -m "Update kakarot to $release_tag"
+          git push --set-upstream origin kakarot-$release_tag --force
+          gh pr create --title "Update Kakarot to ${release_tag}" --body "Update Kakarot to ${release_tag}"


### PR DESCRIPTION
Note: I've had to create a Personal Access Token with write access to the RPC repo for this to work

See resulting PR in RPC https://github.com/kkrt-labs/kakarot-rpc/pull/1181 (got modifying the `on` condition to trigger the workflow, see also https://github.com/kkrt-labs/kakarot/actions/runs/9481929981/job/26125717974

With the release condition activated, see https://github.com/ClementWalter/kakarot/actions/runs/9483859582/job/26131981795

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1200)
<!-- Reviewable:end -->
