### PR TITLE
dev: remove outside_execution checks & docs

### DIFF
--- a/tests/src/kakarot/accounts/test_account_contract.py
+++ b/tests/src/kakarot/accounts/test_account_contract.py
@@ -518,55 +518,8 @@ class TestAccountContract:
 
     class TestExecuteFromOutsideEntrypoint:
 
-        def test_should_raise_when_caller_is_not_any_caller_nor_actual_caller(
-            self, cairo_run
-        ):
-            with cairo_error(message="Execute from outside: invalid caller"):
-                cairo_run(
-                    "test__execute_from_outside_entrypoint",
-                    outside_execution={
-                        "caller": SyscallHandler.caller_address + 1,
-                        "nonce": 0,
-                        "execute_after": 0,
-                        "execute_before": 0,
-                    },
-                    call_array=[],
-                    calldata=[],
-                    signature=[],
-                )
-
-        def test_should_raise_when_call_is_too_early(self, cairo_run):
-            with cairo_error(message="Execute from outside: too early"):
-                cairo_run(
-                    "test__execute_from_outside_entrypoint",
-                    outside_execution={
-                        "caller": SyscallHandler.caller_address,
-                        "nonce": 0,
-                        "execute_after": SyscallHandler.block_timestamp + 1,
-                        "execute_before": 0,
-                    },
-                    call_array=[],
-                    calldata=[],
-                    signature=[],
-                )
-
-        def test_should_raise_when_call_is_too_late(self, cairo_run):
-            with cairo_error(message="Execute from outside: too late"):
-                cairo_run(
-                    "test__execute_from_outside_entrypoint",
-                    outside_execution={
-                        "caller": SyscallHandler.caller_address,
-                        "nonce": 0,
-                        "execute_after": 0,
-                        "execute_before": SyscallHandler.block_timestamp - 1,
-                    },
-                    call_array=[],
-                    calldata=[],
-                    signature=[],
-                )
-
         def test_should_raise_when_call_array_is_empty(self, cairo_run):
-            with cairo_error(message="Execute from outside: multicall not supported"):
+            with cairo_error(message="EOA: multicall not supported"):
                 cairo_run(
                     "test__execute_from_outside_entrypoint",
                     outside_execution={
@@ -581,7 +534,7 @@ class TestAccountContract:
                 )
 
         def test_should_raise_when_call_array_has_more_than_one_call(self, cairo_run):
-            with cairo_error(message="Execute from outside: multicall not supported"):
+            with cairo_error(message="EOA: multicall not supported"):
                 cairo_run(
                     "test__execute_from_outside_entrypoint",
                     outside_execution={


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

`execute_from_outside` purpose is that _validate_ and __execute__  are limited in functionalities. We could not run all EVM checks in validate , and our move to a "real" Starknet chain required a solution to handle the underlying starknet transaction fee for our users.

Thus, we needed to implement a paymaster functionality.
All EVM tx rules validation are now handled in the execute part of a transaction to bypass the limitations of validate , and both these entrypoints have been disabled.
 We use a fleet of relayer accounts to sponsor the Starknet cost of the transaction for our users, so that they don't have to worry about Starknet gas
For this, we implemented the execute_from_outside entrypoint as defined in SNIP-9

The outside_execution nonce is not signed, thus anyone can send a transaction to this entrypoint with any value for outside_execution and pass the first checks: it's indeed useless
However, there should not be a security risk: the EVM transaction sent
```
    calldata_len: felt,
    calldata: felt*,
    signature_len: felt,
    signature: felt*,
```
is signed by the EOA owner, and cannot be replayed

In the end: any checks on outside_execution is useless.
<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Remove checks from the Outside execution
- Add some docs
-

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1437)
<!-- Reviewable:end -->
