### PR TITLE
Remove library_call from precompiles

### DIFF
--- a/src/kakarot/precompiles/kakarot_precompiles.cairo
+++ b/src/kakarot/precompiles/kakarot_precompiles.cairo
@@ -16,7 +16,6 @@ from utils.utils import Helpers
 from backend.starknet import Starknet
 
 const CALL_CONTRACT_SOLIDITY_SELECTOR = 0xb3eb2c1b;
-const LIBRARY_CALL_SOLIDITY_SELECTOR = 0x5a9af197;
 
 // TODO: compute acceptable EVM gas values for Cairo execution
 const CAIRO_PRECOMPILE_GAS = 10000;
@@ -103,16 +102,6 @@ namespace KakarotPrecompiles {
                 return (retdata_len, retdata, CAIRO_PRECOMPILE_GAS, TRUE);
             }
 
-            let (output) = alloc();
-            let output_len = retdata_len * 32;
-            Helpers.felt_array_to_bytes32_array(retdata_len, retdata, output);
-            return (output_len, output, CAIRO_PRECOMPILE_GAS, FALSE);
-        }
-
-        if (selector == LIBRARY_CALL_SOLIDITY_SELECTOR) {
-            let (retdata_len, retdata) = library_call(
-                to_starknet_address, starknet_selector, data_len, data
-            );
             let (output) = alloc();
             let output_len = retdata_len * 32;
             Helpers.felt_array_to_bytes32_array(retdata_len, retdata, output);

--- a/tests/src/kakarot/precompiles/test_precompiles.py
+++ b/tests/src/kakarot/precompiles/test_precompiles.py
@@ -158,20 +158,6 @@ class TestPrecompiles:
                     ),  # call_contract with return data
                     (
                         0x75001,
-                        AUTHORIZED_CALLER_CODE,
-                        bytes.fromhex(
-                            "5a9af197"
-                            + f"{0xc0de:064x}"
-                            + f"{get_selector_from_name('get'):064x}"
-                            + f"{0x60:064x}"  # data_offset
-                            + f"{0x01:064x}"  # data_len
-                            + f"{0x00:064x}"  # data
-                        ),
-                        bytes.fromhex(f"{0x00:064x}"),
-                        False,
-                    ),  # library call
-                    (
-                        0x75001,
                         UNAUTHORIZED_CALLER_CODE,
                         bytes.fromhex("0abcdef0"),
                         b"Kakarot: unauthorizedPrecompile",
@@ -182,7 +168,6 @@ class TestPrecompiles:
                     "invalid_input",
                     "call_contract",
                     "call_contract_w_returndata",
-                    "library_call",
                     "invalid_caller",
                 ],
             )


### PR DESCRIPTION
Time spent on this PR: 0.1

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

This precompile is never used but bears a severe security risk as it allows potential attackers to update the state of Kakarot.

## What is the new behavior?

Removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1397)
<!-- Reviewable:end -->
