### PR TITLE
docs: :memo: update uv installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The project uses [uv](https://github.com/astral-sh/uv) to manage python
 dependencies and run commands. To install uv:
 
 ```bash
-curl -L https://install.astral.sh | bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 To build the CairoZero files:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The README currently suggests an outdated installation command for the uv tool. This command does not work

Resolves #<Issue number>

## What is the new behavior?

The installation command for uv has been updated in the README to reflect the latest recommended command. The new command uses the URL `https://astral.sh/uv/install.sh`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1479)
<!-- Reviewable:end -->
