### PR TITLE
dev: reduce step limit per tx to be same as Sepolia SN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ install-katana:
 	cargo install --git https://github.com/dojoengine/dojo --locked --tag "${KATANA_VERSION}" katana
 
 run-katana:
-	katana --chain-id test --validate-max-steps 6000000 --invoke-max-steps 14000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --seed 0
+	katana --chain-id test --validate-max-steps 1000000 --invoke-max-steps 9000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --seed 0
 
 run-anvil:
 	anvil --block-base-fee-per-gas 1
@@ -94,4 +94,4 @@ run-anvil:
 run-nodes:
 	@echo "Starting Anvil and Katana in messaging mode"
 	@anvil --block-base-fee-per-gas 1 &
-	@katana --chain-id test --validate-max-steps 6000000 --invoke-max-steps 14000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --messaging .katana/messaging_config.json --seed 0
+	@katana --chain-id test --validate-max-steps 1000000 --invoke-max-steps 9000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --messaging .katana/messaging_config.json --seed 0


### PR DESCRIPTION

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

reduced compute limits for tests to match prod

<!-- Please describe the behavior or changes that are being added by this PR. -->

- reduce step limit for `__validate__` and `__execute__` endpoints for tests to match SN Sepolia (resp. 1m and 9m cairo steps)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1504)
<!-- Reviewable:end -->
