### PR TITLE
fix: cairo precompile revert for child contexts

### DIFF
--- a/solidity_contracts/src/CairoPrecompiles/SubContextPrecompile.sol
+++ b/solidity_contracts/src/CairoPrecompiles/SubContextPrecompile.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+
+import {CairoCounterCaller} from "./CairoCounterCaller.sol";
+
+contract SubContextPrecompile {
+    RevertingSubContext immutable revertingSubContext;
+
+    constructor(address _cairo_counter_caller) {
+        revertingSubContext = new RevertingSubContext(_cairo_counter_caller);
+    }
+
+    function exploitLowLevelCall() public {
+        (bool success,) = address(revertingSubContext).call(abi.encodeWithSignature("reverting()"));
+    }
+
+    function exploitChildContext() public {
+        revertingSubContext.reverting();
+    }
+}
+
+contract RevertingSubContext {
+    CairoCounterCaller immutable cairo_counter_caller;
+    uint256 dummyCounter;
+
+    constructor(address _cairo_counter_caller) {
+        cairo_counter_caller = CairoCounterCaller(_cairo_counter_caller);
+    }
+
+    function reverting() public {
+        dummyCounter = 1;
+        cairo_counter_caller.incrementCairoCounter();
+        // force a revert after a call to a cairo precompile in a subcontext
+        require(false);
+    }
+}

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -123,12 +123,12 @@ async def eth(deployer) -> Contract:
     return await get_eth_contract(provider=deployer)
 
 
-@pytest_asyncio.fixture(scope="session")
-async def cairo_counter(deployer) -> Contract:
+@pytest.fixture(scope="session")
+def cairo_counter(deployer) -> Contract:
     """
     Return a cached version of the cairo_counter contract.
     """
-    return await get_contract("Counter", provider=deployer)
+    return get_contract("Counter", provider=deployer)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #1377

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Revert cairo tx when evm revert
- cairo_precompile_called ORed when propagated to parent

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1378)
<!-- Reviewable:end -->
