### PR TITLE
Fix possible overflow in decode_raw

### DIFF
--- a/src/utils/rlp.cairo
+++ b/src/utils/rlp.cairo
@@ -85,6 +85,10 @@ namespace RLP {
         let (rlp_type, offset, len) = decode_type(data);
         local remaining_data_len = data_len - len - offset;
         with_attr error_message("RLP data too short for declared length") {
+            assert [range_check_ptr] = offset;
+            assert [range_check_ptr + 1] = len;
+            assert [range_check_ptr + 2] = offset + len;
+            let range_check_ptr = range_check_ptr + 3;
             assert_nn(remaining_data_len);
         }
 

--- a/tests/src/utils/test_rlp.py
+++ b/tests/src/utils/test_rlp.py
@@ -2,6 +2,7 @@ import pytest
 from hypothesis import given
 from hypothesis.strategies import binary, lists, recursive
 from rlp import codec, decode, encode
+from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
 from tests.utils.constants import TRANSACTIONS
 from tests.utils.errors import cairo_error
@@ -39,6 +40,12 @@ class TestRLP:
                     data_len=len(encode(data)) - 1,
                     data=list(encode(data)),
                 )
+
+        def test_should_raise_when_decoded_params_overflow(self, cairo_run):
+            size = bytes.fromhex(f"{DEFAULT_PRIME - 1:064x}")
+            data = [len(size) + 0xF7] + list(size)
+            with cairo_error("RLP data too short for declared length"):
+                cairo_run("test__decode_raw", data=data)
 
     class TestDecode:
         @given(data=recursive(binary(), lists))

--- a/tests/src/utils/test_utils.cairo
+++ b/tests/src/utils/test_utils.cairo
@@ -220,3 +220,14 @@ func test__split_word_little{range_check_ptr}() -> felt* {
     Helpers.split_word_little(value, len, dst);
     return dst;
 }
+
+func test__bytes_to_felt() -> felt {
+    tempvar len;
+    let (ptr) = alloc();
+    %{
+        ids.len = len(program_input["data"])
+        segments.write_arg(ids.ptr, program_input["data"])
+    %}
+    let res = Helpers.bytes_to_felt(len, ptr);
+    return res;
+}

--- a/tests/src/utils/test_utils.py
+++ b/tests/src/utils/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from ethereum.cancun.vm.runtime import get_valid_jump_destinations
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
 from kakarot_scripts.utils.kakarot import get_contract
 from tests.utils.errors import cairo_error
@@ -232,3 +233,11 @@ class TestSplitWord:
     ):
         with cairo_error("len must be < 32"):
             cairo_run("test__split_word_little", value=value, length=length)
+
+
+class TestBytesToFelt:
+
+    @given(data=st.binary(min_size=0, max_size=35))
+    def test_should_convert_bytes_to_felt_with_overflow(self, cairo_run, data):
+        output = cairo_run("test__bytes_to_felt", data=list(data))
+        assert output == int.from_bytes(data, byteorder="big") % DEFAULT_PRIME


### PR DESCRIPTION
Time spent on this PR: 0.2

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In `rlp.decode_raw`, the `assert_nn(remaining_data_len);` doeesn't check that `remaining_data_len` has not overflown.

Resolves #1376

## What is the new behavior?

Each of the decoded values are asserted in RANGE_CHECK, as well as their sum.

A test has been added, failing first and passing after fix.
