### PR TITLE
chore: bump katana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 KKRT_SSJ_RELEASE_ID = 176384150
 # Kakarot SSJ artifacts for precompiles.
 KKRT_SSJ_BUILD_ARTIFACT_URL = $(shell curl -L https://api.github.com/repos/kkrt-labs/kakarot-ssj/releases/${KKRT_SSJ_RELEASE_ID} | jq -r '.assets[0].browser_download_url')
-KATANA_VERSION = v1.0.0-alpha.14
+KATANA_VERSION = v1.0.0-alpha.16
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 BUILD_DIR = build


### PR DESCRIPTION
bump katana to alpha16, whose genesis ETH token has camelCase AND snake_case entrypoints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1508)
<!-- Reviewable:end -->
