### PR TITLE
Fix cairo_message arbitrary data_len

### DIFF
--- a/src/kakarot/precompiles/kakarot_precompiles.cairo
+++ b/src/kakarot/precompiles/kakarot_precompiles.cairo
@@ -155,7 +155,14 @@ namespace KakarotPrecompiles {
         }
         let target_address = Helpers.bytes20_to_felt(input + 12);
 
-        let data_bytes_len = Helpers.bytes32_to_felt(input + 2 * 32);
+        // We enforce data_len to be at most 4 bytes, made some tests on Starknet
+        // and even bytes4 looks like it's not supported
+        let invalid_data_byte_len = Helpers.bytes_to_felt(28, input + 2 * 32);
+        if (invalid_data_byte_len != 0) {
+            let (revert_reason_len, revert_reason) = Errors.precompileInputError();
+            return (revert_reason_len, revert_reason, CAIRO_MESSAGE_GAS, TRUE);
+        }
+        let data_bytes_len = Helpers.bytes4_to_felt(input + 3 * 32 - 4);
         let data_fits_in_input = is_nn(input_len - 3 * 32 - data_bytes_len);
         if (data_fits_in_input == 0) {
             let (revert_reason_len, revert_reason) = Errors.outOfBoundsRead();

--- a/tests/src/kakarot/precompiles/test_kakarot_precompiles.cairo
+++ b/tests/src/kakarot/precompiles/test_kakarot_precompiles.cairo
@@ -1,0 +1,29 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.alloc import alloc
+
+from kakarot.precompiles.kakarot_precompiles import KakarotPrecompiles
+
+func test__cairo_message{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}() -> (output_len: felt, output: felt*, reverted: felt, gas_used: felt) {
+    alloc_locals;
+    // Given
+    local input_len;
+    local caller_address;
+    let (local input) = alloc();
+    %{
+        ids.input_len = len(program_input["input"])
+        segments.write_arg(ids.input, program_input["input"])
+        ids.caller_address = program_input.get("caller_address", 0)
+    %}
+
+    // When
+    let result = KakarotPrecompiles.cairo_message(
+        input_len=input_len, input=input, caller_address=caller_address
+    );
+
+    return (result.output_len, result.output, result.reverted, result.gas_used);
+}

--- a/tests/src/kakarot/precompiles/test_kakarot_precompiles.py
+++ b/tests/src/kakarot/precompiles/test_kakarot_precompiles.py
@@ -1,0 +1,46 @@
+from hypothesis import given
+from hypothesis import strategies as st
+
+
+class TestKakarotPrecompiles:
+
+    class TestCairoMessage:
+        @given(input_=st.binary(min_size=0, max_size=95))
+        def test_should_revert_input_to_short(self, cairo_run, input_):
+            (output_len, output, reverted, gas_used) = cairo_run(
+                "test__cairo_message", input=input_
+            )
+            assert bytes(output[:output_len]) == b"Kakarot: OutOfBoundsRead"
+            assert reverted
+            assert gas_used == 5000
+
+        @given(input_=st.binary(min_size=96))
+        def test_should_revert_first_word_not_address(self, cairo_run, input_):
+            (output_len, output, reverted, gas_used) = cairo_run(
+                "test__cairo_message", input=input_
+            )
+            assert bool(reverted) == (int.from_bytes(input_[:12], "big") != 0)
+            if reverted:
+                assert bytes(output[:output_len]) == b"Precompile: wrong input_len"
+            assert gas_used == 5000
+
+        @given(data_len=st.integers(min_value=0, max_value=2**256 - 1))
+        def test_should_revert_data_len_not_bytes4(self, cairo_run, data_len):
+            input_ = b"\x00" * 64 + data_len.to_bytes(32, "big")
+            (output_len, output, reverted, gas_used) = cairo_run(
+                "test__cairo_message", input=input_
+            )
+            assert bytes(output[:output_len]) == (
+                b""
+                if data_len == 0
+                else (
+                    # If the data_len is in bound, the rest of the function fails
+                    # due to the data_len being too large wrt the input length.
+                    # One could set input_ to b"\x00" * 64 + data_len.to_bytes(32, "big") + data_len * b"\x00"
+                    # to avoid this issue but it significantly increases the time to run the test
+                    b"Kakarot: OutOfBoundsRead"
+                    if (data_len < 2**32)
+                    else b"Precompile: wrong input_len"
+                )
+            )
+            assert gas_used == 5000


### PR DESCRIPTION
Time spent on this PR: 0.3

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`data_len` is a user input that can be bytes32

Resolves #1373

## What is the new behavior?

Couldn't find a real SN limitation for now but `bytes4` is surely more than enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1387)
<!-- Reviewable:end -->
