### PR TITLE
refactor: bytes_used_128 using unsigned_div_rem

### DIFF
--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -680,279 +680,69 @@ namespace Helpers {
     // @param value The 128-bit value.
     // @return The number of bytes used by the value.
     func bytes_used_128{range_check_ptr}(value: felt) -> felt {
-        tempvar base = 256 ** 15;
-        let bound = base;
-        tempvar max = base - 1;
-        let (output) = alloc();
-
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 15);
+        if (q != 0) {
             return 16;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 1.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 14);
+        if (q != 0) {
             return 15;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 2.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 13);
+        if (q != 0) {
             return 14;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 3.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 12);
+        if (q != 0) {
             return 13;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 0.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 11);
+        if (q != 0) {
             return 12;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 1.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 10);
+        if (q != 0) {
             return 11;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 2.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 9);
+        if (q != 0) {
             return 10;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 3.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 8);
+        if (q != 0) {
             return 9;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 0.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 7);
+        if (q != 0) {
             return 8;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 1.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 6);
+        if (q != 0) {
             return 7;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 2.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 5);
+        if (q != 0) {
             return 6;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 3.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 4);
+        if (q != 0) {
             return 5;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 0.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 3);
+        if (q != 0) {
             return 4;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 1.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 2);
+        if (q != 0) {
             return 3;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 2.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        let (q, r) = unsigned_div_rem(value, 256 ** 1);
+        if (q != 0) {
             return 2;
         }
-        tempvar base = base / 256;
-        let bound = base;
-        tempvar max = base - 1;
-        // 3.
-        let output = output + 1;
-        %{
-            memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base
-            assert res < ids.bound, f'split_int(): Limb {res} is out of range.'
-        %}
-        tempvar x = [output];
-        [range_check_ptr] = x;
-        assert [range_check_ptr + 1] = max - x;
-
-        let range_check_ptr = range_check_ptr + 2;
-        if (value - x != 0) {
+        if (value != 0) {
             return 1;
         }
-
         return 0;
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #1282

## What is the new behavior?

It uses `unsigned_div_rem` to decompose the value

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1301)
<!-- Reviewable:end -->
