### PR TITLE
Enable multisig for account

### DIFF
--- a/.github/workflows/cairo-zero-ci.yml
+++ b/.github/workflows/cairo-zero-ci.yml
@@ -5,9 +5,8 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - cairo_zero/**
-
+    branches:
+      - "*"
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/deployments/starknet-sepolia/deployments.json
+++ b/deployments/starknet-sepolia/deployments.json
@@ -1,32 +1,8 @@
 {
-  "kakarot": {
-    "address": "0x78bd079b79aa45111313f200a22e5c52ff7526c746d73b65672cc28acbe2263",
-    "tx": "0x897e9cb077b13aec370f1dae4807dffb324a621416023e4fd67c4eb1f8d2d3",
-    "artifact": "None"
-  },
-  "EVM": {
-    "address": "0x6ae512c704e2fafbc06e6a6401e9ce02d534aad4bc34400fc1d8d82e88be316",
-    "tx": "0x515788cd50f04984c5b5cd6c7f75014abbb0b7bdfe449b4c2d24dd6816db756",
-    "artifact": "None"
-  },
-  "Counter": {
-    "address": "0x2d6741b182475b7cfc62ec1000fbcba553ea08f2e603fa2840d0288cd2d1e3c",
-    "tx": "0xd1781094a55ac09c3177e6799f9d484c5477baa6d120923c942da5c2fdbfea",
-    "artifact": "build/fixtures/Counter.json"
-  },
-  "MockPragmaOracle": {
-    "address": "0x17e64c92b06da9a331da9fd333a683a33019ae2a393254caf332d4158edc74d",
-    "tx": "0x3d6b91602c1e290bc65c6f85751f5ea156cf982d01c6bf1ea694d7398a9d5a5",
-    "artifact": "build/ssj/contracts_MockPragmaOracle"
-  },
-  "UniversalLibraryCaller": {
-    "address": "0x4e23e34042e1f0198311e2dcfc9565c214a48261574f2b37a7f12d1f65100f1",
-    "tx": "0x3cdee93215396193d9e08e7be3dccc7f6a650ba35f6f57b8762a540ca117816",
-    "artifact": "cairo1_contracts/utils/target/dev/utils_UniversalLibraryCaller.contract_class.json"
-  },
-  "BenchmarkCairoCalls": {
-    "address": "0x6ea732a6102b65dc04b54ec35304d5f27d1c3fbc81fd6810bd90b126f2e0d11",
-    "tx": "0x1c5464c82da97a4e9aeb088da8e5a932e4b14204efb192fe7b81dabe327e2d2",
-    "artifact": "cairo1_contracts/utils/target/dev/utils_BenchmarkCairoCalls.contract_class.json"
-  }
+  "kakarot": "0x78bd079b79aa45111313f200a22e5c52ff7526c746d73b65672cc28acbe2263",
+  "EVM": "0x6ae512c704e2fafbc06e6a6401e9ce02d534aad4bc34400fc1d8d82e88be316",
+  "Counter": "0x2d6741b182475b7cfc62ec1000fbcba553ea08f2e603fa2840d0288cd2d1e3c",
+  "MockPragmaOracle": "0x17e64c92b06da9a331da9fd333a683a33019ae2a393254caf332d4158edc74d",
+  "UniversalLibraryCaller": "0x4e23e34042e1f0198311e2dcfc9565c214a48261574f2b37a7f12d1f65100f1",
+  "BenchmarkCairoCalls": "0x6ea732a6102b65dc04b54ec35304d5f27d1c3fbc81fd6810bd90b126f2e0d11"
 }

--- a/kakarot_scripts/benchmark_cairo_calls.py
+++ b/kakarot_scripts/benchmark_cairo_calls.py
@@ -17,7 +17,7 @@ async def main():
     # %% Deploy contracts
     cairo_contract = await deploy_starknet("BenchmarkCairoCalls")
     cairo_contract_caller = await deploy_kakarot(
-        "CairoPrecompiles", "BenchmarkCairoCalls", cairo_contract["address"]
+        "CairoPrecompiles", "BenchmarkCairoCalls", cairo_contract
     )
     await invoke(
         "kakarot",

--- a/kakarot_scripts/compile_kakarot.py
+++ b/kakarot_scripts/compile_kakarot.py
@@ -3,8 +3,12 @@ import logging
 import multiprocessing as mp
 from datetime import datetime
 
-from kakarot_scripts.constants import COMPILED_CONTRACTS, NETWORK
-from kakarot_scripts.utils.starknet import compile_contract
+from kakarot_scripts.constants import COMPILED_CONTRACTS, DECLARED_CONTRACTS, NETWORK
+from kakarot_scripts.utils.starknet import (
+    compile_contract,
+    compute_deployed_class_hash,
+    dump_class_hashes,
+)
 
 mp.set_start_method("fork")
 
@@ -20,6 +24,10 @@ def main():
     initial_time = datetime.now()
     with mp.Pool() as pool:
         pool.map(compile_contract, COMPILED_CONTRACTS)
+    logger.info("ℹ️  Computing deployed class hashes")
+    with mp.Pool() as pool:
+        class_hashes = pool.map(compute_deployed_class_hash, DECLARED_CONTRACTS)
+    dump_class_hashes(dict(zip(DECLARED_CONTRACTS, class_hashes)))
 
     logger.info(
         f"✅ Compiled all in {(datetime.now() - initial_time).total_seconds():.2f}s"

--- a/kakarot_scripts/constants.py
+++ b/kakarot_scripts/constants.py
@@ -44,6 +44,7 @@ NETWORKS = {
         "max_wait": 60,
         "class_hash": 0x061DAC032F228ABEF9C6626F995015233097AE253A7F72D68552DB02F2971B8F,
         "voyager_api_url": "https://api.voyager.online/beta",
+        "argent_multisig_api": "https://cloud.argent-api.com/v1/multisig/starknet/mainnet",
     },
     "sepolia": {
         "name": "starknet-sepolia",
@@ -56,6 +57,7 @@ NETWORKS = {
         "max_wait": 20,
         "class_hash": 0x061DAC032F228ABEF9C6626F995015233097AE253A7F72D68552DB02F2971B8F,
         "voyager_api_url": "https://sepolia-api.voyager.online/beta",
+        "argent_multisig_api": "https://cloud.argent-api.com/v1/multisig/starknet/sepolia",
     },
     "starknet-devnet": {
         "name": "starknet-devnet",

--- a/kakarot_scripts/deploy_kakarot.py
+++ b/kakarot_scripts/deploy_kakarot.py
@@ -32,11 +32,17 @@ from kakarot_scripts.utils.starknet import deploy as deploy_starknet
 from kakarot_scripts.utils.starknet import (
     dump_declarations,
     dump_deployments,
+    execute_calls,
     get_balance,
     get_declarations,
 )
 from kakarot_scripts.utils.starknet import get_deployments as get_starknet_deployments
-from kakarot_scripts.utils.starknet import get_starknet_account, invoke
+from kakarot_scripts.utils.starknet import (
+    get_starknet_account,
+    invoke,
+    register_lazy_account,
+    remove_lazy_account,
+)
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -47,6 +53,7 @@ logger.setLevel(logging.INFO)
 async def main():
     # %% Declarations
     account = await get_starknet_account()
+    register_lazy_account(account.address)
     logger.info(f"ℹ️  Using account 0x{account.address:064x} as deployer")
     balance_pref = await get_balance(account.address)
 
@@ -71,7 +78,7 @@ async def main():
             "EVM",
             "set_coinbase",
             COINBASE,
-            address=starknet_deployments["EVM"]["address"],
+            address=starknet_deployments["EVM"],
         )
         starknet_deployments["Counter"] = await deploy_starknet("Counter")
         starknet_deployments["MockPragmaOracle"] = await deploy_starknet(
@@ -88,7 +95,7 @@ async def main():
     if starknet_deployments.get("kakarot") and NETWORK["type"] is not NetworkType.DEV:
         logger.info("ℹ️  Kakarot already deployed, checking version.")
         deployed_class_hash = await RPC_CLIENT.get_class_hash_at(
-            starknet_deployments["kakarot"]["address"]
+            starknet_deployments["kakarot"]
         )
         if deployed_class_hash != class_hash["kakarot"]:
             await invoke("kakarot", "upgrade", class_hash["kakarot"])
@@ -118,10 +125,15 @@ async def main():
             "kakarot",
             "set_base_fee",
             DEFAULT_GAS_PRICE,
-            address=starknet_deployments["kakarot"]["address"],
+            address=starknet_deployments["kakarot"],
         )
 
     dump_deployments(starknet_deployments)
+
+    # Execute calls in lazy mode
+    # After this point, Kakarot needs to be deployed for the remaining calls to be executed
+    await execute_calls()
+    remove_lazy_account(account.address)
 
     # %% Pre-EIP155 deployments
     evm_deployments = get_evm_deployments()

--- a/kakarot_scripts/deploy_kakarot.py
+++ b/kakarot_scripts/deploy_kakarot.py
@@ -135,21 +135,23 @@ async def main():
     await execute_calls()
     remove_lazy_account(account.address)
 
-    # %% Pre-EIP155 deployments
+    # %% EVM Deployments
     evm_deployments = get_evm_deployments()
-    evm_deployments["Multicall3"] = await deploy_with_presigned_tx(
+
+    # %% Pre-EIP155 deployments, done only once
+    await deploy_with_presigned_tx(
         MULTICALL3_DEPLOYER,
         MULTICALL3_SIGNED_TX,
         name="Multicall3",
         max_fee=int(0.1e18),
     )
-    evm_deployments["Arachnid_Proxy"] = await deploy_with_presigned_tx(
+    await deploy_with_presigned_tx(
         ARACHNID_PROXY_DEPLOYER,
         ARACHNID_PROXY_SIGNED_TX,
         name="Arachnid Proxy",
         max_fee=int(0.1e18),
     )
-    evm_deployments["CreateX"] = await deploy_with_presigned_tx(
+    await deploy_with_presigned_tx(
         CREATEX_DEPLOYER,
         CREATEX_SIGNED_TX,
         amount=0.3,
@@ -157,7 +159,6 @@ async def main():
         max_fee=int(0.2e18),
     )
 
-    # %% EVM Deployments
     if not EVM_ADDRESS:
         logger.info("ℹ️  No EVM address provided, skipping EVM deployments")
         return

--- a/kakarot_scripts/utils/kakarot.py
+++ b/kakarot_scripts/utils/kakarot.py
@@ -484,7 +484,9 @@ async def send_pre_eip155_transaction(
         "account_contract", "get_nonce", address=starknet_address
     )
     if nonce != 0:
-        logger.info(f"ℹ️  Nonce for {evm_address} is 1, skipping transaction")
+        logger.info(
+            f"ℹ️  Nonce for {evm_address} is not 0 ({nonce}), skipping transaction"
+        )
         return
 
     if WEB3.is_connected():

--- a/kakarot_scripts/utils/starknet.py
+++ b/kakarot_scripts/utils/starknet.py
@@ -566,7 +566,7 @@ async def execute_calls():
 
 @lazy_execute
 async def execute_v1(account, calls):
-    calldata = _parse_calls(1, calls)
+    calldata = _parse_calls(await account.cairo_version, calls)
     msg_hash = compute_transaction_hash(
         tx_hash_prefix=TransactionHashPrefix.INVOKE,
         version=1,

--- a/kakarot_scripts/utils/starknet.py
+++ b/kakarot_scripts/utils/starknet.py
@@ -71,7 +71,7 @@ _logs = defaultdict(list)
 _lazy_execute = defaultdict(bool)
 _multisig_account = defaultdict(bool)
 
-# Dict to store name to selector mapping
+# Dict to store selector to name mapping because argent api requires the name but calls have selector
 _selector_to_name = {get_selector_from_name("deployContract"): "deployContract"}
 
 

--- a/kakarot_scripts/withdraw_accounts.py
+++ b/kakarot_scripts/withdraw_accounts.py
@@ -20,7 +20,7 @@ logger.setLevel(logging.INFO)
 
 # %% Fetch contract events
 def get_contracts():
-    contract_address = hex(get_deployments()["kakarot"]["address"])
+    contract_address = hex(get_deployments()["kakarot"])
     logger.info(f"ℹ️  Fetching contracts from {contract_address}")
     url = f"{NETWORK['voyager_api_url']}/events?ps=10&p=1&contract={contract_address}"
     headers = {

--- a/tests/end_to_end/CairoPrecompiles/Pragma/test_pragma_precompile.py
+++ b/tests/end_to_end/CairoPrecompiles/Pragma/test_pragma_precompile.py
@@ -43,7 +43,7 @@ def serialize_data_type(data_type: dict) -> Tuple:
 
 @pytest_asyncio.fixture(scope="module")
 async def pragma_caller(owner):
-    pragma_oracle_address = get_deployments()["MockPragmaOracle"]["address"]
+    pragma_oracle_address = get_deployments()["MockPragmaOracle"]
     return await deploy(
         "CairoPrecompiles",
         "PragmaCaller",

--- a/tests/end_to_end/CairoPrecompiles/test_dual_vm_token.py
+++ b/tests/end_to_end/CairoPrecompiles/test_dual_vm_token.py
@@ -11,11 +11,9 @@ from tests.utils.errors import cairo_error
 
 @pytest_asyncio.fixture(scope="function")
 async def starknet_token(owner):
-    address = (
-        await deploy_starknet(
-            "StarknetToken", int(1e18), owner.starknet_contract.address
-        )
-    )["address"]
+    address = await deploy_starknet(
+        "StarknetToken", int(1e18), owner.starknet_contract.address
+    )
     return get_contract_starknet("StarknetToken", address=address)
 
 

--- a/tests/end_to_end/EvmPrecompiles/test_evm_precompiles.py
+++ b/tests/end_to_end/EvmPrecompiles/test_evm_precompiles.py
@@ -10,10 +10,7 @@ from kakarot_scripts.utils.kakarot import deploy
 
 @pytest_asyncio.fixture(scope="package")
 async def evm_precompiles():
-    return await deploy(
-        "EvmPrecompiles",
-        "EvmPrecompiles",
-    )
+    return await deploy("EvmPrecompiles", "EvmPrecompiles")
 
 
 def ref_alt_bn128_add(x0, y0, x1, y1):


### PR DESCRIPTION
Time spent on this PR: 0.5

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Not possible to use an Argent multisig account as account in the scripts.

Resolves #1411

## What is the new behavior?

- `get_starknet_account` can handle an Argent multisig account as sender.
- all invoke tx now use the same `execute_v1` function extracted from `starknet-py`.
- this function can be lazy and batch execute calls afterwards instead of executing them when called.
- also added cache of the class_hashes at compile step to speed up the deployment script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1476)
<!-- Reviewable:end -->
