### PR TITLE
FIx venv not cached in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          virtualenvs-path: .venv
           installer-parallel: true
-      - run: poetry config installer.modern-installation false
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
@@ -85,8 +85,8 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          virtualenvs-path: .venv
           installer-parallel: true
-      - run: poetry config installer.modern-installation false
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
@@ -138,8 +138,8 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          virtualenvs-path: .venv
           installer-parallel: true
-      - run: poetry config installer.modern-installation false
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
@@ -243,8 +243,8 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          virtualenvs-path: .venv
           installer-parallel: true
-      - run: poetry config installer.modern-installation false
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Venv is not cached in CI jobs and takes ~3 minutes to be rebuilt

## What is the new behavior?

Path `.venv` set explicitly. Venv is cached.
Removed deprecated `installer.modern-installation false` config

See also : https://github.com/snok/install-poetry/tree/v1/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1361)
<!-- Reviewable:end -->
