### PR TITLE
opti: remove unnecessary assignment Uint256*

### DIFF
--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -114,7 +114,6 @@ namespace Account {
         alloc_locals;
 
         let starknet_address = get_registered_starknet_address(evm_address);
-        local balance_ptr: Uint256*;
 
         // Case touching a non deployed account
         if (starknet_address == 0) {

--- a/src/kakarot/account.cairo
+++ b/src/kakarot/account.cairo
@@ -21,7 +21,7 @@ from starkware.cairo.common.hash_state import (
 )
 from starkware.starknet.common.storage import normalize_address
 from starkware.starknet.common.syscalls import get_contract_address
-from starkware.cairo.lang.compiler.lib.registers import get_ap
+from starkware.cairo.lang.compiler.lib.registers import get_ap, get_fp_and_pc
 from kakarot.constants import Constants
 from kakarot.storages import (
     Kakarot_uninitialized_account_class_hash,
@@ -124,14 +124,15 @@ namespace Account {
             let (ap_val) = get_ap();
             tempvar balance_ptr = cast(ap_val - 2, Uint256*);
             // empty code hash see https://eips.ethereum.org/EIPS/eip-1052
-            tempvar code_hash_ptr = new Uint256(
+            local code_hash: Uint256 = Uint256(
                 Constants.EMPTY_CODE_HASH_LOW, Constants.EMPTY_CODE_HASH_HIGH
             );
+            let (__fp__, _) = get_fp_and_pc();
             let account = Account.init(
                 address=address,
                 code_len=0,
                 code=bytecode,
-                code_hash=code_hash_ptr,
+                code_hash=&code_hash,
                 nonce=0,
                 balance=balance_ptr,
             );
@@ -141,7 +142,7 @@ namespace Account {
         tempvar address = new model.Address(starknet=starknet_address, evm=evm_address);
         fetch_balance(address);
         let (ap_val) = get_ap();
-        tempvar balance_ptr = cast(ap_val - 2, Uint256*);
+        let balance_ptr = cast(ap_val - 2, Uint256*);
 
         let (bytecode_len, bytecode) = IAccount.bytecode(contract_address=starknet_address);
         let (nonce) = IAccount.get_nonce(contract_address=starknet_address);

--- a/src/kakarot/constants.cairo
+++ b/src/kakarot/constants.cairo
@@ -18,6 +18,10 @@ namespace Constants {
     const MAX_CODE_SIZE = 0x6000;
 
     const BURN_ADDRESS = 0xdead;
+
+    // Empty code hash Uint256.
+    const EMPTY_CODE_HASH_LOW = 304396909071904405792975023732328604784;
+    const EMPTY_CODE_HASH_HIGH = 262949717399590921288928019264691438528;
 }
 
 // See model.Opcode:

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -10,6 +10,7 @@ from starkware.cairo.common.math_cmp import is_nn, is_not_zero
 from starkware.cairo.common.uint256 import Uint256, uint256_lt, uint256_le
 from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict_access import DictAccess
+from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 
 from kakarot.account import Account
 from kakarot.interfaces.interfaces import ICairo1Helpers
@@ -525,12 +526,13 @@ namespace SystemOperations {
             return evm;
         }
 
-        tempvar zero = new Uint256(0, 0);
+        local zero: Uint256 = Uint256(0, 0);
+        let (__fp__, _) = get_fp_and_pc();
         // Operation
         let child_evm = CallHelper.generic_call(
             evm,
             gas,
-            value=zero,
+            value=&zero,
             caller=call_sender,
             to=to,
             code_address=to,
@@ -1154,8 +1156,9 @@ namespace CreateHelper {
             let gas_refund = evm.message.parent.evm.gas_refund + (1 - is_exceptional_revert) *
                 evm.gas_refund;
 
-            tempvar stack_code = new Uint256(low=0, high=0);
-            Stack.push(stack_code);
+            local stack_code: Uint256 = Uint256(low=0, high=0);
+            let (__fp__, _) = get_fp_and_pc();
+            Stack.push(&stack_code);
 
             tempvar state = evm.message.parent.state;
 
@@ -1188,8 +1191,9 @@ namespace CreateHelper {
 
         // Stack output: the address of the deployed contract, 0 if the deployment failed.
         let (address_high, address_low) = split_felt(evm.message.address.evm * success);
-        tempvar address = new Uint256(low=address_low, high=address_high);
-        Stack.push(address);
+        local address: Uint256 = Uint256(low=address_low, high=address_high);
+        let (__fp__, _) = get_fp_and_pc();
+        Stack.push(&address);
 
         if (success == FALSE) {
             tempvar state = evm.message.parent.state;

--- a/src/kakarot/stack.cairo
+++ b/src/kakarot/stack.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
 from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
 from starkware.cairo.common.math import assert_le, unsigned_div_rem
-from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
+from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc, get_ap
 from starkware.cairo.common.uint256 import Uint256
 
 from kakarot.constants import Constants
@@ -50,8 +50,10 @@ namespace Stack {
     // @param element The element to push.
     // @return stack The new pointer to the stack.
     func push_uint128{stack: model.Stack*}(element: felt) {
-        tempvar item = new Uint256(element, 0);
-        push(item);
+        tempvar item = Uint256(element, 0);
+        let (ap_val) = get_ap();
+        let item_ptr = cast(ap_val - 2, Uint256*);
+        push(item_ptr);
         return ();
     }
 

--- a/src/kakarot/stack.cairo
+++ b/src/kakarot/stack.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
 from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
 from starkware.cairo.common.math import assert_le, unsigned_div_rem
-from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc, get_ap
+from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256
 
 from kakarot.constants import Constants
@@ -50,10 +50,10 @@ namespace Stack {
     // @param element The element to push.
     // @return stack The new pointer to the stack.
     func push_uint128{stack: model.Stack*}(element: felt) {
-        tempvar item = Uint256(element, 0);
-        let (ap_val) = get_ap();
-        let item_ptr = cast(ap_val - 2, Uint256*);
-        push(item_ptr);
+        alloc_locals;
+        local item: Uint256 = Uint256(element, 0);
+        let (__fp__, _) = get_fp_and_pc();
+        push(&item);
         return ();
     }
 

--- a/src/kakarot/state.cairo
+++ b/src/kakarot/state.cairo
@@ -464,17 +464,18 @@ namespace Internals {
         tempvar address = new model.Address(starknet=starknet_address, evm=evm_address);
         Account.fetch_balance(address);
         let (ap_val) = get_ap();
-        tempvar balance_ptr = cast(ap_val - 2, Uint256*);
+        let balance_ptr = cast(ap_val - 2, Uint256*);
         let (bytecode) = alloc();
         // empty code hash see https://eips.ethereum.org/EIPS/eip-1052
-        tempvar code_hash_ptr = new Uint256(
+        local code_hash: Uint256 = Uint256(
             Constants.EMPTY_CODE_HASH_LOW, Constants.EMPTY_CODE_HASH_HIGH
         );
+        let (__fp__, _) = get_fp_and_pc();
         let account = Account.init(
             address=address,
             code_len=0,
             code=bytecode,
-            code_hash=code_hash_ptr,
+            code_hash=&code_hash,
             nonce=0,
             balance=balance_ptr,
         );

--- a/src/kakarot/state.cairo
+++ b/src/kakarot/state.cairo
@@ -8,11 +8,12 @@ from starkware.cairo.common.default_dict import default_dict_new, default_dict_f
 from starkware.cairo.common.dict import dict_read, dict_write
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.memcpy import memcpy
-from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.registers import get_fp_and_pc, get_ap
 from starkware.cairo.common.uint256 import Uint256, uint256_le
 from starkware.cairo.common.bool import FALSE, TRUE
 
 from kakarot.account import Account
+from kakarot.constants import Constants
 from kakarot.model import model
 from kakarot.gas import Gas
 from utils.dict import default_dict_copy
@@ -461,12 +462,13 @@ namespace Internals {
         alloc_locals;
         let starknet_address = Account.compute_starknet_address(evm_address);
         tempvar address = new model.Address(starknet=starknet_address, evm=evm_address);
-        let balance = Account.fetch_balance(address);
-        tempvar balance_ptr = new Uint256(balance.low, balance.high);
+        Account.fetch_balance(address);
+        let (ap_val) = get_ap();
+        tempvar balance_ptr = cast(ap_val - 2, Uint256*);
         let (bytecode) = alloc();
         // empty code hash see https://eips.ethereum.org/EIPS/eip-1052
         tempvar code_hash_ptr = new Uint256(
-            304396909071904405792975023732328604784, 262949717399590921288928019264691438528
+            Constants.EMPTY_CODE_HASH_LOW, Constants.EMPTY_CODE_HASH_HIGH
         );
         let account = Account.init(
             address=address,

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -15,6 +15,7 @@ from starkware.cairo.common.cairo_secp.bigint import BigInt3, bigint_to_uint256,
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.hash_state import hash_finalize, hash_init, hash_update
 from starkware.starknet.common.syscalls import get_tx_info
+from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 
 from kakarot.model import model
 from utils.bytes import uint256_to_bytes32, felt_to_bytes32
@@ -43,9 +44,11 @@ namespace Helpers {
     }
 
     func to_uint256{range_check_ptr}(val: felt) -> Uint256* {
+        alloc_locals;
         let (high, low) = split_felt(val);
-        tempvar res = new Uint256(low, high);
-        return res;
+        local res: Uint256 = Uint256(low, high);
+        let (__fp__, _) = get_fp_and_pc();
+        return &res;
     }
 
     // @notice This helper converts a felt straight to BigInt3

--- a/tests/src/kakarot/test_account.cairo
+++ b/tests/src/kakarot/test_account.cairo
@@ -7,6 +7,7 @@ from starkware.cairo.common.uint256 import Uint256, assert_uint256_eq
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.memcpy import memcpy
 
+from kakarot.constants import Constants
 from kakarot.model import model
 from kakarot.account import Account
 from tests.utils.helpers import TestHelpers
@@ -173,9 +174,7 @@ func test__fetch_original_storage__state_modified{
     let starknet_address = Account.compute_starknet_address(evm_address);
     tempvar address = new model.Address(starknet_address, evm_address);
     let (local code: felt*) = alloc();
-    tempvar code_hash = new Uint256(
-        304396909071904405792975023732328604784, 262949717399590921288928019264691438528
-    );
+    tempvar code_hash = new Uint256(Constants.EMPTY_CODE_HASH_LOW, Constants.EMPTY_CODE_HASH_HIGH);
     tempvar balance = new Uint256(0, 0);
     let account = Account.init(address, 0, code, code_hash, 0, balance);
 

--- a/tests/src/kakarot/test_state.cairo
+++ b/tests/src/kakarot/test_state.cairo
@@ -11,6 +11,7 @@ from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.starknet.common.syscalls import get_contract_address
 from starkware.cairo.common.memcpy import memcpy
 
+from kakarot.constants import Constants
 from kakarot.model import model
 from backend.starknet import Starknet
 from kakarot.state import State, Internals
@@ -172,9 +173,7 @@ func test___copy_accounts__should_handle_null_pointers{range_check_ptr}() {
     tempvar address = new model.Address(1, 2);
     tempvar balance = new Uint256(1, 0);
     let (code) = alloc();
-    tempvar code_hash = new Uint256(
-        304396909071904405792975023732328604784, 262949717399590921288928019264691438528
-    );
+    tempvar code_hash = new Uint256(Constants.EMPTY_CODE_HASH_LOW, Constants.EMPTY_CODE_HASH_HIGH);
     let account = Account.init(address, 0, code, code_hash, 1, balance);
     dict_write{dict_ptr=accounts}(address.evm, cast(account, felt));
     let empty_address = 'empty address';
@@ -202,9 +201,7 @@ func test__is_account_warm__account_in_state{
     tempvar address = new model.Address(starknet_address, evm_address);
     tempvar balance = new Uint256(1, 0);
     let (code) = alloc();
-    tempvar code_hash = new Uint256(
-        304396909071904405792975023732328604784, 262949717399590921288928019264691438528
-    );
+    tempvar code_hash = new Uint256(Constants.EMPTY_CODE_HASH_LOW, Constants.EMPTY_CODE_HASH_HIGH);
     let account = Account.init(address, 0, code, code_hash, 1, balance);
     tempvar state = State.init();
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): opti

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #1273

Overall, the gains are insignificant 141777 -> 141773 steps
Test run `poetry run pytest tests/src/kakarot -k test_loop_profiling\[10] --profile-cairo`

For `push_uint128` only: 50 -> 49 steps
Test run `poetry run pytest tests/src/kakarot -k test_should_add_an_element_to_the_stack --profile-cairo `

## What is the new behavior?
- Unnecessary assignment are removed for Uint256*
- Refactor empty code hash to use `Constants`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1341)
<!-- Reviewable:end -->
