### PR TITLE
bug: fix early return exec copy

### DIFF
--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -414,17 +414,19 @@ namespace EnvironmentalInformation {
             words_len=memory_expansion.new_words_len,
         );
 
+        let (data_to_store: felt*) = alloc();
         // Offset.high != 0 means that the sliced data is surely 0x00...00
-        // And storing 0 in Memory is just doing nothing
+        // Store 0 in memory
         if (offset.high != 0) {
+            memset(dst=data_to_store, value=0, n=size.low);
+            Memory.store_n(size.low, data_to_store, dest_offset.low);
             return evm;
         }
 
-        let (sliced_data: felt*) = alloc();
         let account = State.get_account(evm_address);
-        slice(sliced_data, account.code_len, account.code, offset.low, size.low);
+        slice(data_to_store, account.code_len, account.code, offset.low, size.low);
 
-        Memory.store_n(size.low, sliced_data, dest_offset.low);
+        Memory.store_n(size.low, data_to_store, dest_offset.low);
 
         return evm;
     }

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -279,15 +279,17 @@ namespace EnvironmentalInformation {
 
         let opcode_number = [evm.message.bytecode + evm.program_counter];
 
+        let (data_to_store: felt*) = alloc();
         // Offset.high != 0 means that the sliced data is surely 0x00...00
-        // And storing 0 in Memory is just doing nothing.
+        // Store 0 in memory
         if (offset.high != 0) {
+            memset(dst=data_to_store, value=0, n=size.low);
+            Memory.store_n(size.low, data_to_store, dest_offset.low);
             return evm;
         }
 
         // 0x37: calldatacopy
         // 0x39: codecopy
-        let (sliced_data: felt*) = alloc();
         local data_len;
         local data: felt*;
         if (opcode_number == 0x37) {
@@ -300,9 +302,9 @@ namespace EnvironmentalInformation {
             tempvar range_check_ptr = range_check_ptr;
         }
         let range_check_ptr = [ap - 1];
-        slice(sliced_data, data_len, data, offset.low, size.low);
+        slice(data_to_store, data_len, data, offset.low, size.low);
 
-        Memory.store_n(size.low, sliced_data, dest_offset.low);
+        Memory.store_n(size.low, data_to_store, dest_offset.low);
 
         return evm;
     }

--- a/tests/src/kakarot/instructions/test_environmental_information.cairo
+++ b/tests/src/kakarot/instructions/test_environmental_information.cairo
@@ -6,7 +6,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
 from starkware.cairo.common.memcpy import memcpy
-
+from starkware.cairo.common.uint256 import ALL_ONES
 from kakarot.instructions.environmental_information import EnvironmentalInformation
 from kakarot.instructions.memory_operations import MemoryOperations
 
@@ -71,15 +71,15 @@ func test__exec_extcodecopy{
 }() -> model.Memory* {
     // Given
     alloc_locals;
-    local address: felt;
     local size: felt;
     local offset: felt;
     local dest_offset: felt;
+    local address: felt;
     %{
-        ids.address = program_input["address"]
         ids.size = program_input["size"]
         ids.offset = program_input["offset"]
         ids.dest_offset = program_input["dest_offset"]
+        ids.address = program_input["address"]
     %}
     let evm = TestHelpers.init_evm();
     let stack = Stack.init();
@@ -109,28 +109,28 @@ func test__exec_extcodecopy_zellic_issue_1258{
 }() -> model.Memory* {
     // Given
     alloc_locals;
-    local address: felt;
     local size: felt;
     local offset_high: felt;
     local dest_offset: felt;
+    local address: felt;
     %{
-        ids.address = program_input["address"]
         ids.size = program_input["size"]
         ids.offset_high = program_input["offset_high"]
         ids.dest_offset = program_input["dest_offset"]
+        ids.address = program_input["address"]
     %}
     let evm = TestHelpers.init_evm();
     let stack = Stack.init();
     let state = State.init();
     let memory = Memory.init();
 
+    tempvar item_1_mstore = new Uint256(ALL_ONES, ALL_ONES);
+    tempvar item_0_mstore = new Uint256(0, 0);
+
     tempvar item_3_extcodecopy = new Uint256(size, 0);
     tempvar item_2_extcodecopy = new Uint256(0, offset_high);
     tempvar item_1_extcodecopy = new Uint256(dest_offset, 0);
     tempvar item_0_extcodecopy = new Uint256(address, 0);
-
-    tempvar item_1_mstore = new Uint256(2 ** 128 - 1, 2 ** 128 - 1);
-    tempvar item_0_mstore = new Uint256(0, 0);
 
     // When
     with stack, memory, state {
@@ -156,22 +156,22 @@ func test__exec_codecopy{
 }() -> model.Memory* {
     // Given
     alloc_locals;
-    local offset: felt;
     local size: felt;
+    local offset: felt;
     local dest_offset: felt;
     local bytecode_len: felt;
     let (bytecode) = alloc();
     local opcode_number: felt;
     %{
-        ids.offset = program_input["offset"]
         ids.size = program_input["size"]
+        ids.offset = program_input["offset"]
         ids.dest_offset = program_input["dest_offset"]
         ids.bytecode_len = len(program_input["bytecode"])
         segments.write_arg(ids.bytecode, program_input["bytecode"])
         ids.opcode_number = program_input["opcode_number"]
     %}
     if (opcode_number == 0x37) {
-        // bytecode is passed as calldata and opcode_number (first element in bytecode variable
+        // bytecode is passed as calldata and opcode_number (first element in bytecode variable)
         // is passed as bytecode
         let evm = TestHelpers.init_evm_with_calldata(1, bytecode, bytecode_len, bytecode);
     } else {
@@ -230,7 +230,7 @@ func test__exec_codecopy_offset_high_zellic_issue_1258{
     tempvar item_1_exec_copy = new Uint256(0, offset_high);
     tempvar item_0_exec_copy = new Uint256(dest_offset, 0);
 
-    tempvar item_1_mstore = new Uint256(2 ** 128 - 1, 2 ** 128 - 1);
+    tempvar item_1_mstore = new Uint256(ALL_ONES, ALL_ONES);
     tempvar item_0_mstore = new Uint256(0, 0);
 
     // When

--- a/tests/src/kakarot/instructions/test_environmental_information.cairo
+++ b/tests/src/kakarot/instructions/test_environmental_information.cairo
@@ -8,6 +8,8 @@ from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
 from starkware.cairo.common.memcpy import memcpy
 
 from kakarot.instructions.environmental_information import EnvironmentalInformation
+from kakarot.instructions.memory_operations import MemoryOperations
+
 from kakarot.memory import Memory
 from kakarot.model import model
 from kakarot.stack import Stack
@@ -93,6 +95,53 @@ func test__exec_extcodecopy{
         Stack.push(item_2);  // offset
         Stack.push(item_1);  // dest_offset
         Stack.push(item_0);  // address
+        let evm = EnvironmentalInformation.exec_extcodecopy(evm);
+    }
+
+    // Then
+    assert stack.size = 0;
+    return memory;
+}
+
+func test__exec_extcodecopy_zellic_issue_1258{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() -> model.Memory* {
+    // Given
+    alloc_locals;
+    local address: felt;
+    local size: felt;
+    local offset_high: felt;
+    local dest_offset: felt;
+    %{
+        ids.address = program_input["address"]
+        ids.size = program_input["size"]
+        ids.offset_high = program_input["offset_high"]
+        ids.dest_offset = program_input["dest_offset"]
+    %}
+    let evm = TestHelpers.init_evm();
+    let stack = Stack.init();
+    let state = State.init();
+    let memory = Memory.init();
+
+    tempvar item_3_extcodecopy = new Uint256(size, 0);
+    tempvar item_2_extcodecopy = new Uint256(0, offset_high);
+    tempvar item_1_extcodecopy = new Uint256(dest_offset, 0);
+    tempvar item_0_extcodecopy = new Uint256(address, 0);
+
+    tempvar item_1_mstore = new Uint256(2 ** 128 - 1, 2 ** 128 - 1);
+    tempvar item_0_mstore = new Uint256(0, 0);
+
+    // When
+    with stack, memory, state {
+        Stack.push(item_1_mstore);
+        Stack.push(item_0_mstore);
+
+        let evm = MemoryOperations.exec_mstore(evm);
+
+        Stack.push(item_3_extcodecopy);  // size
+        Stack.push(item_2_extcodecopy);  // offset
+        Stack.push(item_1_extcodecopy);  // dest_offset
+        Stack.push(item_0_extcodecopy);  // address
         let evm = EnvironmentalInformation.exec_extcodecopy(evm);
     }
 

--- a/tests/src/kakarot/instructions/test_environmental_information.py
+++ b/tests/src/kakarot/instructions/test_environmental_information.py
@@ -54,24 +54,8 @@ class TestEnvironmentalInformation:
 
     class TestExtCodeCopy:
         @pytest.mark.parametrize(
-            "case",
-            [
-                {
-                    "size": 31,
-                    "offset": 0,
-                    "dest_offset": 0,
-                },
-                {
-                    "size": 33,
-                    "offset": 0,
-                    "dest_offset": 0,
-                },
-                {
-                    "size": 1,
-                    "offset": 32,
-                    "dest_offset": 0,
-                },
-            ],
+            "size, offset, dest_offset",
+            [(31, 0, 0), (33, 0, 0), (1, 32, 0)],
             ids=[
                 "size_is_bytecodelen-1",
                 "size_is_bytecodelen+1",
@@ -83,10 +67,9 @@ class TestEnvironmentalInformation:
         @SyscallHandler.patch(
             "Kakarot_evm_to_starknet_address", EXISTING_ACCOUNT, 0x1234
         )
-        def test_extcodecopy_should_copy_code(self, cairo_run, case, bytecode, address):
-            size = case["size"]
-            offset = case["offset"]
-            dest_offset = case["dest_offset"]
+        def test_extcodecopy_should_copy_code(
+            self, cairo_run, size, offset, dest_offset, bytecode, address
+        ):
 
             with SyscallHandler.patch(
                 "IAccount.bytecode", lambda addr, data: [len(bytecode), *bytecode]
@@ -139,6 +122,67 @@ class TestEnvironmentalInformation:
                     dest_offset=0,
                     address=address,
                 )
+            # with a offset_high != 0 all copied bytes are 0
+            copied_bytecode = bytes([0] * size)
+            assert bytes.fromhex(memory)[0:size] == copied_bytecode
+
+    class TestCopy:
+        @pytest.mark.parametrize("opcode_number", [0x39, 0x37])
+        @pytest.mark.parametrize(
+            "size, offset, dest_offset",
+            [(31, 0, 0), (33, 0, 0), (1, 32, 0)],
+            ids=[
+                "size_is_bytecodelen-1",
+                "size_is_bytecodelen+1",
+                "offset_is_bytecodelen",
+            ],
+        )
+        def test_exec_codecopy_should_copy_code(
+            self, cairo_run, size, offset, dest_offset, opcode_number, bytecode
+        ):
+            bytecode.insert(0, opcode_number)  # random bytecode that can be mutated
+            memory = cairo_run(
+                "test__exec_codecopy",
+                size=size,
+                offset=offset,
+                dest_offset=dest_offset,
+                bytecode=bytecode,
+                opcode_number=opcode_number,
+            )
+
+            copied_bytecode = bytes(
+                # bytecode is padded with surely enough 0 and then sliced
+                (bytecode + [0] * (offset + size))[offset : offset + size]
+            )
+            assert (
+                bytes.fromhex(memory)[dest_offset : dest_offset + size]
+                == copied_bytecode
+            )
+
+        @pytest.mark.parametrize("opcode_number", [0x39, 0x37])
+        @pytest.mark.parametrize(
+            "size",
+            [31, 32, 33, 0],
+            ids=[
+                "size_is_bytecodelen-1",
+                "size_is_bytecodelen",
+                "size_is_bytecodelen+1",
+                "size_is_0",
+            ],
+        )
+        def test_exec_codecopy_offset_high_zellic_issue_1258(
+            self, cairo_run, size, opcode_number, bytecode
+        ):
+            bytecode.insert(0, opcode_number)  # random bytecode that can be mutated
+            offset_high = 1
+            memory = cairo_run(
+                "test__exec_codecopy_offset_high_zellic_issue_1258",
+                size=size,
+                offset_high=offset_high,
+                dest_offset=0,
+                bytecode=bytecode,
+                opcode_number=opcode_number,
+            )
             # with a offset_high != 0 all copied bytes are 0
             copied_bytecode = bytes([0] * size)
             assert bytes.fromhex(memory)[0:size] == copied_bytecode

--- a/tests/utils/helpers.cairo
+++ b/tests/utils/helpers.cairo
@@ -27,10 +27,11 @@ namespace TestHelpers {
         bytecode: felt*,
         starknet_contract_address: felt,
         evm_contract_address: felt,
+        calldata_len: felt,
+        calldata: felt*,
     ) -> model.EVM* {
         alloc_locals;
 
-        let (calldata) = alloc();
         let env = Starknet.get_env(0, 0);
         tempvar address = new model.Address(
             starknet=starknet_contract_address, evm=evm_contract_address
@@ -45,7 +46,7 @@ namespace TestHelpers {
             valid_jumpdests_start=valid_jumpdests_start,
             valid_jumpdests=valid_jumpdests,
             calldata=calldata,
-            calldata_len=0,
+            calldata_len=calldata_len,
             value=zero,
             caller=env.origin,
             parent=cast(0, model.Parent*),
@@ -62,13 +63,21 @@ namespace TestHelpers {
 
     func init_evm{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> model.EVM* {
         let (bytecode) = alloc();
-        return init_evm_at_address(0, bytecode, 0, 0);
+        let (calldata) = alloc();
+        return init_evm_at_address(0, bytecode, 0, 0, 0, calldata);
     }
 
     func init_evm_with_bytecode{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
         bytecode_len: felt, bytecode: felt*
     ) -> model.EVM* {
-        return init_evm_at_address(bytecode_len, bytecode, 0, 0);
+        let (calldata) = alloc();
+        return init_evm_at_address(bytecode_len, bytecode, 0, 0, 0, calldata);
+    }
+
+    func init_evm_with_calldata{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        bytecode_len: felt, bytecode: felt*, calldata_len: felt, calldata: felt*
+    ) -> model.EVM* {
+        return init_evm_at_address(bytecode_len, bytecode, 0, 0, calldata_len, calldata);
     }
 
     func init_stack_with_values(stack_len: felt, stack: Uint256*) -> model.Stack* {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When offset is too high(> 2 ** 128), 0 is not copied to memory.

Resolves #1258 

## What is the new behavior?

When offset is too high(> 2 ** 128), 0 is copied in memory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1286)
<!-- Reviewable:end -->
