### PR TITLE
Fix possible overflow of tx params

### DIFF
--- a/src/utils/eth_transaction.cairo
+++ b/src/utils/eth_transaction.cairo
@@ -4,7 +4,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.math_cmp import is_not_zero, is_nn
-from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.math import assert_not_zero, assert_nn
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.uint256 import Uint256
 
@@ -45,12 +45,16 @@ namespace EthTransaction {
         assert items[4].is_list = FALSE;
         assert items[5].is_list = FALSE;
 
+        assert_nn(31 - items[0].data_len);
         let nonce = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
+        assert_nn(31 - items[1].data_len);
         let gas_price = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
+        assert_nn(31 - items[2].data_len);
         let gas_limit = Helpers.bytes_to_felt(items[2].data_len, items[2].data);
         let destination = Helpers.try_parse_destination_from_bytes(
             items[3].data_len, items[3].data
         );
+        assert_nn(32 - items[4].data_len);
         let amount = Helpers.bytes_to_uint256(items[4].data_len, items[4].data);
         let payload_len = items[5].data_len;
         let payload = items[5].data;
@@ -114,13 +118,18 @@ namespace EthTransaction {
         assert items[6].is_list = FALSE;
         assert items[7].is_list = TRUE;
 
+        assert_nn(31 - items[0].data_len);
         let chain_id = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
+        assert_nn(31 - items[1].data_len);
         let nonce = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
+        assert_nn(31 - items[2].data_len);
         let gas_price = Helpers.bytes_to_felt(items[2].data_len, items[2].data);
+        assert_nn(31 - items[3].data_len);
         let gas_limit = Helpers.bytes_to_felt(items[3].data_len, items[3].data);
         let destination = Helpers.try_parse_destination_from_bytes(
             items[4].data_len, items[4].data
         );
+        assert_nn(32 - items[5].data_len);
         let amount = Helpers.bytes_to_uint256(items[5].data_len, items[5].data);
         let payload_len = items[6].data_len;
         let payload = items[6].data;
@@ -172,14 +181,20 @@ namespace EthTransaction {
         assert items[7].is_list = FALSE;
         assert items[8].is_list = TRUE;
 
+        assert_nn(31 - items[0].data_len);
         let chain_id = Helpers.bytes_to_felt(items[0].data_len, items[0].data);
+        assert_nn(31 - items[1].data_len);
         let nonce = Helpers.bytes_to_felt(items[1].data_len, items[1].data);
+        assert_nn(31 - items[2].data_len);
         let max_priority_fee_per_gas = Helpers.bytes_to_felt(items[2].data_len, items[2].data);
+        assert_nn(31 - items[3].data_len);
         let max_fee_per_gas = Helpers.bytes_to_felt(items[3].data_len, items[3].data);
+        assert_nn(31 - items[4].data_len);
         let gas_limit = Helpers.bytes_to_felt(items[4].data_len, items[4].data);
         let destination = Helpers.try_parse_destination_from_bytes(
             items[5].data_len, items[5].data
         );
+        assert_nn(32 - items[6].data_len);
         let amount = Helpers.bytes_to_uint256(items[6].data_len, items[6].data);
         let payload_len = items[7].data_len;
         let payload = items[7].data;

--- a/tests/src/kakarot/test_kakarot.py
+++ b/tests/src/kakarot/test_kakarot.py
@@ -8,7 +8,6 @@ from eth_utils import keccak
 from eth_utils.address import to_checksum_address
 from hypothesis import given
 from hypothesis.strategies import composite, integers
-from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 from starkware.starknet.public.abi import get_storage_var_address
 from web3._utils.abi import map_abi_data
 from web3._utils.normalizers import BASE_RETURN_NORMALIZERS
@@ -453,7 +452,7 @@ class TestKakarot:
                     tx_data=tx_data,
                 )
 
-        @given(gas_limit=integers(min_value=2**64, max_value=DEFAULT_PRIME - 1))
+        @given(gas_limit=integers(min_value=2**64, max_value=2**248 - 1))
         def test_raise_gas_limit_too_high(self, cairo_run, gas_limit):
             tx = {
                 "type": 2,
@@ -479,7 +478,7 @@ class TestKakarot:
                     tx_data=tx_data,
                 )
 
-        @given(maxFeePerGas=integers(min_value=2**128, max_value=DEFAULT_PRIME - 1))
+        @given(maxFeePerGas=integers(min_value=2**128, max_value=2**248 - 1))
         def test_raise_max_fee_per_gas_too_high(self, cairo_run, maxFeePerGas):
             tx = {
                 "type": 2,
@@ -539,7 +538,7 @@ class TestKakarot:
         def max_priority_fee_too_high(draw):
             max_fee_per_gas = draw(integers(min_value=0, max_value=2**128 - 2))
             max_priority_fee_per_gas = draw(
-                integers(min_value=max_fee_per_gas + 1, max_value=DEFAULT_PRIME - 1)
+                integers(min_value=max_fee_per_gas + 1, max_value=2**248 - 1)
             )
             return (max_fee_per_gas, max_priority_fee_per_gas)
 


### PR DESCRIPTION
Time spent on this PR: 0.2

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The usage of `bytes_to_felt` and `bytes_to_uint256` while decoding the tx is not checking possible overflow of the data.

Resolves #1374

## What is the new behavior?

Raise a CairoVM error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1393)
<!-- Reviewable:end -->
