### PR TITLE
fix: messaging tests

### DIFF
--- a/solidity_contracts/src/L1L2Messaging/L1KakarotMessaging.sol
+++ b/solidity_contracts/src/L1L2Messaging/L1KakarotMessaging.sol
@@ -10,12 +10,12 @@ interface IL1KakarotMessaging {
 contract L1KakarotMessaging  {
 
     IStarknetMessaging private _starknetMessaging;
-    uint256 private _kakarotAddress;
+    uint256 public kakarotAddress;
     uint256 constant HANDLE_L1_MESSAGE_SELECTOR = uint256(keccak256("handle_l1_message")) % 2**250;
 
-    constructor(address starknetMessaging, uint256 kakarotAddress) {
-        _starknetMessaging = IStarknetMessaging(starknetMessaging);
-        _kakarotAddress = kakarotAddress;
+    constructor(address starknetMessaging_, uint256 kakarotAddress_) {
+        _starknetMessaging = IStarknetMessaging(starknetMessaging_);
+        kakarotAddress = kakarotAddress_;
     }
 
     /// @notice Sends a message to a contract on L2.
@@ -36,7 +36,7 @@ contract L1KakarotMessaging  {
 
         // Send the converted data to L2
         _starknetMessaging.sendMessageToL2{value: msg.value}(
-            _kakarotAddress,
+            kakarotAddress,
             HANDLE_L1_MESSAGE_SELECTOR,
             convertedData
         );

--- a/tests/end_to_end/L1L2Messaging/test_messaging.py
+++ b/tests/end_to_end/L1L2Messaging/test_messaging.py
@@ -37,17 +37,12 @@ async def l1_kakarot_messaging(sn_messaging_local, invoke):
     # If the contract is already deployed on the l1, we can get the address from the deployments file
     # Otherwise, we deploy it
     l1_addresses = get_l1_addresses()
-    if l1_addresses.get("L1KakarotMessaging"):
-        address = l1_addresses["L1KakarotMessaging"]["address"]
-        if l1_contract_exists(address):
-            return get_l1_contract("L1L2Messaging", "L1KakarotMessaging", address)
-
     kakarot_address = get_deployments()["kakarot"]["address"]
     contract = await deploy_on_l1(
         "L1L2Messaging",
         "L1KakarotMessaging",
-        starknetMessaging=sn_messaging_local.address,
-        kakarotAddress=kakarot_address,
+        starknetMessaging_=sn_messaging_local.address,
+        kakarotAddress_=kakarot_address,
     )
     l1_addresses.update({"L1KakarotMessaging": {"address": contract.address}})
     dump_l1_addresses(l1_addresses)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- fixes an issue with messaging tests when kakarot was re-deployed, causing a mismatch between the l1messaging kakarot address and the actual one. We can simply remove this cache mechanism as re-deploying it for each test is not an issue.
-
-
