### PR TITLE
opti: inline unsigned_div_rem and div_rem

### DIFF
--- a/src/backend/starknet.cairo
+++ b/src/backend/starknet.cairo
@@ -7,7 +7,6 @@ from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.uint256 import Uint256
-from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_nn
 from starkware.cairo.common.memset import memset
 from starkware.starknet.common.syscalls import (
@@ -23,7 +22,6 @@ from kakarot.account import Account
 from kakarot.precompiles.precompiles_helpers import PrecompilesHelpers
 from kakarot.constants import Constants
 from kakarot.interfaces.interfaces import IERC20, IAccount
-
 from kakarot.model import model
 from kakarot.state import State
 from kakarot.storages import (
@@ -36,6 +34,7 @@ from kakarot.storages import (
     Kakarot_block_gas_limit,
     Kakarot_prev_randao,
 )
+from utils.maths import unsigned_div_rem
 
 namespace Starknet {
     // @notice Commit the current state to the underlying data backend (here, Starknet)

--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -5,7 +5,7 @@
 from openzeppelin.access.ownable.library import Ownable
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin, SignatureBuiltin
-from starkware.cairo.common.math import assert_le, unsigned_div_rem
+from starkware.cairo.common.math import assert_le
 from starkware.cairo.common.math_cmp import is_nn
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import (
@@ -25,6 +25,7 @@ from kakarot.accounts.model import CallArray, OutsideExecution
 from kakarot.interfaces.interfaces import IKakarot, IAccount
 from kakarot.errors import Errors
 from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 const GET_STARKNET_ADDRESS_SELECTOR = 0x03e5d65a345b3857ca9d72edca702b8e56c1923c118867752345f710d595b3cf;
 

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.dict_access import DictAccess
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.math import unsigned_div_rem, split_int, split_felt
+from starkware.cairo.common.math import split_int, split_felt
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.uint256 import Uint256, uint256_not, uint256_le
 from starkware.cairo.common.math_cmp import is_nn, is_le_felt
@@ -33,6 +33,7 @@ from utils.uint256 import uint256_add
 from utils.bytes import bytes_to_bytes8_little_endian
 from utils.signature import Signature
 from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 // @dev: should always be zero for EOAs
 @storage_var

--- a/src/kakarot/gas.cairo
+++ b/src/kakarot/gas.cairo
@@ -1,4 +1,4 @@
-from starkware.cairo.common.math import split_felt, unsigned_div_rem
+from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.math_cmp import is_not_zero, is_nn, is_le_felt
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.uint256 import Uint256, uint256_lt
@@ -6,6 +6,7 @@ from starkware.cairo.common.uint256 import Uint256, uint256_lt
 from kakarot.model import model
 from utils.uint256 import uint256_eq
 from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 namespace Gas {
     const JUMPDEST = 1;

--- a/src/kakarot/instructions/environmental_information.cairo
+++ b/src/kakarot/instructions/environmental_information.cairo
@@ -6,7 +6,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.memset import memset
-from starkware.cairo.common.math import unsigned_div_rem, split_felt
+from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.math_cmp import is_not_zero, is_nn
 from starkware.cairo.common.uint256 import Uint256, uint256_le
 
@@ -23,6 +23,7 @@ from utils.array import slice
 from utils.bytes import bytes_to_bytes8_little_endian
 from utils.uint256 import uint256_to_uint160, uint256_add, uint256_eq
 from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 // @title Environmental information opcodes.
 // @notice This file contains the functions to execute for environmental information opcodes.

--- a/src/kakarot/instructions/memory_operations.cairo
+++ b/src/kakarot/instructions/memory_operations.cairo
@@ -7,7 +7,6 @@ from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.math_cmp import is_nn, is_not_zero
-from starkware.cairo.common.math import unsigned_div_rem
 
 from kakarot.errors import Errors
 from kakarot.account import Account
@@ -19,6 +18,7 @@ from kakarot.stack import Stack
 from kakarot.state import State
 from utils.utils import Helpers
 from utils.uint256 import uint256_unsigned_div_rem, uint256_eq
+from utils.maths import unsigned_div_rem
 
 namespace MemoryOperations {
     func exec_mload{

--- a/src/kakarot/instructions/sha3.cairo
+++ b/src/kakarot/instructions/sha3.cairo
@@ -4,7 +4,7 @@
 
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE
-from starkware.cairo.common.math import split_felt, unsigned_div_rem
+from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.math_cmp import is_not_zero
@@ -17,6 +17,7 @@ from kakarot.model import model
 from kakarot.stack import Stack
 from kakarot.storages import Kakarot_cairo1_helpers_class_hash
 from utils.bytes import bytes_to_bytes8_little_endian
+from utils.maths import unsigned_div_rem
 
 namespace Sha3 {
     func exec_sha3{

--- a/src/kakarot/instructions/system_operations.cairo
+++ b/src/kakarot/instructions/system_operations.cairo
@@ -5,7 +5,7 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.math import split_felt, unsigned_div_rem
+from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.math_cmp import is_nn, is_not_zero
 from starkware.cairo.common.uint256 import Uint256, uint256_lt, uint256_le
 from starkware.cairo.common.default_dict import default_dict_new
@@ -31,6 +31,7 @@ from utils.bytes import (
     uint256_to_bytes32,
 )
 from utils.uint256 import uint256_to_uint160, uint256_eq
+from utils.maths import unsigned_div_rem
 
 using bool = felt;
 

--- a/src/kakarot/interpreter.cairo
+++ b/src/kakarot/interpreter.cairo
@@ -12,7 +12,6 @@ from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict import DictAccess
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc, get_ap
 from starkware.cairo.common.uint256 import Uint256, uint256_le
-from starkware.cairo.common.math import unsigned_div_rem
 
 // Internal dependencies
 from kakarot.account import Account
@@ -39,6 +38,7 @@ from kakarot.gas import Gas
 from utils.utils import Helpers
 from utils.array import count_not_zero
 from utils.uint256 import uint256_sub, uint256_add
+from utils.maths import unsigned_div_rem
 
 // @title EVM instructions processing.
 // @notice This file contains functions related to the processing of EVM instructions.

--- a/src/kakarot/memory.cairo
+++ b/src/kakarot/memory.cairo
@@ -3,11 +3,11 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
 from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
-from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.uint256 import Uint256
 
 from kakarot.model import model
 from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 // @title Memory related functions.
 // @notice This file contains functions related to the memory.

--- a/src/kakarot/precompiles/blake2f.cairo
+++ b/src/kakarot/precompiles/blake2f.cairo
@@ -6,7 +6,6 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
-from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.registers import get_fp_and_pc, get_label_location
 from starkware.cairo.common.math_cmp import is_nn
 from starkware.cairo.common.bool import FALSE
@@ -14,6 +13,7 @@ from starkware.cairo.common.bool import FALSE
 // Internal dependencies
 from kakarot.errors import Errors
 from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 // @title Blake2f Precompile related functions.
 // @notice This file contains the logic required to run the blake2f precompile

--- a/src/kakarot/precompiles/ec_recover.cairo
+++ b/src/kakarot/precompiles/ec_recover.cairo
@@ -4,7 +4,6 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.cairo_keccak.keccak import finalize_keccak
 from starkware.cairo.common.bool import FALSE
-from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.math_cmp import RC_BOUND
 from starkware.cairo.common.cairo_secp.ec import EcPoint
 from starkware.cairo.common.cairo_secp.bigint import BigInt3
@@ -16,11 +15,12 @@ from starkware.cairo.common.uint256 import Uint256, uint256_reverse_endian
 from starkware.cairo.common.cairo_secp.bigint import bigint_to_uint256
 from starkware.cairo.common.keccak_utils.keccak_utils import keccak_add_uint256s
 from starkware.cairo.common.memset import memset
-from utils.utils import Helpers
-from utils.array import slice
 from kakarot.errors import Errors
 from kakarot.storages import Kakarot_cairo1_helpers_class_hash
 from kakarot.interfaces.interfaces import ICairo1Helpers
+from utils.utils import Helpers
+from utils.array import slice
+from utils.maths import unsigned_div_rem
 
 // @title EcRecover Precompile related functions.
 // @notice This file contains the logic required to run the ec_recover precompile

--- a/src/kakarot/precompiles/ripemd160.cairo
+++ b/src/kakarot/precompiles/ripemd160.cairo
@@ -6,7 +6,7 @@
 // Starkware dependencies
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.math import unsigned_div_rem, assert_nn_le
+from starkware.cairo.common.math import assert_nn_le
 from starkware.cairo.common.math_cmp import is_nn_le, is_nn
 from starkware.cairo.common.bitwise import bitwise_and, bitwise_xor, bitwise_or
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,9 +18,10 @@ from starkware.cairo.common.memset import memset
 
 // Internal dependencies
 from kakarot.model import model
-from utils.utils import Helpers
 from kakarot.memory import Memory
 from kakarot.evm import EVM
+from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 // @title RIPEMD-160 precompile
 // @custom:precompile

--- a/src/kakarot/precompiles/sha256.cairo
+++ b/src/kakarot/precompiles/sha256.cairo
@@ -7,7 +7,7 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
-from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem
+from starkware.cairo.common.math import assert_nn_le
 from starkware.cairo.common.math_cmp import is_le_felt
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.memset import memset
@@ -22,6 +22,7 @@ from utils.sha_256.packed_sha256 import (
     get_round_constants,
 )
 from utils.utils import Helpers
+from utils.maths import unsigned_div_rem
 
 // @title SHA2-256 Precompile related functions.
 // @notice This file contains the logic required to run the SHA2-256 precompile

--- a/src/kakarot/stack.cairo
+++ b/src/kakarot/stack.cairo
@@ -4,7 +4,6 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.default_dict import default_dict_new, default_dict_finalize
 from starkware.cairo.common.dict import DictAccess, dict_read, dict_write
-from starkware.cairo.common.math import assert_le, unsigned_div_rem
 from starkware.cairo.lang.compiler.lib.registers import get_fp_and_pc
 from starkware.cairo.common.uint256 import Uint256
 

--- a/src/utils/bytes.cairo
+++ b/src/utils/bytes.cairo
@@ -1,17 +1,12 @@
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.math import (
-    unsigned_div_rem,
-    split_int,
-    split_felt,
-    assert_le_felt,
-    assert_nn_le,
-)
+from starkware.cairo.common.math import split_int, split_felt, assert_le_felt, assert_nn_le
 from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.memset import memset
 from starkware.cairo.common.registers import get_label_location
 
 from utils.array import reverse
+from utils.maths import unsigned_div_rem
 
 func felt_to_ascii{range_check_ptr}(dst: felt*, n: felt) -> felt {
     alloc_locals;

--- a/src/utils/dict.cairo
+++ b/src/utils/dict.cairo
@@ -3,8 +3,8 @@ from starkware.cairo.common.default_dict import default_dict_new
 from starkware.cairo.common.dict import dict_write, dict_squash
 from starkware.cairo.common.math_cmp import is_not_zero
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.uint256 import Uint256
+from utils.maths import unsigned_div_rem
 
 func dict_keys{range_check_ptr}(dict_start: DictAccess*, dict_end: DictAccess*) -> (
     keys_len: felt, keys: felt*

--- a/src/utils/maths.cairo
+++ b/src/utils/maths.cairo
@@ -1,0 +1,34 @@
+// @dev Inlined version of unsigned_div_rem
+// Returns q and r such that:
+//  0 <= q < rc_bound, 0 <= r < div and value = q * div + r.
+//
+// Assumption: 0 < div <= PRIME / rc_bound.
+// Prover assumption: value / div < rc_bound.
+//
+// The value of div is restricted to make sure there is no overflow.
+// q * div + r < (q + 1) * div <= rc_bound * (PRIME / rc_bound) = PRIME.
+func unsigned_div_rem{range_check_ptr}(value, div) -> (q: felt, r: felt) {
+    let r = [range_check_ptr];
+    let q = [range_check_ptr + 1];
+    let range_check_ptr = range_check_ptr + 2;
+    %{
+        from starkware.cairo.common.math_utils import assert_integer
+        assert_integer(ids.div)
+        assert 0 < ids.div <= PRIME // range_check_builtin.bound, \
+            f'div={hex(ids.div)} is out of the valid range.'
+        ids.q, ids.r = divmod(ids.value, ids.div)
+    %}
+
+    // equivalent to assert_le(r, div - 1);
+    tempvar a = div - 1 - r;
+    %{
+        from starkware.cairo.common.math_utils import assert_integer
+        assert_integer(ids.a)
+        assert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'
+    %}
+    a = [range_check_ptr];
+    let range_check_ptr = range_check_ptr + 1;
+
+    assert value = q * div + r;
+    return (q, r);
+}

--- a/src/utils/uint256.cairo
+++ b/src/utils/uint256.cairo
@@ -8,9 +8,9 @@ from starkware.cairo.common.uint256 import (
     uint256_lt,
     uint256_not,
 )
-from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.math_cmp import is_nn
+from utils.maths import unsigned_div_rem
 
 // Adds two integers. Returns the result as a 256-bit integer and the (1-bit) carry.
 // Strictly equivalent and faster version of common.uint256.uint256_add using the same whitelisted hint.

--- a/src/utils/utils.cairo
+++ b/src/utils/utils.cairo
@@ -2,7 +2,7 @@
 
 // StarkWare dependencies
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.math import assert_le, split_felt, assert_nn_le, unsigned_div_rem
+from starkware.cairo.common.math import assert_le, split_felt, assert_nn_le
 from starkware.cairo.common.math_cmp import is_nn, is_not_zero
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.dict_access import DictAccess
@@ -18,6 +18,7 @@ from starkware.starknet.common.syscalls import get_tx_info
 
 from kakarot.model import model
 from utils.bytes import uint256_to_bytes32, felt_to_bytes32
+from utils.maths import unsigned_div_rem
 
 // @title Helper Functions
 // @notice This file contains a selection of helper function that simplify tasks such as type conversion and bit manipulation
@@ -382,7 +383,7 @@ namespace Helpers {
 
     // @notice Divides a 128-bit number with remainder.
     // @dev This is almost identical to cairo.common.math.unsigned_dev_rem, but supports the case
-    // @dev of div == 2**128 as well.
+    // @dev of div == 2**128 as well. assert_le is also inlined.
     // @param value: 128bit value to divide.
     // @param div: divisor.
     // @return: quotient and remainder.
@@ -402,7 +403,16 @@ namespace Helpers {
                 f'div={hex(ids.div)} is out of the valid range.'
             ids.q, ids.r = divmod(ids.value, ids.div)
         %}
-        assert_le(r, div - 1);
+
+        // equivalent to assert_le(r, div - 1);
+        tempvar a = div - 1 - r;
+        %{
+            from starkware.cairo.common.math_utils import assert_integer
+            assert_integer(ids.a)
+            assert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'
+        %}
+        a = [range_check_ptr];
+        let range_check_ptr = range_check_ptr + 1;
 
         assert value = q * div + r;
         return (q, r);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): opti

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #1302

## What is the new behavior?
- div_rem and unsigned_div_rem are inlined

From 141777 to 141574
Before:
![main](https://github.com/user-attachments/assets/777a6d51-1a9f-4118-a0b7-929c20c5b3de)

After:
![profile004](https://github.com/user-attachments/assets/856dea61-c400-4523-8702-6c84eb3ad068)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1342)
<!-- Reviewable:end -->
