### PR TITLE
fix: load_packed_bytes is underconstrained

### DIFF
--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -1206,11 +1206,18 @@ namespace Helpers {
 
         jmp cond if remaining_bytes != 0;
 
+        with_attr error_message("Value is not empty") {
+            assert value = 0;
+        }
+
         let bytes = cast([fp], felt*);
         return (bytes=bytes);
 
         cond:
         jmp body if count != 0;
+        with_attr error_message("Value is not empty") {
+            assert value = 0;
+        }
         jmp read;
     }
 

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -1120,13 +1120,12 @@ namespace Helpers {
         alloc_locals;
 
         let (local bytes: felt*) = alloc();
-        local bound = 256;
-        local base = 256;
-
         if (bytes_len == 0) {
             return (bytes=bytes);
         }
 
+        local bound = 256;
+        local base = 256;
         let (local chunk_counts, local remainder) = unsigned_div_rem(bytes_len, BYTES_PER_FELT);
 
         tempvar remaining_bytes = bytes_len;
@@ -1145,8 +1144,8 @@ namespace Helpers {
 
         tempvar value = input[index];
 
-        let remainder = [fp + 4];
         let chunk_counts = [fp + 3];
+        let remainder = [fp + 4];
         tempvar remaining_chunk = chunk_counts - index;
         jmp full_chunk if remaining_chunk != 0;
         tempvar count = remainder;
@@ -1169,9 +1168,9 @@ namespace Helpers {
         let value = [ap - 2];
         let count = [ap - 1];
 
-        let base = [fp + 1];
-        let bound = [fp + 2];
         let bytes = cast([fp], felt*);
+        let bound = [fp + 1];
+        let base = [fp + 2];
 
         tempvar offset = (index - 1) * BYTES_PER_FELT + count - 1;
         let output = bytes + offset;
@@ -1209,7 +1208,6 @@ namespace Helpers {
         with_attr error_message("Value is not empty") {
             assert value = 0;
         }
-
         let bytes = cast([fp], felt*);
         return (bytes=bytes);
 

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -1146,6 +1146,7 @@ namespace Helpers {
 
         let chunk_counts = [fp + 3];
         let remainder = [fp + 4];
+
         tempvar remaining_chunk = chunk_counts - index;
         jmp full_chunk if remaining_chunk != 0;
         tempvar count = remainder;

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -168,7 +168,7 @@ class TestLoadPackedBytes:
         output = cairo_run("test__load_packed_bytes", data=packed_bytes)
         assert output == list(bytes)
 
-    def test_should_rasise_zellic_issue_1283_load_packed_bytes(
+    def test_should_raise_zellic_issue_1283_load_packed_bytes(
         self, cairo_program, cairo_run
     ):
         bytes = random.randbytes(100)

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -177,8 +177,8 @@ class TestLoadPackedBytes:
             patch_hint(
                 cairo_program,
                 "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'",
-                "memory[ids.output] = res = 0x12\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'",
+                "memory[ids.output] = res = 0x12",
             ),
+            cairo_error(message="Value is not empty"),
         ):
-            with cairo_error(message="Value is not empty"):
-                cairo_run("test__load_packed_bytes", data=packed_bytes)
+            cairo_run("test__load_packed_bytes", data=packed_bytes)

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -7,7 +7,9 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from kakarot_scripts.utils.kakarot import get_contract
+from tests.utils.errors import cairo_error
 from tests.utils.helpers import pack_calldata
+from tests.utils.hints import patch_hint
 
 
 @pytest.mark.parametrize(
@@ -165,3 +167,18 @@ class TestLoadPackedBytes:
         packed_bytes = pack_calldata(bytes)
         output = cairo_run("test__load_packed_bytes", data=packed_bytes)
         assert output == list(bytes)
+
+    def test_should_rasise_zellic_issue_1283_load_packed_bytes(
+        self, cairo_program, cairo_run
+    ):
+        bytes = random.randbytes(100)
+        packed_bytes = pack_calldata(bytes)
+        with (
+            patch_hint(
+                cairo_program,
+                "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'",
+                "memory[ids.output] = res = 0x12\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'",
+            ),
+        ):
+            with cairo_error(message="Value is not empty"):
+                cairo_run("test__load_packed_bytes", data=packed_bytes)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Missing contraints in load_packed_bytes

Resolves #1283

## What is the new behavior?

load_packed_bytes is not underconstrained

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1299)
<!-- Reviewable:end -->
