### PR TITLE
fix: enforce len < 32 split word

### DIFF
--- a/src/kakarot/precompiles/ec_recover.cairo
+++ b/src/kakarot/precompiles/ec_recover.cairo
@@ -15,7 +15,7 @@ from starkware.cairo.common.cairo_secp.signature import (
 from starkware.cairo.common.uint256 import Uint256, uint256_reverse_endian
 from starkware.cairo.common.cairo_secp.bigint import bigint_to_uint256
 from starkware.cairo.common.keccak_utils.keccak_utils import keccak_add_uint256s
-
+from starkware.cairo.common.memset import memset
 from utils.utils import Helpers
 from utils.array import slice
 from kakarot.errors import Errors
@@ -74,7 +74,8 @@ namespace PrecompileEcRecover {
         }
 
         let (output) = alloc();
-        Helpers.split_word(recovered_address, 32, output);
+        memset(output, 0, 12);
+        Helpers.split_word(recovered_address, 20, output + 12);
 
         return (32, output, GAS_COST_EC_RECOVER, 0);
     }

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -436,9 +436,15 @@ namespace Helpers {
     // @notice Splits a felt into `len` bytes, big-endian, and outputs to `dst`.
     func split_word{range_check_ptr}(value: felt, len: felt, dst: felt*) {
         if (len == 0) {
-            assert value = 0;
+            with_attr error_message("value not empty") {
+                assert value = 0;
+            }
             return ();
         }
+        with_attr error_message("len must be < 32") {
+            assert is_nn(31 - len) = TRUE;
+        }
+
         tempvar len = len - 1;
         let output = &dst[len];
         let base = 256;
@@ -455,8 +461,13 @@ namespace Helpers {
     // @notice Splits a felt into `len` bytes, little-endian, and outputs to `dst`.
     func split_word_little{range_check_ptr}(value: felt, len: felt, dst: felt*) {
         if (len == 0) {
-            assert value = 0;
+            with_attr error_message("value not empty") {
+                assert value = 0;
+            }
             return ();
+        }
+        with_attr error_message("len must be < 32") {
+            assert is_nn(31 - len) = TRUE;
         }
         let output = &dst[0];
         let base = 256;

--- a/tests/src/utils/test_utils.cairo
+++ b/tests/src/utils/test_utils.cairo
@@ -194,3 +194,29 @@ func test__load_packed_bytes{range_check_ptr}() -> felt* {
 
     return output;
 }
+
+func test__split_word{range_check_ptr}() -> felt* {
+    alloc_locals;
+    local value: felt;
+    local len: felt;
+    %{
+        ids.value = program_input["value"]
+        ids.len = program_input["length"]
+    %}
+    let (dst) = alloc();
+    Helpers.split_word(value, len, dst);
+    return dst;
+}
+
+func test__split_word_little{range_check_ptr}() -> felt* {
+    alloc_locals;
+    local value: felt;
+    local len: felt;
+    %{
+        ids.value = program_input["value"]
+        ids.len = program_input["length"]
+    %}
+    let (dst) = alloc();
+    Helpers.split_word_little(value, len, dst);
+    return dst;
+}

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -185,24 +185,15 @@ class TestLoadPackedBytes:
 
 
 class TestSplitWord:
-    @given(
-        value=st.integers(min_value=0, max_value=2**248 - 1),
-    )
-    @settings(max_examples=10)
+    @given(value=st.integers(min_value=0, max_value=2**248 - 1))
     def test_should_split_word(self, cairo_run, value):
         length = (value.bit_length() + 7) // 8
         output = cairo_run("test__split_word", value=value, length=length)
-        res = bytes(output)
-        assert (
-            bytes.fromhex(f"{value:x}".rjust(length * 2, "0"))
-            if value != 0
-            else b"" == res
+        assert bytes(output) == (
+            bytes.fromhex(f"{value:x}".rjust(length * 2, "0")) if value != 0 else b""
         )
 
-    @given(
-        value=st.integers(min_value=1, max_value=2**248 - 1),
-    )
-    @settings(max_examples=5)
+    @given(value=st.integers(min_value=1, max_value=2**248 - 1))
     def test_should_raise_value_not_empty_split_word(self, cairo_run, value):
         length = (value.bit_length() + 7) // 8
         with cairo_error("value not empty"):
@@ -212,29 +203,21 @@ class TestSplitWord:
         value=st.integers(min_value=0, max_value=2**248 - 1),
         length=st.integers(min_value=32),
     )
-    @settings(max_examples=5)
     def test_should_raise_issue_zellic_1278_split_word(self, cairo_run, value, length):
         with cairo_error("len must be < 32"):
             cairo_run("test__split_word", value=value, length=length)
 
-    @given(
-        value=st.integers(min_value=0, max_value=2**248 - 1),
-    )
-    @settings(max_examples=10)
+    @given(value=st.integers(min_value=0, max_value=2**248 - 1))
     def test_should_split_word_little(self, cairo_run, value):
         length = (value.bit_length() + 7) // 8
         output = cairo_run("test__split_word_little", value=value, length=length)
-        res = bytes(output)
-        assert (
+        assert bytes(output) == (
             bytes.fromhex(f"{value:x}".rjust(length * 2, "0"))[::-1]
             if value != 0
-            else b"" == res
+            else b""
         )
 
-    @given(
-        value=st.integers(min_value=1, max_value=2**248 - 1),
-    )
-    @settings(max_examples=5)
+    @given(value=st.integers(min_value=1, max_value=2**248 - 1))
     def test_should_raise_value_not_empty_split_word_little(self, cairo_run, value):
         length = (value.bit_length() + 7) // 8
         with cairo_error("value not empty"):
@@ -244,7 +227,6 @@ class TestSplitWord:
         value=st.integers(min_value=0, max_value=2**248 - 1),
         length=st.integers(min_value=32),
     )
-    @settings(max_examples=5)
     def test_should_raise_issue_zellic_1278_split_word_little(
         self, cairo_run, value, length
     ):

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -182,3 +182,71 @@ class TestLoadPackedBytes:
             cairo_error(message="Value is not empty"),
         ):
             cairo_run("test__load_packed_bytes", data=packed_bytes)
+
+
+class TestSplitWord:
+    @given(
+        value=st.integers(min_value=0, max_value=2**248 - 1),
+    )
+    @settings(max_examples=10)
+    def test_should_split_word(self, cairo_run, value):
+        length = (value.bit_length() + 7) // 8
+        output = cairo_run("test__split_word", value=value, length=length)
+        res = bytes(output)
+        assert (
+            bytes.fromhex(f"{value:x}".rjust(length * 2, "0"))
+            if value != 0
+            else b"" == res
+        )
+
+    @given(
+        value=st.integers(min_value=1, max_value=2**248 - 1),
+    )
+    @settings(max_examples=5)
+    def test_should_raise_value_not_empty_split_word(self, cairo_run, value):
+        length = (value.bit_length() + 7) // 8
+        with cairo_error("value not empty"):
+            cairo_run("test__split_word", value=value, length=length - 1)
+
+    @given(
+        value=st.integers(min_value=0, max_value=2**248 - 1),
+        length=st.integers(min_value=32),
+    )
+    @settings(max_examples=5)
+    def test_should_raise_issue_zellic_1278_split_word(self, cairo_run, value, length):
+        with cairo_error("len must be < 32"):
+            cairo_run("test__split_word", value=value, length=length)
+
+    @given(
+        value=st.integers(min_value=0, max_value=2**248 - 1),
+    )
+    @settings(max_examples=10)
+    def test_should_split_word_little(self, cairo_run, value):
+        length = (value.bit_length() + 7) // 8
+        output = cairo_run("test__split_word_little", value=value, length=length)
+        res = bytes(output)
+        assert (
+            bytes.fromhex(f"{value:x}".rjust(length * 2, "0"))[::-1]
+            if value != 0
+            else b"" == res
+        )
+
+    @given(
+        value=st.integers(min_value=1, max_value=2**248 - 1),
+    )
+    @settings(max_examples=5)
+    def test_should_raise_value_not_empty_split_word_little(self, cairo_run, value):
+        length = (value.bit_length() + 7) // 8
+        with cairo_error("value not empty"):
+            cairo_run("test__split_word_little", value=value, length=length - 1)
+
+    @given(
+        value=st.integers(min_value=0, max_value=2**248 - 1),
+        length=st.integers(min_value=32),
+    )
+    @settings(max_examples=5)
+    def test_should_raise_issue_zellic_1278_split_word_little(
+        self, cairo_run, value, length
+    ):
+        with cairo_error("len must be < 32"):
+            cairo_run("test__split_word_little", value=value, length=length)

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -212,13 +212,13 @@ class TestSplitWord:
         length = (value.bit_length() + 7) // 8
         output = cairo_run("test__split_word_little", value=value, length=length)
         assert bytes(output) == (
-            value.to_bytes(byteorder="little", length=length)
-            if value != 0
-            else b""
+            value.to_bytes(byteorder="little", length=length) if value != 0 else b""
         )
 
     @given(value=st.integers(min_value=1, max_value=2**248 - 1))
-    def test_should_raise_when_len_is_too_small_split_word_little(self, cairo_run, value):
+    def test_should_raise_when_len_is_too_small_split_word_little(
+        self, cairo_run, value
+    ):
         length = (value.bit_length() + 7) // 8
         with cairo_error("value not empty"):
             cairo_run("test__split_word_little", value=value, length=length - 1)

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -190,11 +190,11 @@ class TestSplitWord:
         length = (value.bit_length() + 7) // 8
         output = cairo_run("test__split_word", value=value, length=length)
         assert bytes(output) == (
-            bytes.fromhex(f"{value:x}".rjust(length * 2, "0")) if value != 0 else b""
+            value.to_bytes(byteorder="big", length=length) if value != 0 else b""
         )
 
     @given(value=st.integers(min_value=1, max_value=2**248 - 1))
-    def test_should_raise_value_not_empty_split_word(self, cairo_run, value):
+    def test_should_raise_when_length_is_too_short_split_word(self, cairo_run, value):
         length = (value.bit_length() + 7) // 8
         with cairo_error("value not empty"):
             cairo_run("test__split_word", value=value, length=length - 1)
@@ -203,7 +203,7 @@ class TestSplitWord:
         value=st.integers(min_value=0, max_value=2**248 - 1),
         length=st.integers(min_value=32),
     )
-    def test_should_raise_issue_zellic_1278_split_word(self, cairo_run, value, length):
+    def test_should_raise_when_len_ge_32_split_word(self, cairo_run, value, length):
         with cairo_error("len must be < 32"):
             cairo_run("test__split_word", value=value, length=length)
 
@@ -212,13 +212,13 @@ class TestSplitWord:
         length = (value.bit_length() + 7) // 8
         output = cairo_run("test__split_word_little", value=value, length=length)
         assert bytes(output) == (
-            bytes.fromhex(f"{value:x}".rjust(length * 2, "0"))[::-1]
+            value.to_bytes(byteorder="little", length=length)
             if value != 0
             else b""
         )
 
     @given(value=st.integers(min_value=1, max_value=2**248 - 1))
-    def test_should_raise_value_not_empty_split_word_little(self, cairo_run, value):
+    def test_should_raise_when_len_is_too_small_split_word_little(self, cairo_run, value):
         length = (value.bit_length() + 7) // 8
         with cairo_error("value not empty"):
             cairo_run("test__split_word_little", value=value, length=length - 1)
@@ -227,7 +227,7 @@ class TestSplitWord:
         value=st.integers(min_value=0, max_value=2**248 - 1),
         length=st.integers(min_value=32),
     )
-    def test_should_raise_issue_zellic_1278_split_word_little(
+    def test_should_raise_when_len_ge_32_split_word_little(
         self, cairo_run, value, length
     ):
         with cairo_error("len must be < 32"):


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Split word is underconstrained and not tested

Resolves #1278

## What is the new behavior?

Split word raise if len > 32 and is tested

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1305)
<!-- Reviewable:end -->
