### PR TITLE
feat: block transactions on view entrypoints

### DIFF
--- a/src/kakarot/kakarot.cairo
+++ b/src/kakarot/kakarot.cairo
@@ -339,6 +339,9 @@ func eth_call{
     access_list: felt*,
 ) -> (return_data_len: felt, return_data: felt*, success: felt, gas_used: felt) {
     alloc_locals;
+
+    Helpers.assert_view_call();
+
     let fp_and_pc = get_fp_and_pc();
     local __fp__: felt* = fp_and_pc.fp_val;
     let (evm, state, gas_used, _) = Kakarot.eth_call(
@@ -388,6 +391,9 @@ func eth_estimate_gas{
     access_list: felt*,
 ) -> (return_data_len: felt, return_data: felt*, success: felt, required_gas: felt) {
     alloc_locals;
+
+    Helpers.assert_view_call();
+
     let fp_and_pc = get_fp_and_pc();
     local __fp__: felt* = fp_and_pc.fp_val;
     let (evm, state, _, gas_required) = Kakarot.eth_call(

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -1223,7 +1223,6 @@ namespace Helpers {
             assert tx_info.account_contract_address = 0;
             assert tx_info.max_fee = 0;
             assert tx_info.signature_len = 0;
-            assert [tx_info.signature] = 0;
             assert tx_info.transaction_hash = 0;
             assert is_not_zero(tx_info.chain_id) = 1;
             assert tx_info.nonce = 0;

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -1215,7 +1215,7 @@ namespace Helpers {
     }
 
     // @notice Ensure the tx is a view call
-    // @dev Verify tx field are empty except for chain_id
+    // @dev Verify tx fields are empty except for chain_id
     func assert_view_call{syscall_ptr: felt*}() -> () {
         let (tx_info) = get_tx_info();
         with_attr error_message("Only view call") {

--- a/tests/end_to_end/CairoPrecompiles/Pragma/test_pragma_precompile.py
+++ b/tests/end_to_end/CairoPrecompiles/Pragma/test_pragma_precompile.py
@@ -40,7 +40,7 @@ def serialize_data_type(data_type: dict) -> Tuple:
         return (serialized_entry_type, query_args, 0)
 
 
-@pytest.fixture(autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 async def setup(get_contract, invoke, mocked_values, pragma_caller, max_fee):
     pragma_oracle = get_contract("MockPragmaOracle")
     tx = await pragma_oracle.functions["set_price"].invoke_v1(

--- a/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
+++ b/tests/end_to_end/CairoPrecompiles/test_cairo_precompiles.py
@@ -6,7 +6,7 @@ from kakarot_scripts.utils.starknet import get_deployments, wait_for_transaction
 from tests.utils.errors import evm_error
 
 
-@pytest.fixture(autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 async def cleanup(get_contract, max_fee):
     yield
     cairo_counter = get_contract("Counter")

--- a/tests/end_to_end/test_kakarot.py
+++ b/tests/end_to_end/test_kakarot.py
@@ -34,7 +34,7 @@ def evm(get_contract):
     return get_contract("EVM")
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def other():
     """
     Just another Starknet contract.
@@ -49,7 +49,7 @@ async def other():
 
 
 @pytest.fixture(scope="session")
-async def class_hashes():
+def class_hashes():
     """
     All declared class hashes.
     """


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

It is possible to send transactions on `eth_call` and `eth_estimate_gas` kakarot entrypoints

Resolves #1257

## What is the new behavior?
Transactions (invoke) will fail on those entrypoints

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1281)
<!-- Reviewable:end -->
