### PR TITLE
fix: use immutable in L1KakarotMessaging

### DIFF
--- a/solidity_contracts/src/L1L2Messaging/L1KakarotMessaging.sol
+++ b/solidity_contracts/src/L1L2Messaging/L1KakarotMessaging.sol
@@ -13,9 +13,13 @@ contract L1KakarotMessaging {
     IStarknetMessaging private immutable _starknetMessaging;
     uint256 public immutable kakarotAddress;
 
+    /// @dev Address of this contract
+    address private immutable _self;
+
     constructor(address starknetMessaging_, uint256 kakarotAddress_) {
         _starknetMessaging = IStarknetMessaging(starknetMessaging_);
         kakarotAddress = kakarotAddress_;
+        _self = address(this);
     }
 
     /// @notice Sends a message to a contract on L2.
@@ -43,6 +47,7 @@ contract L1KakarotMessaging {
     ///     is the caller of this function.
     /// @param payload The payload of the message to consume.
     function consumeMessageFromL2(bytes calldata payload) external returns (bytes32 msgHash) {
+        require(address(this) != _self, "NOT_DELEGATECALL");
         // Will revert if the message is not consumable.
         // Consider each byte of calldata as a uint256.
         uint256[] memory convertedPayload = new uint256[](payload.length);

--- a/solidity_contracts/src/L1L2Messaging/L1KakarotMessaging.sol
+++ b/solidity_contracts/src/L1L2Messaging/L1KakarotMessaging.sol
@@ -5,13 +5,13 @@ import "../starknet/IStarknetMessaging.sol";
 
 interface IL1KakarotMessaging {
     function sendMessageToL2(address to, uint248 value, bytes memory data) external payable;
+    function consumeMessageFromL2(bytes calldata payload) external returns (bytes32 msgHash);
 }
 
-contract L1KakarotMessaging  {
-
-    IStarknetMessaging private _starknetMessaging;
-    uint256 public kakarotAddress;
-    uint256 constant HANDLE_L1_MESSAGE_SELECTOR = uint256(keccak256("handle_l1_message")) % 2**250;
+contract L1KakarotMessaging {
+    uint256 constant HANDLE_L1_MESSAGE_SELECTOR = uint256(keccak256("handle_l1_message")) % 2 ** 250;
+    IStarknetMessaging private immutable _starknetMessaging;
+    uint256 public immutable kakarotAddress;
 
     constructor(address starknetMessaging_, uint256 kakarotAddress_) {
         _starknetMessaging = IStarknetMessaging(starknetMessaging_);
@@ -35,25 +35,20 @@ contract L1KakarotMessaging  {
         }
 
         // Send the converted data to L2
-        _starknetMessaging.sendMessageToL2{value: msg.value}(
-            kakarotAddress,
-            HANDLE_L1_MESSAGE_SELECTOR,
-            convertedData
-        );
+        _starknetMessaging.sendMessageToL2{value: msg.value}(kakarotAddress, HANDLE_L1_MESSAGE_SELECTOR, convertedData);
     }
 
-    //TODO: investigate why delegate-calling into this function fails consuming the message.
-    // /// @notice Consumes a message sent from L2.
-    // /// @dev Must be called with a delegatecall so that the `msg.sender` in the StarknetMessaging contract
-    // ///     is the caller of this function.
-    // /// @param payload The payload of the message to consume.
-    // function consumeMessageFromL2(bytes calldata payload) external returns (bytes32 msgHash){
-    //     // Will revert if the message is not consumable.
-    //     // Consider each byte of calldata as a uint256.
-    //     uint256[] memory convertedPayload = new uint256[](payload.length);
-    //     for (uint256 i = 0; i < payload.length; i++) {
-    //         convertedPayload[i] = uint256(uint8(payload[i]));
-    //     }
-    //     return _starknetMessaging.consumeMessageFromL2(_kakarotAddress, convertedPayload);
-    // }
+    /// @notice Consumes a message sent from L2.
+    /// @dev Must be called with a delegatecall so that the `msg.sender` in the StarknetMessaging contract
+    ///     is the caller of this function.
+    /// @param payload The payload of the message to consume.
+    function consumeMessageFromL2(bytes calldata payload) external returns (bytes32 msgHash) {
+        // Will revert if the message is not consumable.
+        // Consider each byte of calldata as a uint256.
+        uint256[] memory convertedPayload = new uint256[](payload.length);
+        for (uint256 i = 0; i < payload.length; i++) {
+            convertedPayload[i] = uint256(uint8(payload[i]));
+        }
+        return _starknetMessaging.consumeMessageFromL2(kakarotAddress, convertedPayload);
+    }
 }

--- a/solidity_contracts/src/L1L2Messaging/MessageAppL1.sol
+++ b/solidity_contracts/src/L1L2Messaging/MessageAppL1.sol
@@ -64,18 +64,10 @@ contract MessageAppL1 {
     */
     function consumeCounterIncrease(bytes calldata payload) external {
         // Will revert if the message is not consumable.
-        //TODO: debug why using the delegatecall doesn't consume the message properly.
         // Delegatecall to _l1KakarotMessaging
-        // (bool success, ) = address(_l1KakarotMessaging).delegatecall(
-        //     abi.encodeWithSignature("consumeMessageFromL2(bytes)", payload)
-        // );
-        // require(success, "message consumption failed");
-
-        uint256[] memory convertedPayload = new uint256[](payload.length);
-        for (uint256 i = 0; i < payload.length; i++) {
-            convertedPayload[i] = uint256(uint8(payload[i]));
-        }
-        _starknetMessaging.consumeMessageFromL2(_kakarotAddress, convertedPayload);
+        (bool success,) =
+            address(_l1KakarotMessaging).delegatecall(abi.encodeWithSignature("consumeMessageFromL2(bytes)", payload));
+        require(success, "message consumption failed");
 
         // Decode the uint256 value from the payload
         uint256 value = abi.decode(payload, (uint256));

--- a/solidity_contracts/src/L1L2Messaging/MessageAppL1.sol
+++ b/solidity_contracts/src/L1L2Messaging/MessageAppL1.sol
@@ -10,24 +10,18 @@ import "../starknet/IStarknetMessaging.sol";
 // It saves a lot's of space to use those custom error instead of strings.
 error InvalidPayload();
 
-/**
-   @title Test contract to receive / send messages to starknet.
-   @author Glihm https://github.com/glihm/starknet-messaging-dev
-*/
+/// @title Test contract to receive / send messages to starknet.
+/// @author Glihm https://github.com/glihm/starknet-messaging-dev
 contract MessageAppL1 {
-
     IStarknetMessaging private _starknetMessaging;
     IL1KakarotMessaging private _l1KakarotMessaging;
     uint256 private _kakarotAddress;
     uint256 public receivedMessagesCounter;
 
-    /**
-       @notice Constructor.
-
-       @param starknetMessaging The address of the StarknetMessaging contract.
-       @param l1KakarotMessaging The address of the L1KakarotMessaging contract.
-       @param kakarotAddress The Starknet address, on L2, of the Kakarot contract.
-    */
+    /// @notice Constructor.
+    /// @param starknetMessaging The address of the StarknetMessaging contract.
+    /// @param l1KakarotMessaging The address of the L1KakarotMessaging contract.
+    /// @param kakarotAddress The Starknet address, on L2, of the Kakarot contract.
     constructor(address starknetMessaging, address l1KakarotMessaging, uint256 kakarotAddress) {
         _starknetMessaging = IStarknetMessaging(starknetMessaging);
         _l1KakarotMessaging = IL1KakarotMessaging(l1KakarotMessaging);
@@ -37,31 +31,19 @@ contract MessageAppL1 {
     /// @notice Increases the counter inside the MessageAppL2 contract deployed on Kakarot.
     /// @dev Must be called with a value sufficient to pay for the L1 message fee.
     /// @param l2AppAddress The address of the L2 contract to trigger.
-    function increaseL2AppCounter(
-        address l2AppAddress
-    )
-        external
-        payable
-    {
+    function increaseL2AppCounter(address l2AppAddress) external payable {
         _l1KakarotMessaging.sendMessageToL2{value: msg.value}(
-            l2AppAddress,
-            0,
-            abi.encodeCall(
-                MessageAppL2.increaseMessagesCounter, 1
-            )
+            l2AppAddress, 0, abi.encodeCall(MessageAppL2.increaseMessagesCounter, 1)
         );
     }
 
-
-    /**
-       @notice Manually consumes a message that was received from L2.
-       @param payload Payload of the message used to verify the hash.
-       @dev A message "received" means that the message hash is registered as consumable.
-       One must provide the message content, to let Starknet Core contract verify the hash
-       and validate the message content before being consumed.
-       The L1KakarotMessaging contract must be called with a delegatecall to ensure that
-       the Starknet Core contract considers this contract as the consumer.
-    */
+    /// @notice Manually consumes a message that was received from L2.
+    /// @param payload Payload of the message used to verify the hash.
+    /// @dev A message "received" means that the message hash is registered as consumable.
+    /// One must provide the message content, to let Starknet Core contract verify the hash
+    /// and validate the message content before being consumed.
+    /// The L1KakarotMessaging contract must be called with a delegatecall to ensure that
+    /// the Starknet Core contract considers this contract as the consumer.
     function consumeCounterIncrease(bytes calldata payload) external {
         // Will revert if the message is not consumable.
         // Delegatecall to _l1KakarotMessaging


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
`consumeMessageFromL2` in `L1KakarotMessaging` was not used and commented.
There is a storage collision when calling `L1KakarotMessaging` in delegatecall as `_starknetMessaging` and `_kakarotAddress` are stored in slot 0 and 1.

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #1228

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
- In `L1KakarotMessaging` contract 
    - `_starknetMessaging` and `_kakarotAddress` are passed as immutable
This contract should not have storage if possible to avoid storage collision. If necessary implement [ERC7201](https://eips.ethereum.org/EIPS/eip-7201) or other solution. 
    - adds a `self` immutable to add a check in `consumeMessageFromL2` to ensure it is called in `delegatecall` 
- forge fmt

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1242)
<!-- Reviewable:end -->
