### PR TITLE
ci: fix release job

### DIFF
--- a/.github/workflows/cairo-zero-release.yml
+++ b/.github/workflows/cairo-zero-release.yml
@@ -51,7 +51,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
       - name: Install dependencies
-        run: make setup
+        run: make setup-ci
       - name: Compile all the cairo files
         run: make build
       - name: Zip the build

--- a/.github/workflows/ssj-ci.yml
+++ b/.github/workflows/ssj-ci.yml
@@ -69,7 +69,7 @@ jobs:
           python-version-file: .python-version
 
       - name: Install dependencies
-        run: make setup
+        run: make setup-ci
 
       - name: Load performance artifacts
         uses: actions/download-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ setup:
 	uv sync --all-extras --dev
 
 setup-ci:
+	cp .env.example .env
 	uv sync --all-extras --dev
 
 katana: ;

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ $(SSJ_ZIP):
 setup:
 	@python kakarot_scripts/setup/setup.py $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 	uv sync --all-extras --dev
+
+setup-ci:
+	uv sync --all-extras --dev
+
 katana: ;
 
 build: $(SSJ_DIR)


### PR DESCRIPTION
Fixes release job by:
- Copying the .env file to have an EVM_PRIVATE_KEY in environment (required for build)
- Adding a new `setup-ci` target that only sets up the bare minimum for the CIs to run.

Proof that it works: https://github.com/enitrat/kakarot/actions/runs/11566994717
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1552)
<!-- Reviewable:end -->
