### PR TITLE
feat: blobbasefee return ONE

### DIFF
--- a/blockchain-tests-skip.yml
+++ b/blockchain-tests-skip.yml
@@ -47,11 +47,6 @@ testname:
   vmArithmeticTest:
     - expPower256Of256_d0g0v0_Cancun #RunResources error
     - exp_d9g0v0_Cancun #RunResources error
-  stBadOpcode:
-    - opc4ADiffPlaces_d0g0v0_Cancun
-    - opc4ADiffPlaces_d21g0v0_Cancun
-    - opc4ADiffPlaces_d22g0v0_Cancun
-    - opc4ADiffPlaces_d23g0v0_Cancun
   stAttackTest:
     - ContractCreationSpam_d0g0v0_Cancun #RunResources error
   stChainId:

--- a/blockchain-tests-skip.yml
+++ b/blockchain-tests-skip.yml
@@ -585,8 +585,6 @@ regex:
     - .*
   eip4788_beacon_root:
     - .*
-  eip7516_blobgasfee:
-    - .*
   stEIP4844-blobtransactions:
     - .*
   stMemoryStressTest:

--- a/kakarot_scripts/ef_tests/fetch.py
+++ b/kakarot_scripts/ef_tests/fetch.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import requests
 
-EF_TESTS_TAG = "v13.3-kkrt-1"
+EF_TESTS_TAG = "v14.1.1-kkrt"
 EF_TESTS_URL = (
     f"https://github.com/kkrt-labs/tests/archive/refs/tags/{EF_TESTS_TAG}.tar.gz"
 )

--- a/src/kakarot/constants.cairo
+++ b/src/kakarot/constants.cairo
@@ -5,6 +5,9 @@ from kakarot.gas import Gas
 // @title Constants file.
 // @notice This file contains global constants.
 namespace Constants {
+    // BLOCK
+    const MIN_BASE_FEE_PER_BLOB_GAS = 1;  // https://eips.ethereum.org/EIPS/eip-4844#gas-accounting
+
     const UINT128_MAX = 0xffffffffffffffffffffffffffffffff;
 
     // STACK

--- a/src/kakarot/instructions/block_information.cairo
+++ b/src/kakarot/instructions/block_information.cairo
@@ -134,7 +134,7 @@ namespace BlockInformation {
 
         blobbasefee:
         let stack = cast([fp - 6], model.Stack*);
-        Stack.push_uint128(0);
+        Stack.push_uint128(Constants.MIN_BASE_FEE_PER_BLOB_GAS);
         jmp end;
 
         end:

--- a/tests/end_to_end/bytecodes.py
+++ b/tests/end_to_end/bytecodes.py
@@ -1,11 +1,7 @@
 import pytest
 
-from kakarot_scripts.constants import (
-    BLOCK_GAS_LIMIT,
-    COINBASE,
-    MIN_BASE_FEE_PER_BLOB_GAS,
-    NETWORK,
-)
+from kakarot_scripts.constants import BLOCK_GAS_LIMIT, COINBASE, NETWORK
+from tests.utils.constants import MIN_BASE_FEE_PER_BLOB_GAS
 
 test_cases = [
     {

--- a/tests/end_to_end/bytecodes.py
+++ b/tests/end_to_end/bytecodes.py
@@ -1,6 +1,11 @@
 import pytest
 
-from kakarot_scripts.constants import BLOCK_GAS_LIMIT, COINBASE, NETWORK
+from kakarot_scripts.constants import (
+    BLOCK_GAS_LIMIT,
+    COINBASE,
+    MIN_BASE_FEE_PER_BLOB_GAS,
+    NETWORK,
+)
 
 test_cases = [
     {
@@ -1002,7 +1007,7 @@ test_cases = [
             "value": 0,
             "code": "4a00",
             "calldata": "",
-            "stack": "0",
+            "stack": f"{MIN_BASE_FEE_PER_BLOB_GAS}",
             "memory": "",
             "return_data": "",
             "success": 1,

--- a/tests/src/kakarot/instructions/test_block_information.py
+++ b/tests/src/kakarot/instructions/test_block_information.py
@@ -3,7 +3,12 @@ from unittest.mock import patch
 import pytest
 
 from kakarot_scripts.constants import COINBASE
-from tests.utils.constants import BLOCK_GAS_LIMIT, CHAIN_ID, Opcodes
+from tests.utils.constants import (
+    BLOCK_GAS_LIMIT,
+    CHAIN_ID,
+    MIN_BASE_FEE_PER_BLOB_GAS,
+    Opcodes,
+)
 from tests.utils.syscall_handler import SyscallHandler
 
 
@@ -19,7 +24,7 @@ class TestBlockInformation:
             (Opcodes.CHAINID, CHAIN_ID),
             (Opcodes.BASEFEE, 0),
             (Opcodes.BLOBHASH, 0),
-            (Opcodes.BLOBBASEFEE, 0),
+            (Opcodes.BLOBBASEFEE, MIN_BASE_FEE_PER_BLOB_GAS),
         ],
     )
     @SyscallHandler.patch("Kakarot_coinbase", COINBASE)

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -6,6 +6,7 @@ import pytest
 from kakarot_scripts.constants import BLOCK_GAS_LIMIT
 
 BLOCK_GAS_LIMIT = BLOCK_GAS_LIMIT
+MIN_BASE_FEE_PER_BLOB_GAS = 1
 
 CHAIN_ID = int.from_bytes(b"KKRT", "big")  # KKRT (0x4b4b5254) in ASCII
 BIG_CHAIN_ID = int.from_bytes(b"SN_SEPOLIA", "big")


### PR DESCRIPTION
`BLOBBASEFEE` should return the `MIN_BASE_FEE_PER_BLOB_GAS` defined in  https://eips.ethereum.org/EIPS/eip-4844#gas-accounting instead of Zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1442)
<!-- Reviewable:end -->
