### PR TITLE
Fix underconstrained segments

### DIFF
--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -104,7 +104,7 @@ func execute_from_outside{
     }
     let (tx_info) = get_tx_info();
     let version = tx_info.version;
-    with_attr error_message("Deprecated tx version: {version}") {
+    with_attr error_message("Deprecated tx version: 0") {
         assert_le(1, version);
     }
 

--- a/src/kakarot/accounts/account_contract.cairo
+++ b/src/kakarot/accounts/account_contract.cairo
@@ -5,7 +5,7 @@
 from openzeppelin.access.ownable.library import Ownable, Ownable_owner
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin, SignatureBuiltin
-from starkware.cairo.common.math import assert_le
+from starkware.cairo.common.math import assert_le, assert_not_zero
 from starkware.cairo.common.math_cmp import is_nn
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import (
@@ -86,7 +86,9 @@ func execute_from_outside{
 
     // Starknet validation
     if (outside_execution.caller != 'ANY_CALLER') {
-        assert caller = outside_execution.caller;
+        with_attr error_message("Execute from outside: invalid caller") {
+            assert caller = outside_execution.caller;
+        }
     }
     let (block_timestamp) = get_block_timestamp();
     let too_early = is_nn(outside_execution.execute_after - block_timestamp);
@@ -114,8 +116,17 @@ func execute_from_outside{
 
     // Unpack the tx data
     let packed_tx_data_len = [call_array].data_len;
+    with_attr error_message("Execute from outside: packed_tx_data_len is zero or out of range") {
+        assert_not_zero(packed_tx_data_len);
+        assert [range_check_ptr] = packed_tx_data_len;
+        let range_check_ptr = range_check_ptr + 1;
+    }
     let packed_tx_data = calldata + [call_array].data_offset;
     let tx_data_len = [packed_tx_data];
+    with_attr error_message("Execute from outside: tx_data_len is out of range") {
+        assert [range_check_ptr] = tx_data_len;
+        let range_check_ptr = range_check_ptr + 1;
+    }
     let (tx_data) = Helpers.load_packed_bytes(
         packed_tx_data_len - 1, packed_tx_data + 1, tx_data_len
     );

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -163,6 +163,11 @@ namespace AccountContract {
         let s = Uint256(signature[2], signature[3]);
         let v = signature[4];
 
+        with_attr error_message("tx_data_len not in range: {tx_data_len}") {
+            assert [range_check_ptr] = tx_data_len;
+            let range_check_ptr = range_check_ptr + 1;
+        }
+
         let tx_type = EthTransaction.get_tx_type(tx_data);
         local y_parity: felt;
         local pre_eip155_tx: felt;

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -168,7 +168,7 @@ namespace AccountContract {
             let range_check_ptr = range_check_ptr + 1;
         }
 
-        let tx_type = EthTransaction.get_tx_type(tx_data);
+        let tx_type = EthTransaction.get_tx_type(tx_data_len, tx_data);
         local y_parity: felt;
         local pre_eip155_tx: felt;
         if (tx_type == 0) {

--- a/src/kakarot/accounts/library.cairo
+++ b/src/kakarot/accounts/library.cairo
@@ -163,11 +163,6 @@ namespace AccountContract {
         let s = Uint256(signature[2], signature[3]);
         let v = signature[4];
 
-        with_attr error_message("tx_data_len not in range: {tx_data_len}") {
-            assert [range_check_ptr] = tx_data_len;
-            let range_check_ptr = range_check_ptr + 1;
-        }
-
         let tx_type = EthTransaction.get_tx_type(tx_data_len, tx_data);
         local y_parity: felt;
         local pre_eip155_tx: felt;

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -1,5 +1,6 @@
 from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.math_cmp import is_nn
+from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.alloc import alloc
 
 from utils.utils import Helpers
@@ -24,6 +25,10 @@ namespace RLP {
     //  original array and data_size is the size of the data.
     func decode_type{range_check_ptr}(data_len: felt, data: felt*) -> (felt, felt, felt) {
         alloc_locals;
+
+        with_attr error_message("RLP data is empty") {
+            assert_not_zero(data_len);
+        }
 
         let prefix = [data];
 

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -83,8 +83,9 @@ namespace RLP {
         }
 
         let (rlp_type, offset, len) = decode_type(data);
+        local remaining_data_len = data_len - len - offset;
         with_attr error_message("RLP data too short for declared length") {
-            assert_nn(data_len - offset - len);
+            assert_nn(remaining_data_len);
         }
 
         if (rlp_type == TYPE_LIST) {
@@ -98,7 +99,6 @@ namespace RLP {
         }
         tempvar items = items + Item.SIZE;
 
-        let remaining_data_len = data_len - len - offset;
         let items_len = decode_raw(
             items=items, data_len=remaining_data_len, data=data + offset + len
         );

--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -1,12 +1,15 @@
-from starkware.cairo.common.bool import FALSE
+from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.math_cmp import is_nn
-from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.math import assert_not_zero, assert_nn
 from starkware.cairo.common.alloc import alloc
 
 from utils.utils import Helpers
 
 // The namespace handling all RLP computation
 namespace RLP {
+    const TYPE_STRING = 0;
+    const TYPE_LIST = 1;
+
     // The type returned when data is RLP decoded
     // An RLP Item is either a byte array or a list of other RLP Items.
     // The data is either a pointer to the first byte in the array or a pointer to the first Item in the list.
@@ -23,7 +26,9 @@ namespace RLP {
     // @dev type=0 means the item is a byte array, type=1 means the item is a list.
     // @returns (type, data_offset, data_size) where data_offset is the offset of the data in the
     //  original array and data_size is the size of the data.
-    func decode_type{range_check_ptr}(data_len: felt, data: felt*) -> (felt, felt, felt) {
+    func decode_type{range_check_ptr}(data_len: felt, data: felt*) -> (
+        rlp_type: felt, offset: felt, len: felt
+    ) {
         alloc_locals;
 
         with_attr error_message("RLP data is empty") {
@@ -35,30 +40,36 @@ namespace RLP {
         // Char
         let is_le_127 = is_nn(0x7f - prefix);
         if (is_le_127 != FALSE) {
-            return (0, 0, 1);
+            return (TYPE_STRING, 0, 1);
         }
 
         let is_le_183 = is_nn(0xb7 - prefix);  // a max 55 bytes long string
         if (is_le_183 != FALSE) {
-            return (0, 1, prefix - 0x80);
+            return (TYPE_STRING, 1, prefix - 0x80);
         }
 
         let is_le_191 = is_nn(0xbf - prefix);  // string longer than 55 bytes
         if (is_le_191 != FALSE) {
             local len_bytes_count = prefix - 0xb7;
+            with_attr error_message("RLP data too short for declared length") {
+                assert_nn(data_len - len_bytes_count - 1);
+            }
             let string_len = Helpers.bytes_to_felt(len_bytes_count, data + 1);
-            return (0, 1 + len_bytes_count, string_len);
+            return (TYPE_STRING, 1 + len_bytes_count, string_len);
         }
 
         let is_le_247 = is_nn(0xf7 - prefix);  // list 0-55 bytes long
         if (is_le_247 != FALSE) {
             local list_len = prefix - 0xc0;
-            return (1, 1, list_len);
+            return (TYPE_LIST, 1, list_len);
         }
 
         local len_bytes_count = prefix - 0xf7;
+        with_attr error_message("RLP data too short for declared length") {
+            assert_nn(data_len - len_bytes_count - 1);
+        }
         let list_len = Helpers.bytes_to_felt(len_bytes_count, data + 1);
-        return (1, 1 + len_bytes_count, list_len);
+        return (TYPE_LIST, 1 + len_bytes_count, list_len);
     }
 
     // @notice Decodes a Recursive Length Prefix (RLP) encoded data.
@@ -81,17 +92,22 @@ namespace RLP {
         }
 
         let (rlp_type, offset, len) = decode_type(data_len=data_len, data=data);
+        with_attr error_message("RLP data too short for declared length") {
+            assert_nn(data_len - offset - len);
+        }
 
-        if (rlp_type == 1) {
+        if (rlp_type == TYPE_LIST) {
             // Case list
             let (sub_items: Item*) = alloc();
             let sub_items_len = decode_raw(items=sub_items, data_len=len, data=data + offset);
-            assert [items] = Item(data_len=sub_items_len, data=cast(sub_items, felt*), is_list=1);
+            assert [items] = Item(
+                data_len=sub_items_len, data=cast(sub_items, felt*), is_list=TRUE
+            );
             tempvar range_check_ptr = range_check_ptr;
         } else {
             // Case string or empty list. If the list or string is empty,
             // the data_len is 0 so not passing an empty data segment is fine.
-            assert [items] = Item(data_len=len, data=data + offset, is_list=rlp_type);
+            assert [items] = Item(data_len=len, data=data + offset, is_list=FALSE);
             tempvar range_check_ptr = range_check_ptr;
         }
         tempvar items = items + Item.SIZE;

--- a/tests/src/kakarot/accounts/test_account_contract.cairo
+++ b/tests/src/kakarot/accounts/test_account_contract.cairo
@@ -17,7 +17,9 @@ from kakarot.accounts.account_contract import (
     set_authorized_pre_eip155_tx,
     execute_starknet_call,
     set_code_hash,
+    execute_from_outside,
 )
+from kakarot.accounts.model import OutsideExecution, CallArray
 
 func test__initialize{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
@@ -134,6 +136,50 @@ func test__execute_from_outside{
     // When
     let (return_data_len, return_data) = AccountContract.execute_from_outside(
         tx_data_len, tx_data, signature_len, signature, chain_id
+    );
+
+    return (return_data_len, return_data);
+}
+
+func test__execute_from_outside_entrypoint{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr
+}() -> (felt, felt*) {
+    // Given
+
+    let (outside_execution: OutsideExecution*) = alloc();
+    tempvar call_array_len: felt;
+    let (call_array: CallArray*) = alloc();
+    tempvar calldata_len: felt;
+    let (calldata) = alloc();
+    tempvar signature_len: felt;
+    let (signature) = alloc();
+
+    %{
+        from itertools import chain
+
+        segments.write_arg(ids.outside_execution.address_, program_input["outside_execution"].values())
+        ids.call_array_len = len(program_input["call_array"])
+        segments.write_arg(
+            ids.call_array.address_,
+            list(chain.from_iterable([
+                call_.values() for call_ in program_input["call_array"]
+            ])),
+        )
+        ids.calldata_len = len(program_input["calldata"])
+        segments.write_arg(ids.calldata, program_input["calldata"])
+        ids.signature_len = len(program_input["signature"])
+        segments.write_arg(ids.signature, program_input["signature"])
+    %}
+
+    // When
+    let (return_data_len, return_data) = execute_from_outside(
+        [outside_execution],
+        call_array_len,
+        call_array,
+        calldata_len,
+        calldata,
+        signature_len,
+        signature,
     );
 
     return (return_data_len, return_data);

--- a/tests/src/kakarot/accounts/test_account_contract.cairo
+++ b/tests/src/kakarot/accounts/test_account_contract.cairo
@@ -124,7 +124,7 @@ func test__execute_from_outside{
     tempvar chain_id: felt;
 
     %{
-        ids.tx_data_len = len(program_input["tx_data"])
+        ids.tx_data_len = program_input.get("tx_data_len", len(program_input["tx_data"]))
         segments.write_arg(ids.tx_data, program_input["tx_data"])
         ids.signature_len = len(program_input["signature"])
         segments.write_arg(ids.signature, program_input["signature"])

--- a/tests/src/kakarot/accounts/test_account_contract.py
+++ b/tests/src/kakarot/accounts/test_account_contract.py
@@ -298,6 +298,16 @@ class TestAccountContract:
                     chain_id=CHAIN_ID,
                 )
 
+        def test_should_raise_when_tx_data_len_not_in_range(self, cairo_run):
+            with cairo_error(message=f"tx_data_len not in range: {2**128}"):
+                cairo_run(
+                    "test__execute_from_outside",
+                    tx_data_len=2**128,
+                    tx_data=[],
+                    signature=list(range(5)),
+                    chain_id=CHAIN_ID,
+                )
+
         def test_should_raise_with_wrong_signature(self, cairo_run):
             with cairo_error(message="Invalid signature."):
                 cairo_run(

--- a/tests/src/kakarot/accounts/test_account_contract.py
+++ b/tests/src/kakarot/accounts/test_account_contract.py
@@ -895,7 +895,7 @@ class TestAccountContract:
                     signature=[],
                 )
 
-        @pytest.mark.parametrize("data_len", [0, 2**128])
+        @given(data_len=integers(min_value=2**128, max_value=DEFAULT_PRIME))
         def test_should_raise_when_packed_data_len_is_zero_or_out_of_range(
             self, cairo_run, data_len
         ):
@@ -915,7 +915,7 @@ class TestAccountContract:
                             "to": 0,
                             "selector": 0,
                             "data_offset": 0,
-                            "data_len": data_len,
+                            "data_len": data_len % DEFAULT_PRIME,
                         },
                     ],
                     calldata=[],

--- a/tests/src/utils/test_eth_transaction.cairo
+++ b/tests/src/utils/test_eth_transaction.cairo
@@ -53,11 +53,15 @@ func test__parse_access_list{range_check_ptr}(output_ptr: felt*) {
 func test__get_tx_type{range_check_ptr}() -> felt {
     alloc_locals;
     // Given
+    tempvar data_len: felt;
     let (data) = alloc();
-    %{ segments.write_arg(ids.data, program_input["data"]) %}
+    %{
+        ids.data_len = program_input.get("data_len", len(program_input["data"]))
+        segments.write_arg(ids.data, program_input["data"])
+    %}
 
     // When
-    let tx_type = EthTransaction.get_tx_type(data);
+    let tx_type = EthTransaction.get_tx_type(data_len, data);
 
     return tx_type;
 }

--- a/tests/src/utils/test_eth_transaction.py
+++ b/tests/src/utils/test_eth_transaction.py
@@ -91,3 +91,7 @@ class TestEthTransaction:
             encoded_unsigned_tx = rlp_encode_signed_data(transaction)
             tx_type = cairo_run("test__get_tx_type", data=list(encoded_unsigned_tx))
             assert tx_type == transaction.get("type", 0)
+
+        def test_should_raise_when_data_len_is_zero(self, cairo_run):
+            with cairo_error("tx_data_len is zero"):
+                cairo_run("test__get_tx_type", data_len=0, data=[1, 2, 3])

--- a/tests/src/utils/test_rlp.cairo
+++ b/tests/src/utils/test_rlp.cairo
@@ -11,7 +11,7 @@ func test__decode_raw{range_check_ptr}() -> RLP.Item* {
     tempvar data_len: felt;
     let (data) = alloc();
     %{
-        ids.data_len = len(program_input["data"])
+        ids.data_len = program_input.get("data_len", len(program_input["data"]))
         segments.write_arg(ids.data, program_input["data"])
     %}
 
@@ -42,15 +42,11 @@ func test__decode{range_check_ptr}() -> RLP.Item* {
 func test__decode_type{range_check_ptr}() -> (felt, felt, felt) {
     alloc_locals;
     // Given
-    tempvar data_len: felt;
     let (data) = alloc();
-    %{
-        ids.data_len = len(program_input["data"])
-        segments.write_arg(ids.data, program_input["data"])
-    %}
+    %{ segments.write_arg(ids.data, program_input["data"]) %}
 
     // When
-    let (type, offset, len) = RLP.decode_type(data_len, data);
+    let (type, offset, len) = RLP.decode_type(data);
 
     // Then
     return (type, offset, len);

--- a/tests/src/utils/test_rlp.cairo
+++ b/tests/src/utils/test_rlp.cairo
@@ -5,6 +5,23 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.memcpy import memcpy
 
+func test__decode_raw{range_check_ptr}() -> RLP.Item* {
+    alloc_locals;
+    // Given
+    tempvar data_len: felt;
+    let (data) = alloc();
+    %{
+        ids.data_len = len(program_input["data"])
+        segments.write_arg(ids.data, program_input["data"])
+    %}
+
+    // When
+    let (local items: RLP.Item*) = alloc();
+    RLP.decode_raw(items, data_len, data);
+
+    return items;
+}
+
 func test__decode{range_check_ptr}() -> RLP.Item* {
     alloc_locals;
     // Given

--- a/tests/src/utils/test_rlp.py
+++ b/tests/src/utils/test_rlp.py
@@ -26,6 +26,10 @@ class TestRLP:
 
             assert output == [expected_type, expected_offset, expected_len]
 
+        def test_should_raise_when_data_len_is_zero(self, cairo_run):
+            with cairo_error("RLP data is empty"):
+                cairo_run("test__decode_type", data=[])
+
     class TestDecode:
         @given(data=recursive(binary(), lists))
         async def test_should_match_decode_reference_implementation(

--- a/tests/src/utils/test_rlp.py
+++ b/tests/src/utils/test_rlp.py
@@ -30,11 +30,21 @@ class TestRLP:
             with cairo_error("RLP data is empty"):
                 cairo_run("test__decode_type", data=[])
 
+        @pytest.mark.parametrize("prefix", [0xB8, 0xF8])
+        def test_should_raise_when_prefix_encoded_lenght_is_greater_than_actual(
+            self, cairo_run, prefix
+        ):
+            with cairo_error("RLP data too short for declared length"):
+                cairo_run("test__decode_type", data=[prefix])
+
+    class TestDecodeRaw:
+        def test_should_raise_when_parsed_len_greater_than_data(self, cairo_run):
+            with cairo_error("RLP data too short for declared length"):
+                cairo_run("test__decode_raw", data=[0xB8, 0x01])
+
     class TestDecode:
         @given(data=recursive(binary(), lists))
-        async def test_should_match_decode_reference_implementation(
-            self, cairo_run, data
-        ):
+        def test_should_match_decode_reference_implementation(self, cairo_run, data):
             encoded_data = encode(data)
 
             items = cairo_run("test__decode", data=list(encoded_data))
@@ -44,7 +54,7 @@ class TestRLP:
             data=recursive(binary(), lists),
             extra_data=binary(min_size=1, max_size=255),
         )
-        async def test_raise_when_data_contains_extra_bytes(
+        def test_raise_when_data_contains_extra_bytes(
             self, cairo_run, data, extra_data
         ):
             encoded_data = encode(data)

--- a/tests/src/utils/test_rlp.py
+++ b/tests/src/utils/test_rlp.py
@@ -26,21 +26,19 @@ class TestRLP:
 
             assert output == [expected_type, expected_offset, expected_len]
 
-        def test_should_raise_when_data_len_is_zero(self, cairo_run):
-            with cairo_error("RLP data is empty"):
-                cairo_run("test__decode_type", data=[])
-
-        @pytest.mark.parametrize("prefix", [0xB8, 0xF8])
-        def test_should_raise_when_prefix_encoded_lenght_is_greater_than_actual(
-            self, cairo_run, prefix
-        ):
-            with cairo_error("RLP data too short for declared length"):
-                cairo_run("test__decode_type", data=[prefix])
-
     class TestDecodeRaw:
         def test_should_raise_when_parsed_len_greater_than_data(self, cairo_run):
             with cairo_error("RLP data too short for declared length"):
                 cairo_run("test__decode_raw", data=[0xB8, 0x01])
+
+        @given(data=lists(binary(min_size=2), min_size=2) | binary(min_size=2))
+        def test_should_raise_when_malicious_prover_fills_data(self, cairo_run, data):
+            with cairo_error("RLP data too short for declared length"):
+                cairo_run(
+                    "test__decode_raw",
+                    data_len=len(encode(data)) - 1,
+                    data=list(encode(data)),
+                )
 
     class TestDecode:
         @given(data=recursive(binary(), lists))


### PR DESCRIPTION
Time spent on this PR: 0.5

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Segments are not constrained enough, making it possible for a malicious prover to tweak tx data.

Resolves #1313

## What is the new behavior?

Added more `assert` to make sure that we don't read data beyond `data_len`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1356)
<!-- Reviewable:end -->
