### PR TITLE
remove 'make build-cairo1' from release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,6 @@ To build the test Solidity smart contracts:
 make build-sol
 ```
 
-To build the Cairo1 files:
-
-```bash
-# install scarb via ASDF if you haven't done it already
-# https://docs.swmansion.com/scarb/download.html#install-via-asdf
-make build-cairo1
-```
-
 ## Code style
 
 The project uses [trunk.io](https://trunk.io/) to run a comprehensive list of

--- a/docker/deployer/Dockerfile
+++ b/docker/deployer/Dockerfile
@@ -76,7 +76,7 @@ RUN source "$HOME/.asdf/asdf.sh" && asdf plugin add scarb && asdf install scarb 
 
 
 RUN --mount=type=cache,target=/root/.cache \
-    source "$HOME/.asdf/asdf.sh" && make fetch-ssj-artifacts && make build && make build-cairo1 && make build-sol
+    source "$HOME/.asdf/asdf.sh" && make fetch-ssj-artifacts && make build && make build-sol
 
 
 ############################################


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the `build-cairo1` step from the release script as it is no longer existing and integrated in the python build instead.
-
-

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1400)
<!-- Reviewable:end -->
