### PR TITLE
Fix RLP.decode

### DIFF
--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -28,12 +28,12 @@ namespace EthTransaction {
     ) -> model.EthTransaction* {
         // see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
         alloc_locals;
-        let (items: RLP.Item*) = alloc();
-        RLP.decode(items, tx_data_len, tx_data);
+        let (tx_items: RLP.Item*) = alloc();
+        RLP.decode(tx_items, tx_data_len, tx_data);
 
-        assert [items].is_list = TRUE;
-        let items_len = [items].data_len;
-        let items = cast([items].data, RLP.Item*);
+        assert [tx_items].is_list = TRUE;
+        let items_len = [tx_items].data_len;
+        let items = cast([tx_items].data, RLP.Item*);
 
         // Pre eip-155 txs have 6 fields, post eip-155 txs have 9 fields
         // We check for both cases here, and do the remaining ones in the next if block
@@ -91,12 +91,12 @@ namespace EthTransaction {
     ) -> model.EthTransaction* {
         alloc_locals;
 
-        let (items: RLP.Item*) = alloc();
-        RLP.decode(items, tx_data_len - 1, tx_data + 1);
+        let (tx_items: RLP.Item*) = alloc();
+        RLP.decode(tx_items, tx_data_len - 1, tx_data + 1);
 
-        assert [items].is_list = TRUE;
-        let items_len = [items].data_len;
-        let items = cast([items].data, RLP.Item*);
+        assert [tx_items].is_list = TRUE;
+        let items_len = [tx_items].data_len;
+        let items = cast([tx_items].data, RLP.Item*);
 
         assert items_len = 8;
         assert items[0].is_list = FALSE;
@@ -148,12 +148,12 @@ namespace EthTransaction {
     ) -> model.EthTransaction* {
         alloc_locals;
 
-        let (items: RLP.Item*) = alloc();
-        RLP.decode(items, tx_data_len - 1, tx_data + 1);
+        let (tx_items: RLP.Item*) = alloc();
+        RLP.decode(tx_items, tx_data_len - 1, tx_data + 1);
 
-        assert [items].is_list = TRUE;
-        let items_len = [items].data_len;
-        let items = cast([items].data, RLP.Item*);
+        assert [tx_items].is_list = TRUE;
+        let items_len = [tx_items].data_len;
+        let items = cast([tx_items].data, RLP.Item*);
 
         assert items_len = 9;
         assert items[0].is_list = FALSE;

--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -35,6 +35,13 @@ namespace EthTransaction {
         let items_len = [items].data_len;
         let items = cast([items].data, RLP.Item*);
 
+        assert items[0].is_list = FALSE;
+        assert items[1].is_list = FALSE;
+        assert items[2].is_list = FALSE;
+        assert items[3].is_list = FALSE;
+        assert items[4].is_list = FALSE;
+        assert items[5].is_list = FALSE;
+
         let nonce = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
         let gas_price = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
         let gas_limit = Helpers.bytes_to_felt(items[2].data_len, items[2].data);
@@ -50,6 +57,9 @@ namespace EthTransaction {
             tempvar chain_id = 0;
         } else {
             assert items_len = 9;
+            assert items[6].is_list = FALSE;
+            assert items[7].is_list = FALSE;
+            assert items[8].is_list = FALSE;
             let chain_id = Helpers.bytes_to_felt(items[6].data_len, items[6].data);
         }
         let chain_id = [ap - 1];
@@ -87,6 +97,14 @@ namespace EthTransaction {
         let items = cast([items].data, RLP.Item*);
 
         assert items_len = 8;
+        assert items[0].is_list = FALSE;
+        assert items[1].is_list = FALSE;
+        assert items[2].is_list = FALSE;
+        assert items[3].is_list = FALSE;
+        assert items[4].is_list = FALSE;
+        assert items[5].is_list = FALSE;
+        assert items[6].is_list = FALSE;
+        assert items[7].is_list = TRUE;
 
         let chain_id = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
         let nonce = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
@@ -136,6 +154,15 @@ namespace EthTransaction {
         let items = cast([items].data, RLP.Item*);
 
         assert items_len = 9;
+        assert items[0].is_list = FALSE;
+        assert items[1].is_list = FALSE;
+        assert items[2].is_list = FALSE;
+        assert items[3].is_list = FALSE;
+        assert items[4].is_list = FALSE;
+        assert items[5].is_list = FALSE;
+        assert items[6].is_list = FALSE;
+        assert items[7].is_list = FALSE;
+        assert items[8].is_list = TRUE;
 
         let chain_id = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
         let nonce = Helpers.bytes_to_felt(items[1].data_len, items[1].data);

--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -35,6 +35,8 @@ namespace EthTransaction {
         let items_len = [items].data_len;
         let items = cast([items].data, RLP.Item*);
 
+        // Pre eip-155 txs have 6 fields, post eip-155 txs have 9 fields
+        // We check for both cases here, and do the remaining ones in the next if block
         assert items[0].is_list = FALSE;
         assert items[1].is_list = FALSE;
         assert items[2].is_list = FALSE;

--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -31,27 +31,26 @@ namespace EthTransaction {
         let (items: RLP.Item*) = alloc();
         RLP.decode(items, tx_data_len, tx_data);
 
-        // the tx is a list of fields, hence first level RLP decoding
-        // is a single item, which is indeed the sought list
         assert [items].is_list = TRUE;
-        let sub_items_len = [items].data_len;
-        let sub_items = cast([items].data, RLP.Item*);
+        let items_len = [items].data_len;
+        let items = cast([items].data, RLP.Item*);
 
-        let nonce = Helpers.bytes_to_felt(sub_items[0].data_len, sub_items[0].data);
-        let gas_price = Helpers.bytes_to_felt(sub_items[1].data_len, sub_items[1].data);
-        let gas_limit = Helpers.bytes_to_felt(sub_items[2].data_len, sub_items[2].data);
+        let nonce = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
+        let gas_price = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
+        let gas_limit = Helpers.bytes_to_felt(items[2].data_len, items[2].data);
         let destination = Helpers.try_parse_destination_from_bytes(
-            sub_items[3].data_len, sub_items[3].data
+            items[3].data_len, items[3].data
         );
-        let amount = Helpers.bytes_to_uint256(sub_items[4].data_len, sub_items[4].data);
-        let payload_len = sub_items[5].data_len;
-        let payload = sub_items[5].data;
+        let amount = Helpers.bytes_to_uint256(items[4].data_len, items[4].data);
+        let payload_len = items[5].data_len;
+        let payload = items[5].data;
 
         // pre eip-155 txs have 6 fields, post eip-155 txs have 9 fields
-        if (sub_items_len == 6) {
+        if (items_len == 6) {
             tempvar chain_id = 0;
         } else {
-            let chain_id = Helpers.bytes_to_felt(sub_items[6].data_len, sub_items[6].data);
+            assert items_len = 9;
+            let chain_id = Helpers.bytes_to_felt(items[6].data_len, items[6].data);
         }
         let chain_id = [ap - 1];
 
@@ -82,23 +81,27 @@ namespace EthTransaction {
 
         let (items: RLP.Item*) = alloc();
         RLP.decode(items, tx_data_len - 1, tx_data + 1);
-        let sub_items_len = [items].data_len;
-        let sub_items = cast([items].data, RLP.Item*);
 
-        let chain_id = Helpers.bytes_to_felt(sub_items[0].data_len, sub_items[0].data);
-        let nonce = Helpers.bytes_to_felt(sub_items[1].data_len, sub_items[1].data);
-        let gas_price = Helpers.bytes_to_felt(sub_items[2].data_len, sub_items[2].data);
-        let gas_limit = Helpers.bytes_to_felt(sub_items[3].data_len, sub_items[3].data);
+        assert [items].is_list = TRUE;
+        let items_len = [items].data_len;
+        let items = cast([items].data, RLP.Item*);
+
+        assert items_len = 8;
+
+        let chain_id = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
+        let nonce = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
+        let gas_price = Helpers.bytes_to_felt(items[2].data_len, items[2].data);
+        let gas_limit = Helpers.bytes_to_felt(items[3].data_len, items[3].data);
         let destination = Helpers.try_parse_destination_from_bytes(
-            sub_items[4].data_len, sub_items[4].data
+            items[4].data_len, items[4].data
         );
-        let amount = Helpers.bytes_to_uint256(sub_items[5].data_len, sub_items[5].data);
-        let payload_len = sub_items[6].data_len;
-        let payload = sub_items[6].data;
+        let amount = Helpers.bytes_to_uint256(items[5].data_len, items[5].data);
+        let payload_len = items[6].data_len;
+        let payload = items[6].data;
 
         let (access_list: felt*) = alloc();
         let access_list_len = parse_access_list(
-            access_list, sub_items[7].data_len, cast(sub_items[7].data, RLP.Item*)
+            access_list, items[7].data_len, cast(items[7].data, RLP.Item*)
         );
         tempvar tx = new model.EthTransaction(
             signer_nonce=nonce,
@@ -127,28 +130,27 @@ namespace EthTransaction {
 
         let (items: RLP.Item*) = alloc();
         RLP.decode(items, tx_data_len - 1, tx_data + 1);
-        // the tx is a list of fields, hence first level RLP decoding
-        // is a single item, which is indeed the sought list
-        assert [items].is_list = TRUE;
-        let sub_items_len = [items].data_len;
-        let sub_items = cast([items].data, RLP.Item*);
 
-        let chain_id = Helpers.bytes_to_felt(sub_items[0].data_len, sub_items[0].data);
-        let nonce = Helpers.bytes_to_felt(sub_items[1].data_len, sub_items[1].data);
-        let max_priority_fee_per_gas = Helpers.bytes_to_felt(
-            sub_items[2].data_len, sub_items[2].data
-        );
-        let max_fee_per_gas = Helpers.bytes_to_felt(sub_items[3].data_len, sub_items[3].data);
-        let gas_limit = Helpers.bytes_to_felt(sub_items[4].data_len, sub_items[4].data);
+        assert [items].is_list = TRUE;
+        let items_len = [items].data_len;
+        let items = cast([items].data, RLP.Item*);
+
+        assert items_len = 9;
+
+        let chain_id = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
+        let nonce = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
+        let max_priority_fee_per_gas = Helpers.bytes_to_felt(items[2].data_len, items[2].data);
+        let max_fee_per_gas = Helpers.bytes_to_felt(items[3].data_len, items[3].data);
+        let gas_limit = Helpers.bytes_to_felt(items[4].data_len, items[4].data);
         let destination = Helpers.try_parse_destination_from_bytes(
-            sub_items[5].data_len, sub_items[5].data
+            items[5].data_len, items[5].data
         );
-        let amount = Helpers.bytes_to_uint256(sub_items[6].data_len, sub_items[6].data);
-        let payload_len = sub_items[7].data_len;
-        let payload = sub_items[7].data;
+        let amount = Helpers.bytes_to_uint256(items[6].data_len, items[6].data);
+        let payload_len = items[7].data_len;
+        let payload = items[7].data;
         let (access_list: felt*) = alloc();
         let access_list_len = parse_access_list(
-            access_list, sub_items[8].data_len, cast(sub_items[8].data, RLP.Item*)
+            access_list, items[8].data_len, cast(items[8].data, RLP.Item*)
         );
         tempvar tx = new model.EthTransaction(
             signer_nonce=nonce,

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -106,6 +106,7 @@ namespace RLP {
             assert extra_bytes = 0;
         }
         let items_len = decode_raw(items=items, data_len=data_len, data=data);
+        assert items_len = 1;
         return items_len;
     }
 }

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -91,14 +91,8 @@ namespace RLP {
         }
         tempvar items = items + Item.SIZE;
 
-        let total_item_len = len + offset;
-        let is_lt_input = is_nn(data_len + 1 - total_item_len);
-        if (is_lt_input != FALSE) {
-            let items_len = decode(
-                items=items, data_len=data_len - total_item_len, data=data + total_item_len
-            );
-            return 1 + items_len;
-        }
-        return 1;
+        let remaining_data_len = data_len - len - offset;
+        let items_len = decode(items=items, data_len=remaining_data_len, data=data + offset + len);
+        return 1 + items_len;
     }
 }

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -98,7 +98,7 @@ namespace RLP {
         return 1 + items_len;
     }
 
-    func decode{range_check_ptr}(items: Item*, data_len: felt, data: felt*) -> felt {
+    func decode{range_check_ptr}(items: Item*, data_len: felt, data: felt*) {
         alloc_locals;
         let (rlp_type, offset, len) = decode_type(data_len=data_len, data=data);
         local extra_bytes = data_len - offset - len;
@@ -107,6 +107,6 @@ namespace RLP {
         }
         let items_len = decode_raw(items=items, data_len=data_len, data=data);
         assert items_len = 1;
-        return items_len;
+        return ();
     }
 }

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -68,7 +68,7 @@ namespace RLP {
     // @param data The RLP encoded data.
     // @param items The pointer to the next free cell in the list of items decoded.
     // @return items_len The number of items decoded.
-    func decode{range_check_ptr}(items: Item*, data_len: felt, data: felt*) -> felt {
+    func decode_raw{range_check_ptr}(items: Item*, data_len: felt, data: felt*) -> felt {
         alloc_locals;
 
         if (data_len == 0) {
@@ -80,7 +80,7 @@ namespace RLP {
         if (rlp_type == 1) {
             // Case list
             let (sub_items: Item*) = alloc();
-            let sub_items_len = decode(items=sub_items, data_len=len, data=data + offset);
+            let sub_items_len = decode_raw(items=sub_items, data_len=len, data=data + offset);
             assert [items] = Item(data_len=sub_items_len, data=cast(sub_items, felt*), is_list=1);
             tempvar range_check_ptr = range_check_ptr;
         } else {
@@ -92,7 +92,20 @@ namespace RLP {
         tempvar items = items + Item.SIZE;
 
         let remaining_data_len = data_len - len - offset;
-        let items_len = decode(items=items, data_len=remaining_data_len, data=data + offset + len);
+        let items_len = decode_raw(
+            items=items, data_len=remaining_data_len, data=data + offset + len
+        );
         return 1 + items_len;
+    }
+
+    func decode{range_check_ptr}(items: Item*, data_len: felt, data: felt*) -> felt {
+        alloc_locals;
+        let (rlp_type, offset, len) = decode_type(data_len=data_len, data=data);
+        local extra_bytes = data_len - offset - len;
+        with_attr error_message("RLP string ends with {extra_bytes} superfluous bytes") {
+            assert extra_bytes = 0;
+        }
+        let items_len = decode_raw(items=items, data_len=data_len, data=data);
+        return items_len;
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@ import logging
 import os
 
 import pytest
+from dotenv import load_dotenv
 from hypothesis import Verbosity, settings
 from starkware.cairo.lang.instances import LAYOUTS
 
+load_dotenv()
 logging.getLogger("asyncio").setLevel(logging.ERROR)
 logger = logging.getLogger()
 

--- a/tests/fixtures/starknet.py
+++ b/tests/fixtures/starknet.py
@@ -234,9 +234,6 @@ def cairo_run(request, cairo_program) -> list:
         output_stem = Path(
             f"{output_stem[:160]}_{int(time_ns())}_{md5(output_stem.encode()).digest().hex()[:8]}"
         )
-        logger.info(
-            f"Test {request.node.path.stem}_{entrypoint}_{displayed_args} artifacts saved at: {output_stem}"
-        )
         if request.config.getoption("profile_cairo"):
             tracer_data = TracerData(
                 program=cairo_program,

--- a/tests/src/utils/test_eth_transaction.py
+++ b/tests/src/utils/test_eth_transaction.py
@@ -15,10 +15,7 @@ class TestEthTransaction:
             self, cairo_run, transaction
         ):
             encoded_unsigned_tx = rlp_encode_signed_data(transaction)
-            decoded_tx = cairo_run(
-                "test__decode",
-                data=list(encoded_unsigned_tx),
-            )
+            decoded_tx = cairo_run("test__decode", data=list(encoded_unsigned_tx))
 
             expected_data = (
                 "0x" + transaction["data"].hex()

--- a/tests/src/utils/test_eth_transaction.py
+++ b/tests/src/utils/test_eth_transaction.py
@@ -10,6 +10,19 @@ from tests.utils.helpers import flatten_tx_access_list, rlp_encode_signed_data
 class TestEthTransaction:
 
     class TestDecodeTransaction:
+
+        async def test_should_raise_with_list_items(self, cairo_run):
+            transaction = {
+                "nonce": 0,
+                "gasPrice": 234567897654321,
+                "gas": 2_000_000,
+                "to": "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55",
+                "value": ["000000000"],
+                "data": b"",
+            }
+            with cairo_error():
+                cairo_run("test__decode", data=list(encode(list(transaction.values()))))
+
         @pytest.mark.parametrize("transaction", TRANSACTIONS)
         async def test_should_decode_all_transactions_types(
             self, cairo_run, transaction

--- a/tests/src/utils/test_rlp.cairo
+++ b/tests/src/utils/test_rlp.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 
-func test__decode{range_check_ptr}() -> (items_len: felt, items: RLP.Item*) {
+func test__decode{range_check_ptr}() -> RLP.Item* {
     alloc_locals;
     // Given
     tempvar data_len: felt;
@@ -17,9 +17,9 @@ func test__decode{range_check_ptr}() -> (items_len: felt, items: RLP.Item*) {
 
     // When
     let (local items: RLP.Item*) = alloc();
-    let items_len = RLP.decode(items, data_len, data);
+    RLP.decode(items, data_len, data);
 
-    return (items_len, items);
+    return items;
 }
 
 func test__decode_type{range_check_ptr}() -> (felt, felt, felt) {

--- a/tests/src/utils/test_rlp.cairo
+++ b/tests/src/utils/test_rlp.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 
-func test__decode{range_check_ptr}(output_ptr: felt*) {
+func test__decode{range_check_ptr}() -> (items_len: felt, items: RLP.Item*) {
     alloc_locals;
     // Given
     tempvar data_len: felt;
@@ -17,17 +17,12 @@ func test__decode{range_check_ptr}(output_ptr: felt*) {
 
     // When
     let (local items: RLP.Item*) = alloc();
-    RLP.decode(items, data_len, data);
+    let items_len = RLP.decode(items, data_len, data);
 
-    %{
-        from tests.utils.hints import flatten_rlp_list
-        # The cairo functions returns a single RLP list of size 1 containing the decoded objects.
-        flatten_rlp_list(ids.items.address_, 1, ids.output_ptr, memory, segments)
-    %}
-    return ();
+    return (items_len, items);
 }
 
-func test__decode_type{range_check_ptr}(output_ptr: felt*) {
+func test__decode_type{range_check_ptr}() -> (felt, felt, felt) {
     alloc_locals;
     // Given
     tempvar data_len: felt;
@@ -41,31 +36,5 @@ func test__decode_type{range_check_ptr}(output_ptr: felt*) {
     let (type, offset, len) = RLP.decode_type(data_len, data);
 
     // Then
-    assert [output_ptr] = type;
-    assert [output_ptr + 1] = offset;
-    assert [output_ptr + 2] = len;
-
-    return ();
-}
-
-func test__decode_transaction{range_check_ptr}(output_ptr: felt*) {
-    alloc_locals;
-    // Given
-    tempvar data_len: felt;
-    let (data) = alloc();
-    %{
-        ids.data_len = len(program_input["data"])
-        segments.write_arg(ids.data, program_input["data"])
-    %}
-
-    // When
-    let (local items: RLP.Item*) = alloc();
-    RLP.decode(items, data_len, data);
-
-    %{
-        from tests.utils.hints import flatten_rlp_list
-        # The cairo functions returns a single RLP list of size 1 containing the decoded objects.
-        flatten_rlp_list(ids.items.address_, 1, ids.output_ptr, memory, segments)
-    %}
-    return ();
+    return (type, offset, len);
 }

--- a/tests/src/utils/test_rlp.py
+++ b/tests/src/utils/test_rlp.py
@@ -33,9 +33,8 @@ class TestRLP:
         ):
             encoded_data = encode(data)
 
-            items_len, items = cairo_run("test__decode", data=list(encoded_data))
-            decoded = items[0] if items_len == 1 else items
-            assert decoded == decode(encoded_data)
+            items = cairo_run("test__decode", data=list(encoded_data))
+            assert items[0] == decode(encoded_data)
 
         @given(
             data=recursive(binary(), lists),
@@ -61,6 +60,5 @@ class TestRLP:
             else:
                 rlp_encoding = encoded_unsigned_tx
 
-            items_len, items = cairo_run("test__decode", data=list(rlp_encoding))
-            decoded = items[0] if items_len == 1 else items
-            assert decoded == decode(rlp_encoding)
+            items = cairo_run("test__decode", data=list(rlp_encoding))
+            assert items[0] == decode(rlp_encoding)

--- a/tests/src/utils/test_rlp.py
+++ b/tests/src/utils/test_rlp.py
@@ -1,25 +1,16 @@
-import random
-
 import pytest
+from hypothesis import given
+from hypothesis.strategies import binary
 from rlp import codec, decode, encode
 
 from tests.utils.constants import TRANSACTIONS
-from tests.utils.helpers import flatten, rlp_encode_signed_data
+from tests.utils.helpers import rlp_encode_signed_data
 
 
 class TestRLP:
     class TestDecodeType:
-        @pytest.mark.parametrize(
-            "payload_len",
-            [0, 55, 256],
-        )
-        def test_should_match_decoded_rlp_type_string(self, cairo_run, payload_len):
-            # generate random string of bytes. if payload_len is 0, then generate a single byte inferior to 0x80
-            data = (
-                random.randbytes(payload_len)
-                if payload_len != 0
-                else random.randint(0, 0x80)
-            )
+        @given(data=binary(min_size=0, max_size=255))
+        def test_should_match_decoded_rlp_type_string(self, cairo_run, data):
             encoded_data = encode(data)
 
             [
@@ -30,16 +21,13 @@ class TestRLP:
             ] = codec.consume_length_prefix(encoded_data, 0)
             expected_type = 0 if rlp_type == bytes else 1
 
-            output = cairo_run("test__decode_type", data=encoded_data)
+            output = cairo_run("test__decode_type", data=list(encoded_data))
 
-            assert output[0] == expected_type
-            assert output[1] == expected_offset
-            assert output[2] == expected_len
+            assert output == [expected_type, expected_offset, expected_len]
 
-        @pytest.mark.parametrize("payload_len", [0, 55, 256])
-        def test_should_match_decoded_rlp_type_list(self, cairo_run, payload_len):
-            data = [random.randbytes(payload_len)]
-            encoded_data = encode(data)
+        @given(data=binary(min_size=0, max_size=255))
+        def test_should_match_decoded_rlp_type_list(self, cairo_run, data):
+            encoded_data = encode([data])
 
             [
                 prefix,
@@ -47,31 +35,22 @@ class TestRLP:
                 expected_len,
                 expected_offset,
             ] = codec.consume_length_prefix(encoded_data, 0)
-            expected_type = 1 if rlp_type == list else 0
+            expected_type = 0 if rlp_type == bytes else 1
 
-            output = cairo_run("test__decode_type", data=encoded_data)
+            output = cairo_run("test__decode_type", data=list(encoded_data))
 
-            assert output[0] == expected_type
-            assert output[1] == expected_offset
-            assert output[2] == expected_len
+            assert output == [expected_type, expected_offset, expected_len]
 
     class TestDecode:
-        @pytest.mark.parametrize("payload_len", [55, 56])
+        @given(data=binary(min_size=0, max_size=255))
         async def test_should_match_decode_reference_implementation(
-            self, cairo_run, payload_len
+            self, cairo_run, data
         ):
-            data = [random.randbytes(payload_len - 1)]
             encoded_data = encode(data)
-            expected_result = decode(encoded_data)
 
-            # flatten the decoded data into a single bytes l
-            # there must be no nested lists at the end
-            flattened_data = flatten(list(expected_result))
-            flattened_output = cairo_run(
-                "test__decode", data=list(encoded_data), is_list=1
-            )
-
-            assert flattened_data == flattened_output
+            items_len, items = cairo_run("test__decode", data=list(encoded_data))
+            decoded = items[0] if items_len == 1 else items
+            assert decoded == decode(encoded_data)
 
         @pytest.mark.parametrize("transaction", TRANSACTIONS)
         def test_should_decode_all_tx_types(self, cairo_run, transaction):
@@ -84,13 +63,6 @@ class TestRLP:
             else:
                 rlp_encoding = encoded_unsigned_tx
 
-            decoded_tx = decode(rlp_encoding)
-
-            # flatten the decoded data into a single bytes l
-            # there must be no nested lists at the end
-            flattened_data = flatten(decoded_tx)
-            flattened_output = cairo_run(
-                "test__decode_transaction", data=rlp_encoding, is_list=1
-            )
-
-            assert flattened_data == flattened_output
+            items_len, items = cairo_run("test__decode", data=list(rlp_encoding))
+            decoded = items[0] if items_len == 1 else items
+            assert decoded == decode(rlp_encoding)

--- a/tests/utils/hints.py
+++ b/tests/utils/hints.py
@@ -17,24 +17,6 @@ def debug_info(program):
     return _debug_info
 
 
-def flatten_rlp_list(list_ptr, list_len, output_ptr, memory, segments):
-    for i in range(list_len):
-        data_len = memory[list_ptr + i * 3]
-        data_ptr = memory[list_ptr + i * 3 + 1]
-        is_list = memory[list_ptr + i * 3 + 2]
-
-        if is_list:
-            output_ptr = flatten_rlp_list(
-                data_ptr, data_len, output_ptr, memory, segments
-            )
-        else:
-            data = [memory[data_ptr + j] for j in range(data_len)]
-            segments.write_arg(output_ptr, data)
-            output_ptr += len(data)
-
-    return output_ptr
-
-
 def new_default_dict(
     dict_manager, segments, default_value, initial_dict, temp_segment: bool = False
 ):


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`RLP.decode` doesn't check that the result is consistent with the given len prefix.
In other words, given two encoded items `b1` and `b2`, `RLP.decode(b1 + b2)` will actually decode
`b1` and `b2` while it should raise because `b1 + b2` is not a valid RLP (it's a list with missing prefix).

Resolves #1306

## What is the new behavior?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1307)
<!-- Reviewable:end -->
