### PR TITLE
dev: prepare parallelization of end to end tests

### DIFF
--- a/kakarot_scripts/constants.py
+++ b/kakarot_scripts/constants.py
@@ -323,11 +323,11 @@ class RelayerPool:
             )
             for relayer in relayers
         ]
-        self._index = 0
+        self.index = 0
 
     def __next__(self) -> Account:
-        relayer = self.relayer_accounts[self._index]
-        self._index = (self._index + 1) % len(self.relayer_accounts)
+        relayer = self.relayer_accounts[self.index]
+        self.index = (self.index + 1) % len(self.relayer_accounts)
         return relayer
 
 

--- a/kakarot_scripts/utils/kakarot.py
+++ b/kakarot_scripts/utils/kakarot.py
@@ -709,7 +709,10 @@ async def deploy_and_fund_evm_address(evm_address: str, amount: float):
         await fund_address(evm_address, amount - account_balance)
     if not await _contract_exists(starknet_address):
         await _invoke_starknet(
-            "kakarot", "deploy_externally_owned_account", int(evm_address, 16)
+            "kakarot",
+            "deploy_externally_owned_account",
+            int(evm_address, 16),
+            account=next(NETWORK["relayers"]),
         )
     return starknet_address
 

--- a/kakarot_scripts/utils/starknet.py
+++ b/kakarot_scripts/utils/starknet.py
@@ -164,8 +164,8 @@ async def fund_address(
         else:
             logger.info(f"{amount / 1e18} ETH minted to {hex(address)}")
     else:
-        account = funding_account or await get_starknet_account()
-        eth_contract = token_contract or await get_eth_contract()
+        account = funding_account or next(NETWORK["relayers"])
+        eth_contract = token_contract or await get_eth_contract(account)
         balance = await get_balance(account.address, eth_contract)
         if balance < amount:
             raise ValueError(

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -8,7 +8,7 @@ from eth_keys.datatypes import PrivateKey
 from starknet_py.contract import Contract
 from starknet_py.net.account.account import Account
 
-from kakarot_scripts.constants import RPC_CLIENT, NetworkType
+from kakarot_scripts.constants import NETWORK, RPC_CLIENT, NetworkType
 from kakarot_scripts.utils.kakarot import eth_balance_of
 from kakarot_scripts.utils.kakarot import get_contract as get_solidity_contract
 from kakarot_scripts.utils.kakarot import get_eoa
@@ -182,3 +182,16 @@ def block_hash():
         ).block_hash
 
     return _factory
+
+
+@pytest.fixture(autouse=True, scope="session")
+def relayers(worker_id):
+    """
+    Override NETWORK["relayers"] to use the worker_id as the index and avoid nonce issues.
+    """
+    try:
+        logger.info(f"Setting relayer index to {int(worker_id[2:])}")
+        NETWORK["relayers"].index = int(worker_id[2:])
+    except ValueError:
+        logger.info(f"Error while setting relayer index to {worker_id}")
+    return

--- a/tests/fixtures/starknet.py
+++ b/tests/fixtures/starknet.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import math
-import shutil
 from hashlib import md5
 from pathlib import Path
 from time import perf_counter, time_ns
@@ -24,9 +23,9 @@ from starkware.cairo.lang.vm.utils import RunResources
 from starkware.starknet.compiler.starknet_pass_manager import starknet_pass_manager
 
 from tests.utils.constants import Opcodes
-from tests.utils.coverage import VmWithCoverage, report_runs
+from tests.utils.coverage import VmWithCoverage
 from tests.utils.hints import debug_info
-from tests.utils.reporting import dump_coverage, profile_from_tracer_data
+from tests.utils.reporting import profile_from_tracer_data
 from tests.utils.serde import Serde
 from tests.utils.syscall_handler import SyscallHandler
 
@@ -36,23 +35,6 @@ pd.set_option("display.width", 1000)
 
 logging.getLogger("asyncio").setLevel(logging.INFO)
 logger = logging.getLogger()
-
-
-@pytest.fixture(scope="session", autouse=True)
-async def coverage(worker_id, request):
-
-    output_dir = Path("coverage")
-    shutil.rmtree(output_dir, ignore_errors=True)
-
-    yield
-
-    output_dir.mkdir(exist_ok=True, parents=True)
-    files = report_runs(excluded_file={"site-packages", "tests"})
-
-    if worker_id == "master":
-        dump_coverage(output_dir, files)
-    else:
-        dump_coverage(output_dir / worker_id, files)
 
 
 def cairo_compile(path):

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -1,0 +1,24 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.utils.coverage import report_runs
+from tests.utils.reporting import dump_coverage
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def coverage(worker_id):
+
+    output_dir = Path("coverage")
+    shutil.rmtree(output_dir, ignore_errors=True)
+
+    yield
+
+    output_dir.mkdir(exist_ok=True, parents=True)
+    files = report_runs(excluded_file={"site-packages", "tests"})
+
+    if worker_id == "master":
+        dump_coverage(output_dir, files)
+    else:
+        dump_coverage(output_dir / worker_id, files)


### PR DESCRIPTION
Time spent on this PR: 0.2

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

It's not possible to use pytest-xdist with end to end tests.

## What is the new behavior?

Some of the nonce issues have been solved. Katana still drops transaction with no obvious reason/no error message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1382)
<!-- Reviewable:end -->
