### PR TITLE
refactor: CairoLib

### DIFF
--- a/solidity_contracts/src/CairoPrecompiles/DualVmToken.sol
+++ b/solidity_contracts/src/CairoPrecompiles/DualVmToken.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.27;
 
+import {WhitelistedCallCairoLib} from "./WhitelistedCallCairoLib.sol";
 import {CairoLib} from "kakarot-lib/CairoLib.sol";
-
-using CairoLib for uint256;
 
 /// @notice EVM adapter into a Cairo ERC20 token
 /// @dev This implementation is highly experimental
@@ -12,6 +11,7 @@ using CairoLib for uint256;
 /// @author Kakarot
 /// @author Modified from Solmate (https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC20.sol)
 contract DualVmToken {
+    using WhitelistedCallCairoLib for uint256;
     /*//////////////////////////////////////////////////////////////
                         CAIRO SPECIFIC VARIABLES
     //////////////////////////////////////////////////////////////*/

--- a/solidity_contracts/src/CairoPrecompiles/PragmaCaller.sol
+++ b/solidity_contracts/src/CairoPrecompiles/PragmaCaller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.0 <0.9.0;
 
 import {CairoLib} from "kakarot-lib/CairoLib.sol";
 
@@ -8,9 +8,6 @@ using CairoLib for uint256;
 contract PragmaCaller {
     /// @dev The starknet address of the pragma oracle
     uint256 pragmaOracle;
-
-    /// @dev The cairo function selector to call - `get_data_median`
-    uint256 constant FUNCTION_SELECTOR_GET_DATA_MEDIAN = uint256(keccak256("get_data_median")) % 2 ** 250;
 
     struct PragmaPricesResponse {
         uint256 price;
@@ -46,7 +43,7 @@ contract PragmaCaller {
             data[2] = request.expirationTimestamp;
         }
 
-        bytes memory returnData = pragmaOracle.staticcallCairo(FUNCTION_SELECTOR_GET_DATA_MEDIAN, data);
+        bytes memory returnData = pragmaOracle.staticcallCairo("get_data_median", data);
 
         assembly {
             // Load the values from the return data

--- a/solidity_contracts/src/CairoPrecompiles/WhitelistedCallCairoLib.sol
+++ b/solidity_contracts/src/CairoPrecompiles/WhitelistedCallCairoLib.sol
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
+/// @notice A library to interact with the 0x75001 Whitelisted Cairo Call precompile.
 library WhitelistedCallCairoLib {
     /// @dev The Cairo precompile contract's address.
     address constant WHITELISTED_CALL_CAIRO_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000075001;
 
+    /// @notice Calls the Cairo precompile with the given contract address, function selector and data.
+    /// @param contractAddress The address of the contract to call.
+    /// @param functionSelector The function selector to call.
+    /// @param data The data to pass to the function.
+    /// @return The result of the Cairo precompile call.
     function callCairo(uint256 contractAddress, uint256 functionSelector, uint256[] memory data)
         internal
         returns (bytes memory)
@@ -31,6 +37,11 @@ library WhitelistedCallCairoLib {
         return callCairo(contractAddress, functionSelector, data);
     }
 
+    /// @notice Delegate calls the Cairo precompile with the given contract address, function selector and data.
+    /// @param contractAddress The address of the contract to delegate call.
+    /// @param functionName The function name to delegate call.
+    /// @param data The data to pass to the function.
+    /// @return The result of the Cairo precompile delegate call.
     function delegatecallCairo(uint256 contractAddress, string memory functionName, uint256[] memory data)
         internal
         returns (bytes memory)
@@ -49,6 +60,12 @@ library WhitelistedCallCairoLib {
         return delegatecallCairo(contractAddress, functionName, data);
     }
 
+    /// @notice Static calls the Cairo precompile with the given contract address, function selector and data.
+    /// @dev This doesn't protect against mutation of the underlying Cairo contract state.
+    /// @param contractAddress The address of the contract to static call.
+    /// @param functionName The function name to static call.
+    /// @param data The data to pass to the function.
+    /// @return The result of the Cairo precompile static call.
     function staticcallCairo(uint256 contractAddress, string memory functionName, uint256[] memory data)
         internal
         view

--- a/solidity_contracts/src/CairoPrecompiles/WhitelistedCallCairoLib.sol
+++ b/solidity_contracts/src/CairoPrecompiles/WhitelistedCallCairoLib.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+library WhitelistedCallCairoLib {
+    /// @dev The Cairo precompile contract's address.
+    address constant WHITELISTED_CALL_CAIRO_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000075001;
+
+    function callCairo(uint256 contractAddress, uint256 functionSelector, uint256[] memory data)
+        internal
+        returns (bytes memory)
+    {
+        bytes memory callData = abi.encode(contractAddress, functionSelector, data);
+
+        (bool success, bytes memory result) = WHITELISTED_CALL_CAIRO_PRECOMPILE_ADDRESS.call(callData);
+        require(success, string(abi.encodePacked("CairoLib: cairo call failed with: ", result)));
+
+        return result;
+    }
+
+    function callCairo(uint256 contractAddress, string memory functionName, uint256[] memory data)
+        internal
+        returns (bytes memory)
+    {
+        uint256 functionSelector = uint256(keccak256(bytes(functionName))) % 2 ** 250;
+        return callCairo(contractAddress, functionSelector, data);
+    }
+
+    function callCairo(uint256 contractAddress, string memory functionName) internal returns (bytes memory) {
+        uint256[] memory data = new uint256[](0);
+        uint256 functionSelector = uint256(keccak256(bytes(functionName))) % 2 ** 250;
+        return callCairo(contractAddress, functionSelector, data);
+    }
+
+    function delegatecallCairo(uint256 contractAddress, string memory functionName, uint256[] memory data)
+        internal
+        returns (bytes memory)
+    {
+        uint256 functionSelector = uint256(keccak256(bytes(functionName))) % 2 ** 250;
+        bytes memory callData = abi.encode(contractAddress, functionSelector, data);
+
+        (bool success, bytes memory result) = WHITELISTED_CALL_CAIRO_PRECOMPILE_ADDRESS.delegatecall(callData);
+        require(success, string(abi.encodePacked("CairoLib: cairo call failed with: ", result)));
+
+        return result;
+    }
+
+    function delegatecallCairo(uint256 contractAddress, string memory functionName) internal returns (bytes memory) {
+        uint256[] memory data = new uint256[](0);
+        return delegatecallCairo(contractAddress, functionName, data);
+    }
+
+    function staticcallCairo(uint256 contractAddress, string memory functionName, uint256[] memory data)
+        internal
+        view
+        returns (bytes memory)
+    {
+        uint256 functionSelector = uint256(keccak256(bytes(functionName))) % 2 ** 250;
+        bytes memory callData = abi.encode(contractAddress, functionSelector, data);
+
+        (bool success, bytes memory result) = WHITELISTED_CALL_CAIRO_PRECOMPILE_ADDRESS.staticcall(callData);
+        require(success, string(abi.encodePacked("CairoLib: cairo call failed with: ", result)));
+
+        return result;
+    }
+
+    function staticcallCairo(uint256 contractAddress, string memory functionName)
+        internal
+        view
+        returns (bytes memory)
+    {
+        uint256[] memory data = new uint256[](0);
+        return staticcallCairo(contractAddress, functionName, data);
+    }
+}

--- a/solidity_contracts/src/CairoPrecompiles/WhitelistedCallCairoPrecompileTest.sol
+++ b/solidity_contracts/src/CairoPrecompiles/WhitelistedCallCairoPrecompileTest.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
-import {CairoLib} from "kakarot-lib/CairoLib.sol";
-
-using CairoLib for uint256;
+import {WhitelistedCallCairoLib} from "./WhitelistedCallCairoLib.sol";
 
 contract WhitelistedCallCairoPrecompileTest {
     /// @dev The cairo contract to call
@@ -14,7 +12,7 @@ contract WhitelistedCallCairoPrecompileTest {
     }
 
     function getCairoCounter() public view returns (uint256 counterValue) {
-        bytes memory returnData = cairoCounter.staticcallCairo("get");
+        bytes memory returnData = WhitelistedCallCairoLib.staticcallCairo(cairoCounter, "get");
 
         // The return data is a 256-bit integer, so we can directly cast it to uint256
         return abi.decode(returnData, (uint256));
@@ -24,12 +22,12 @@ contract WhitelistedCallCairoPrecompileTest {
     /// @dev The delegatecall preserves the caller's context, so the caller's address will
     /// be the caller of this function.
     function delegateCallIncrementCairoCounter() external {
-        cairoCounter.delegatecallCairo("inc");
+        WhitelistedCallCairoLib.delegatecallCairo(cairoCounter, "inc");
     }
 
     /// @notice Calls the Cairo contract to increment its internal counter
     function incrementCairoCounter() external {
-        cairoCounter.callCairo("inc");
+        WhitelistedCallCairoLib.callCairo(cairoCounter, "inc");
     }
 
     /// @notice Calls the Cairo contract to set its internal counter to an arbitrary value
@@ -44,14 +42,13 @@ contract WhitelistedCallCairoPrecompileTest {
         uint256[] memory data = new uint256[](2);
         data[0] = uint256(newCounterLow);
         data[1] = uint256(newCounterHigh);
-        cairoCounter.callCairo("set_counter", data);
+        WhitelistedCallCairoLib.callCairo(cairoCounter, "set_counter", data);
     }
 
     /// @notice Calls the Cairo contract to get the (starknet) address of the last caller
     /// @return lastCaller The starknet address of the last caller
     function getLastCaller() external view returns (uint256 lastCaller) {
-        bytes memory returnData = cairoCounter.staticcallCairo("get_last_caller");
-
+        bytes memory returnData = WhitelistedCallCairoLib.staticcallCairo(cairoCounter, "get_last_caller");
         return abi.decode(returnData, (uint256));
     }
 }

--- a/tests/end_to_end/CairoPrecompiles/Pragma/test_pragma_precompile.py
+++ b/tests/end_to_end/CairoPrecompiles/Pragma/test_pragma_precompile.py
@@ -5,7 +5,6 @@ import pytest_asyncio
 
 from kakarot_scripts.utils.kakarot import deploy
 from kakarot_scripts.utils.starknet import get_contract, get_deployments, invoke
-from tests.utils.errors import cairo_error
 
 ENTRY_TYPE_INDEX = {"SpotEntry": 0, "FutureEntry": 1, "GenericEntry": 2}
 
@@ -137,20 +136,3 @@ class TestPragmaPrecompile:
             if data_type.get("FutureEntry")
             else 0
         )
-
-    @pytest.mark.parametrize(
-        "data_type", [{"SpotEntry": int.from_bytes(b"BTC/USD", byteorder="big")}]
-    )
-    async def test_should_fail_unauthorized_caller(self, pragma_caller, data_type):
-        await invoke(
-            "kakarot",
-            "set_authorized_cairo_precompile_caller",
-            int(pragma_caller.address, 16),
-            False,
-        )
-        solidity_input = serialize_data_type(data_type)
-
-        with cairo_error(
-            "EVM tx reverted, reverting SN tx because of previous calls to cairo precompiles"
-        ):
-            await pragma_caller.getDataMedianSpot(solidity_input)


### PR DESCRIPTION
Refactors the CairoLib and its usage.
The CairoLib from `kakarot-lib` now only exposes public, non-whitelisted entrypoints (including multicall).

As such, the DualVmToken and other contracts relying on the whitelisted `delegatecall` feature are using an internal `WhitelistedCallCairoLib` library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1510)
<!-- Reviewable:end -->
