### PR TITLE
feat: add execute_starknet_call entrypoint to account contract

### DIFF
--- a/solidity_contracts/src/CairoPrecompiles/CairoCounterCaller.sol
+++ b/solidity_contracts/src/CairoPrecompiles/CairoCounterCaller.sol
@@ -16,10 +16,9 @@ contract CairoCounterCaller {
     uint256 constant FUNCTION_SELECTOR_SET_COUNTER = uint256(keccak256("set_counter")) % 2 ** 250;
 
     /// @dev The cairo function selector to call - `get`
-    uint256 constant FUNCTION_SELECTOR_GET = uint256(keccak256("get")) % 2**250;
+    uint256 constant FUNCTION_SELECTOR_GET = uint256(keccak256("get")) % 2 ** 250;
 
-    uint256 constant FUNCTION_SELECTOR_GET_LAST_CALLER = uint256(keccak256("get_last_caller")) % 2**250;
-
+    uint256 constant FUNCTION_SELECTOR_GET_LAST_CALLER = uint256(keccak256("get_last_caller")) % 2 ** 250;
 
     constructor(uint256 cairoContractAddress) {
         cairoCounter = cairoContractAddress;

--- a/solidity_contracts/src/CairoPrecompiles/CairoCounterCaller.sol
+++ b/solidity_contracts/src/CairoPrecompiles/CairoCounterCaller.sol
@@ -16,7 +16,10 @@ contract CairoCounterCaller {
     uint256 constant FUNCTION_SELECTOR_SET_COUNTER = uint256(keccak256("set_counter")) % 2 ** 250;
 
     /// @dev The cairo function selector to call - `get`
-    uint256 constant FUNCTION_SELECTOR_GET = uint256(keccak256("get")) % 2 ** 250;
+    uint256 constant FUNCTION_SELECTOR_GET = uint256(keccak256("get")) % 2**250;
+
+    uint256 constant FUNCTION_SELECTOR_GET_LAST_CALLER = uint256(keccak256("get_last_caller")) % 2**250;
+
 
     constructor(uint256 cairoContractAddress) {
         cairoCounter = cairoContractAddress;
@@ -46,5 +49,13 @@ contract CairoCounterCaller {
         data[0] = uint256(newCounterLow);
         data[1] = uint256(newCounterHigh);
         cairoCounter.callContract(FUNCTION_SELECTOR_SET_COUNTER, data);
+    }
+
+    /// @notice Calls the Cairo contract to get the (starknet) address of the last caller
+    /// @return lastCaller The starknet address of the last caller
+    function getLastCaller() external view returns (uint256 lastCaller) {
+        bytes memory returnData = cairoCounter.staticcallContract(FUNCTION_SELECTOR_GET_LAST_CALLER);
+
+        return abi.decode(returnData, (uint256));
     }
 }

--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -6,6 +6,7 @@
 from openzeppelin.access.ownable.library import Ownable, Ownable_owner
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin, SignatureBuiltin
 from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.bool import FALSE, TRUE
 
 // Local dependencies
 from kakarot.accounts.library import (
@@ -323,5 +324,5 @@ func execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range
     let (retdata_len, retdata) = call_contract(
         called_address, function_selector, calldata_len, calldata
     );
-    return (retdata_len, retdata);
+    return (retdata_len, retdata, TRUE);
 }

--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -313,9 +313,13 @@ func set_authorized_pre_eip155_tx{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
 @external
 func execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     called_address: felt, function_selector: felt, calldata_len: felt, calldata: felt*
-) -> (retdata_len: felt, retdata: felt*) {
+) -> (retdata_len: felt, retdata: felt*, success: felt) {
     Ownable.assert_only_owner();
-    AccountContract.assert_not_kakarot(called_address);
+    let (kakarot_address) = Ownable.owner();
+    if (kakarot_address == called_address) {
+        let (retdata) = alloc();
+        return (0, retdata, FALSE);
+    }
     let (retdata_len, retdata) = call_contract(
         called_address, function_selector, calldata_len, calldata
     );

--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -313,7 +313,7 @@ func set_authorized_pre_eip155_tx{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
 
 @external
 func execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    called_address: felt, function_selector: felt, calldata_len: felt, calldata: felt*
+    to: felt, function_selector: felt, calldata_len: felt, calldata: felt*
 ) -> (retdata_len: felt, retdata: felt*, success: felt) {
     Ownable.assert_only_owner();
     let (kakarot_address) = Ownable.owner();

--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -317,12 +317,10 @@ func execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range
 ) -> (retdata_len: felt, retdata: felt*, success: felt) {
     Ownable.assert_only_owner();
     let (kakarot_address) = Ownable.owner();
-    if (kakarot_address == called_address) {
+    if (kakarot_address == to) {
         let (retdata) = alloc();
         return (0, retdata, FALSE);
     }
-    let (retdata_len, retdata) = call_contract(
-        called_address, function_selector, calldata_len, calldata
-    );
+    let (retdata_len, retdata) = call_contract(to, function_selector, calldata_len, calldata);
     return (retdata_len, retdata, TRUE);
 }

--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -16,7 +16,12 @@ from kakarot.accounts.library import (
 )
 from kakarot.accounts.model import CallArray
 from kakarot.interfaces.interfaces import IKakarot, IAccount
-from starkware.starknet.common.syscalls import get_tx_info, get_caller_address, replace_class
+from starkware.starknet.common.syscalls import (
+    get_tx_info,
+    get_caller_address,
+    replace_class,
+    call_contract,
+)
 from starkware.cairo.common.math import assert_le, unsigned_div_rem
 from starkware.cairo.common.alloc import alloc
 
@@ -303,4 +308,16 @@ func set_authorized_pre_eip155_tx{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
     Ownable.assert_only_owner();
     Account_authorized_message_hashes.write(message_hash, 1);
     return ();
+}
+
+@external
+func execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    called_address: felt, function_selector: felt, calldata_len: felt, calldata: felt*
+) -> (retdata_len: felt, retdata: felt*) {
+    Ownable.assert_only_owner();
+    AccountContract.assert_not_kakarot(called_address);
+    let (retdata_len, retdata) = call_contract(
+        called_address, function_selector, calldata_len, calldata
+    );
+    return (retdata_len, retdata);
 }

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -510,17 +510,6 @@ namespace AccountContract {
         );
         return is_valid_jumpdest(index=index);
     }
-
-    // @notice asserts that the caller is not kakarot
-    func assert_not_kakarot{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        address: felt
-    ) {
-        let (kakarot_address) = Ownable.owner();
-        with_attr error_message("Kakarot: cannot re-enter kakarot contract") {
-            assert_not_zero(kakarot_address - address);
-        }
-        return ();
-    }
 }
 
 namespace Internals {

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -510,6 +510,17 @@ namespace AccountContract {
         );
         return is_valid_jumpdest(index=index);
     }
+
+    // @notice asserts that the caller is not kakarot
+    func assert_not_kakarot{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        address: felt
+    ) {
+        let (kakarot_address) = Ownable.owner();
+        with_attr error_message("Kakarot: cannot re-enter kakarot contract") {
+            assert_not_zero(kakarot_address - address);
+        }
+        return ();
+    }
 }
 
 namespace Internals {

--- a/src/kakarot/errors.cairo
+++ b/src/kakarot/errors.cairo
@@ -429,6 +429,40 @@ namespace Errors {
         dw 'e';
     }
 
+    func accountNotDeployed() -> (error_len: felt, error: felt*) {
+        let (error) = get_label_location(account_not_deployed_error_message);
+        return (27, error);
+
+        account_not_deployed_error_message:
+        dw 'K';
+        dw 'a';
+        dw 'k';
+        dw 'a';
+        dw 'r';
+        dw 'o';
+        dw 't';
+        dw ':';
+        dw ' ';
+        dw 'a';
+        dw 'c';
+        dw 'c';
+        dw 'o';
+        dw 'u';
+        dw 'n';
+        dw 't';
+        dw 'N';
+        dw 'o';
+        dw 't';
+        dw 'D';
+        dw 'e';
+        dw 'p';
+        dw 'l';
+        dw 'o';
+        dw 'y';
+        dw 'e';
+        dw 'd';
+    }
+
     func notImplementedPrecompile(address: felt) -> (error_len: felt, error: felt*) {
         alloc_locals;
         let (error) = alloc();

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -92,7 +92,7 @@ namespace IAccount {
     }
 
     func execute_starknet_call(
-        called_address: felt, function_selector: felt, calldata_len: felt, calldata: felt*
+        to: felt, function_selector: felt, calldata_len: felt, calldata: felt*
     ) -> (retdata_len: felt, retdata: felt*, success: felt) {
     }
 }

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -93,7 +93,7 @@ namespace IAccount {
 
     func execute_starknet_call(
         called_address: felt, function_selector: felt, calldata_len: felt, calldata: felt*
-    ) -> (retdata_len: felt, retdata: felt*) {
+    ) -> (retdata_len: felt, retdata: felt*, success: felt) {
     }
 }
 

--- a/src/kakarot/interfaces/interfaces.cairo
+++ b/src/kakarot/interfaces/interfaces.cairo
@@ -90,6 +90,11 @@ namespace IAccount {
 
     func set_authorized_pre_eip155_tx(msg_hash: Uint256) {
     }
+
+    func execute_starknet_call(
+        called_address: felt, function_selector: felt, calldata_len: felt, calldata: felt*
+    ) -> (retdata_len: felt, retdata: felt*) {
+    }
 }
 
 @contract_interface

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -67,8 +67,17 @@ namespace Interpreter {
             let is_precompile = Precompiles.is_precompile(evm.message.code_address.evm);
             let caller_address = evm.message.caller;
             // Caller of the contract that is calling the precompile
-            let sender_context = evm.message.parent.evm.message.caller;
             if (is_precompile != FALSE) {
+                // If the precompile is called straight from an EOA, the sender_context is the EOA
+                // Otherwise, the sender_context is the caller of the contract that is calling the precompile
+                // This is only relevant for the Kakarot Cairo Module precompile.
+                let parent_context = evm.message.parent;
+                let is_parent_zero = Helpers.is_zero(cast(parent_context, felt));
+                if (is_parent_zero != FALSE) {
+                    tempvar sender_context = evm.message.caller;
+                } else {
+                    tempvar sender_context = parent_context.evm.message.caller;
+                }
                 let (
                     output_len, output, gas_used, precompile_reverted
                 ) = Precompiles.exec_precompile(

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -66,6 +66,8 @@ namespace Interpreter {
         if (is_pc_ge_code_len != FALSE) {
             let is_precompile = Precompiles.is_precompile(evm.message.code_address.evm);
             let caller_address = evm.message.caller;
+            // Caller of the contract that is calling the precompile
+            let sender_context = evm.message.parent.evm.message.caller;
             if (is_precompile != FALSE) {
                 let (
                     output_len, output, gas_used, precompile_reverted
@@ -74,6 +76,7 @@ namespace Interpreter {
                     evm.message.calldata_len,
                     evm.message.calldata,
                     caller_address,
+                    sender_context,
                 );
                 let evm = EVM.charge_gas(evm, gas_used);
                 let evm_reverted = is_not_zero(evm.reverted);

--- a/src/kakarot/library.cairo
+++ b/src/kakarot/library.cairo
@@ -357,6 +357,7 @@ namespace Kakarot {
     // @notice returns the EVM address associated to a Starknet account deployed by kakarot.
     //         Prevents cases where some Starknet account has an entrypoint get_evm_address()
     //         but isn't part of Kakarot system
+    // Also mitigates re-entrancy risk with the Cairo Interop module
     // @dev Raise if the declared corresponding evm address (retrieved with get_evm_address)
     //      does not recomputes into to the actual caller address
     func safe_get_evm_address{

--- a/src/kakarot/precompiles/kakarot_precompiles.cairo
+++ b/src/kakarot/precompiles/kakarot_precompiles.cairo
@@ -62,7 +62,7 @@ namespace KakarotPrecompiles {
 
         // Load address and cairo selector called
         // Safe to assume that the 32 bytes in input do not overflow a felt (whitelisted precompiles)
-        let starknet_address = Helpers.bytes32_to_felt(args_ptr);
+        let to_starknet_address = Helpers.bytes32_to_felt(args_ptr);
 
         let starknet_selector_ptr = args_ptr + 32;
         let starknet_selector = Helpers.bytes32_to_felt(starknet_selector_ptr);
@@ -90,7 +90,7 @@ namespace KakarotPrecompiles {
             }
 
             let (retdata_len, retdata, success) = IAccount.execute_starknet_call(
-                sender_starknet_address, starknet_address, starknet_selector, data_len, data
+                sender_starknet_address, to_starknet_address, starknet_selector, data_len, data
             );
             let (output) = alloc();
             let output_len = retdata_len * 32;
@@ -100,7 +100,7 @@ namespace KakarotPrecompiles {
 
         if (selector == LIBRARY_CALL_SOLIDITY_SELECTOR) {
             let (retdata_len, retdata) = library_call(
-                starknet_address, starknet_selector, data_len, data
+                to_starknet_address, starknet_selector, data_len, data
             );
             let (output) = alloc();
             let output_len = retdata_len * 32;

--- a/src/kakarot/precompiles/kakarot_precompiles.cairo
+++ b/src/kakarot/precompiles/kakarot_precompiles.cairo
@@ -79,8 +79,8 @@ namespace KakarotPrecompiles {
         let (data_len, data) = Helpers.load_256_bits_array(data_bytes_len, data_ptr);
 
         if (selector == CALL_CONTRACT_SOLIDITY_SELECTOR) {
-            let caller_starknet_address = Account.get_registered_starknet_address(sender_context);
-            let is_not_deployed = Helpers.is_zero(caller_starknet_address);
+            let sender_starknet_address = Account.get_registered_starknet_address(sender_context);
+            let is_not_deployed = Helpers.is_zero(sender_starknet_address);
 
             if (is_not_deployed != FALSE) {
                 let (revert_reason_len, revert_reason) = Errors.accountNotDeployed();
@@ -90,7 +90,7 @@ namespace KakarotPrecompiles {
             }
 
             let (retdata_len, retdata, success) = IAccount.execute_starknet_call(
-                caller_starknet_address, starknet_address, starknet_selector, data_len, data
+                sender_starknet_address, starknet_address, starknet_selector, data_len, data
             );
             let (output) = alloc();
             let output_len = retdata_len * 32;

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -71,9 +71,9 @@ namespace Precompiles {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(evm_address: felt, input_len: felt, input: felt*, caller_address: felt, sender_context) -> (
-        output_len: felt, output: felt*, gas_used: felt, reverted: felt
-    ) {
+    }(
+        evm_address: felt, input_len: felt, input: felt*, caller_address: felt, sender_context: felt
+    ) -> (output_len: felt, output: felt*, gas_used: felt, reverted: felt) {
         let is_eth_precompile = is_le(evm_address, LAST_ETHEREUM_PRECOMPILE_ADDRESS);
         tempvar syscall_ptr = syscall_ptr;
         tempvar pedersen_ptr = pedersen_ptr;

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -90,7 +90,7 @@ namespace Precompiles {
         tempvar syscall_ptr = syscall_ptr;
         tempvar pedersen_ptr = pedersen_ptr;
         tempvar range_check_ptr = range_check_ptr;
-        jmp pre_kakarot_precompile if is_kakarot_precompile_ != 0;
+        jmp kakarot_precompile if is_kakarot_precompile_ != 0;
         jmp unauthorized_call;
 
         eth_precompile:
@@ -155,20 +155,15 @@ namespace Precompiles {
         call PrecompileP256Verify.run;  // offset 0x0b: precompile 0x100
         ret;
 
-        pre_kakarot_precompile:
-        let is_cairo_contract_call = Helpers.is_zero(
-            FIRST_KAKAROT_PRECOMPILE_ADDRESS - evm_address
-        );
+        kakarot_precompile:
+        let is_cairo_module = Helpers.is_zero(FIRST_KAKAROT_PRECOMPILE_ADDRESS - evm_address);
         let is_whitelisted = KakarotPrecompiles.is_caller_whitelisted(caller_address);
-        tempvar is_authorized = is_cairo_contract_call * is_whitelisted;
+        tempvar is_not_authorized = is_cairo_module * (1 - is_whitelisted);
         tempvar syscall_ptr = syscall_ptr;
         tempvar pedersen_ptr = pedersen_ptr;
         tempvar range_check_ptr = range_check_ptr;
-        jmp call_kakarot_precompiles if is_authorized != 0;
-        jmp unauthorized_call if is_cairo_contract_call != 0;
-        jmp call_kakarot_precompiles;
+        jmp unauthorized_call if is_not_authorized != 0;
 
-        call_kakarot_precompiles:
         tempvar index = evm_address - FIRST_KAKAROT_PRECOMPILE_ADDRESS;
         tempvar offset = 1 + 3 * index;
 

--- a/src/kakarot/precompiles/precompiles.cairo
+++ b/src/kakarot/precompiles/precompiles.cairo
@@ -60,6 +60,8 @@ namespace Precompiles {
     // @param evm_address The precompile evm_address.
     // @param input_len The length of the input array.
     // @param input The input array.
+    // @param caller_address The address of the contract that calls the precompile.
+    // @param sender_context The address of the sender in the context of the caller contract.
     // @return output_len The output length.
     // @return output The output array.
     // @return gas_used The gas usage of precompile.
@@ -69,7 +71,7 @@ namespace Precompiles {
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
-    }(evm_address: felt, input_len: felt, input: felt*, caller_address: felt) -> (
+    }(evm_address: felt, input_len: felt, input: felt*, caller_address: felt, sender_context) -> (
         output_len: felt, output: felt*, gas_used: felt, reverted: felt
     ) {
         let is_eth_precompile = is_le(evm_address, LAST_ETHEREUM_PRECOMPILE_ADDRESS);
@@ -175,10 +177,10 @@ namespace Precompiles {
         [ap] = pedersen_ptr, ap++;
         [ap] = range_check_ptr, ap++;
         [ap] = bitwise_ptr, ap++;
-        [ap] = evm_address, ap++;
         [ap] = input_len, ap++;
         [ap] = input, ap++;
         [ap] = caller_address, ap++;
+        [ap] = sender_context, ap++;
 
         // Kakarot precompiles. Offset must have been computed appropriately,
         // based on the total number of kakarot precompiles

--- a/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
+++ b/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
@@ -79,7 +79,7 @@ class TestCairoPrecompiles:
             self, get_contract, cairo_counter_caller
         ):
             eoa = await get_eoa()
-            await cairo_counter_caller.incrementCairoCounter(caller_eoa=eoa)
+            await cairo_counter_caller.incrementCairoCounter()
             last_caller_address = await cairo_counter_caller.getLastCaller(
                 caller_eoa=eoa
             )

--- a/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
+++ b/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
@@ -79,8 +79,6 @@ class TestCairoPrecompiles:
             self, get_contract, cairo_counter_caller
         ):
             eoa = await get_eoa()
-            await cairo_counter_caller.incrementCairoCounter()
-            last_caller_address = await cairo_counter_caller.getLastCaller(
-                caller_eoa=eoa
-            )
+            await cairo_counter_caller.incrementCairoCounter(caller_eoa=eoa)
+            last_caller_address = await cairo_counter_caller.getLastCaller()
             assert last_caller_address == eoa.address

--- a/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
+++ b/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
@@ -1,6 +1,7 @@
 import pytest
 import pytest_asyncio
 
+from kakarot_scripts.utils.kakarot import get_eoa
 from kakarot_scripts.utils.starknet import get_deployments, wait_for_transaction
 from tests.utils.errors import evm_error
 
@@ -73,3 +74,13 @@ class TestCairoPrecompiles:
             )
             with evm_error("CairoLib: call_contract failed"):
                 await cairo_counter_caller.incrementCairoCounter(max_fee=max_fee)
+
+        async def test_last_caller_address_should_be_eoa(
+            self, get_contract, cairo_counter_caller
+        ):
+            eoa = await get_eoa()
+            await cairo_counter_caller.incrementCairoCounter(caller_eoa=eoa)
+            last_caller_address = await cairo_counter_caller.getLastCaller(
+                caller_eoa=eoa
+            )
+            assert last_caller_address == eoa.address

--- a/tests/end_to_end/L1L2Messaging/test_messaging.py
+++ b/tests/end_to_end/L1L2Messaging/test_messaging.py
@@ -96,6 +96,7 @@ def wait_for_message(sn_messaging_local):
 
 @pytest.mark.asyncio(scope="module")
 class TestL2ToL1Messages:
+    @pytest.mark.slow
     async def test_should_increment_counter_on_l1(
         self, sn_messaging_local, message_app_l1, message_app_l2, wait_for_message
     ):
@@ -113,6 +114,7 @@ class TestL2ToL1Messages:
 
 @pytest.mark.asyncio(scope="module")
 class TestL1ToL2Messages:
+    @pytest.mark.slow
     async def test_should_increment_counter_on_l2(
         self, l1_kakarot_messaging, message_app_l1, message_app_l2
     ):
@@ -125,6 +127,7 @@ class TestL1ToL2Messages:
         msg_counter_after = await message_app_l2.receivedMessagesCounter()
         assert msg_counter_after == msg_counter_before + increment_value
 
+    @pytest.mark.slow
     async def test_should_fail_unauthorized_message_sender(
         self, invoke, l1_kakarot_messaging, message_app_l1, message_app_l2
     ):

--- a/tests/fixtures/Counter.cairo
+++ b/tests/fixtures/Counter.cairo
@@ -3,9 +3,14 @@
 from starkware.cairo.common.math_cmp import is_not_zero
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256, uint256_add
+from starkware.starknet.common.syscalls import get_caller_address
 
 @storage_var
 func Counter() -> (res: Uint256) {
+}
+
+@storage_var
+func last_caller() -> (res: felt) {
 }
 
 @external
@@ -13,6 +18,9 @@ func inc{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
     let (current_counter) = Counter.read();
     let (new_value, _) = uint256_add(current_counter, Uint256(1, 0));
     Counter.write(value=new_value);
+
+    let (caller) = get_caller_address();
+    last_caller.write(caller);
     return ();
 }
 
@@ -21,6 +29,9 @@ func set_counter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     new_counter: Uint256
 ) {
     Counter.write(new_counter);
+
+    let (caller) = get_caller_address();
+    last_caller.write(caller);
     return ();
 }
 
@@ -28,4 +39,12 @@ func set_counter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 func get{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (count: Uint256) {
     let (current_counter) = Counter.read();
     return (count=current_counter);
+}
+
+@view
+func get_last_caller{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    caller: felt
+) {
+    let (caller) = last_caller.read();
+    return (caller=caller);
 }

--- a/tests/src/kakarot/accounts/test_account_contract.cairo
+++ b/tests/src/kakarot/accounts/test_account_contract.cairo
@@ -107,15 +107,6 @@ func test__set_authorized_pre_eip155_tx{
     set_authorized_pre_eip155_tx(msg_hash);
     return ();
 }
-
-func test__assert_not_kakarot{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    tempvar address: felt;
-    %{ ids.address = program_input["address"] %}
-    // When
-    AccountContract.assert_not_kakarot(address);
-    return ();
-}
-
 func test__execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     ) -> (felt*, felt) {
     // Given

--- a/tests/src/kakarot/accounts/test_account_contract.cairo
+++ b/tests/src/kakarot/accounts/test_account_contract.cairo
@@ -117,7 +117,7 @@ func test__assert_not_kakarot{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
 }
 
 func test__execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    ) -> felt* {
+    ) -> (felt*, felt) {
     // Given
     tempvar called_address: felt;
     tempvar function_selector: felt;
@@ -131,11 +131,11 @@ func test__execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*,
     %}
 
     // When
-    let (retdata_len, retdata) = execute_starknet_call(
+    let (retdata_len, retdata, success) = execute_starknet_call(
         called_address, function_selector, calldata_len, calldata
     );
 
-    return retdata;
+    return (retdata, success);
 }
 
 func test__validate{

--- a/tests/src/kakarot/accounts/test_account_contract.py
+++ b/tests/src/kakarot/accounts/test_account_contract.py
@@ -326,15 +326,14 @@ class TestAccountContract:
         @SyscallHandler.patch("Ownable_owner", SyscallHandler.caller_address)
         def test_should_fail_if_calling_kakarot(self, cairo_run):
             function_selector = 0xBCD
-            with cairo_error(
-                message="Kakarot: cannot re-enter kakarot contract"
-            ), SyscallHandler.patch(function_selector, lambda addr, data: []):
-                cairo_run(
+            with SyscallHandler.patch(function_selector, lambda addr, data: []):
+                return_data, success = cairo_run(
                     "test__execute_starknet_call",
                     called_address=SyscallHandler.caller_address,
                     function_selector=function_selector,
                     calldata=[],
                 )
+                assert success == 0
 
         @SyscallHandler.patch("Ownable_owner", SyscallHandler.caller_address)
         def test_should_execute_starknet_call(self, cairo_run):

--- a/tests/src/kakarot/accounts/test_account_contract.py
+++ b/tests/src/kakarot/accounts/test_account_contract.py
@@ -303,16 +303,6 @@ class TestAccountContract:
                 value=1,
             )
 
-    class TestAssertNotKakarot:
-        @SyscallHandler.patch("Ownable_owner", 0xABC)
-        def test_should_fail_if_kakarot(self, cairo_run):
-            with cairo_error(message="Kakarot: cannot re-enter kakarot contract"):
-                cairo_run("test__assert_not_kakarot", address=0xABC)
-
-        @SyscallHandler.patch("Ownable_owner", 0xABC)
-        def test_should_pass_if_not_kakarot(self, cairo_run):
-            cairo_run("test__assert_not_kakarot", address=0xDEF)
-
     class TestExecuteStarknetCall:
         def test_should_assert_only_owner(self, cairo_run):
             with cairo_error(message="Ownable: caller is not the owner"):

--- a/tests/src/kakarot/accounts/test_account_contract.py
+++ b/tests/src/kakarot/accounts/test_account_contract.py
@@ -340,11 +340,13 @@ class TestAccountContract:
             called_address = 0xABCDEF1234567890
             function_selector = 0x0987654321FEDCBA
             calldata = [random.randint(0, 255) for _ in range(32)]
-            expected_return_data = [random.randint(0, 255) for _ in range(32)]
+            expected_return_data = [random.randint(0, 255) for _ in range(32)] + [
+                int(True)
+            ]
             with SyscallHandler.patch(
                 function_selector, lambda addr, data: expected_return_data
             ):
-                return_data = cairo_run(
+                return_data, success = cairo_run(
                     "test__execute_starknet_call",
                     called_address=called_address,
                     function_selector=function_selector,
@@ -352,6 +354,7 @@ class TestAccountContract:
                 )
 
             assert return_data == expected_return_data
+            assert success == 1
             SyscallHandler.mock_call.assert_any_call(
                 contract_address=called_address,
                 function_selector=function_selector,

--- a/tests/src/kakarot/precompiles/test_precompiles.cairo
+++ b/tests/src/kakarot/precompiles/test_precompiles.cairo
@@ -25,17 +25,23 @@ func test__precompiles_run{
     local address;
     local input_len;
     local caller_address;
+    local sender_context;
     let (local input) = alloc();
     %{
         ids.address = program_input["address"]
         ids.input_len = len(program_input["input"])
         ids.caller_address = program_input.get("caller_address", 0)
+        ids.sender_context = program_input.get("sender_context", 0)
         segments.write_arg(ids.input, program_input["input"])
     %}
 
     // When
     let result = Precompiles.exec_precompile(
-        evm_address=address, input_len=input_len, input=input, caller_address=caller_address
+        evm_address=address,
+        input_len=input_len,
+        input=input,
+        caller_address=caller_address,
+        sender_context=sender_context,
     );
     let output_len = result.output_len;
     let (output) = alloc();

--- a/tests/utils/syscall_handler.py
+++ b/tests/utils/syscall_handler.py
@@ -1,7 +1,7 @@
 import time
 from collections import OrderedDict
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from hashlib import sha256
 from typing import Optional, Union
 from unittest import mock
@@ -131,11 +131,6 @@ def parse_state(state):
         }
         for address, account in state.items()
     }
-
-
-class InstanceMethodPlaceholder:
-    def __init__(self, method_name):
-        self.method_name = method_name
 
 
 @dataclass
@@ -434,7 +429,6 @@ class SyscallHandler:
                 response: CallContractResponse,
             }
         """
-
         function_selector = segments.memory[syscall_ptr + 2]
         if function_selector not in self.patches:
             raise ValueError(
@@ -452,9 +446,7 @@ class SyscallHandler:
             function_selector=function_selector,
             calldata=calldata,
         )
-
         retdata = self.patches.get(function_selector)(contract_address, calldata)
-
         retdata_segment = segments.add()
         segments.write_arg(retdata_segment, retdata)
         segments.write_arg(syscall_ptr + 5, [len(retdata), retdata_segment])

--- a/tests/utils/syscall_handler.py
+++ b/tests/utils/syscall_handler.py
@@ -451,6 +451,8 @@ class SyscallHandler:
             retdata = _handle_execute_starknet_call(
                 calldata[0], calldata[1], calldata[2:]
             )
+            # append [1] for success
+            retdata.append(1)
         else:
             retdata = self.patches.get(function_selector)(contract_address, calldata)
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  --> 0.3d

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a `execute_starknet_call` entrypoint to the account contract class. This entrypoint is invoked by Kakarot and allows calling _any_ other starknet contract deployed on the Starknet Chain
- <!> This could be a re-entrancy attack vector into kakarot. While direct EOA->KKT->EOA->KKT calls have been disabled,  EOA -> KKT -> EOA -> CairoContract -> Kakarot could still happen 🤔 Possible mitigation: ensure callers of non-protected KKT entrypoints like `eth_send_transaction` are either
1) 0 (starknet_call) or 2) a valid Kakarot account (checked against the internal registry)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1239)
<!-- Reviewable:end -->
