### PR TITLE
[KGA-82] [KGA-80] fix: codehash commitment

### DIFF
--- a/cairo_zero/backend/starknet.cairo
+++ b/cairo_zero/backend/starknet.cairo
@@ -177,6 +177,10 @@ namespace Internals {
         if (starknet_account_exists == 0) {
             // Deploy account
             Starknet.deploy(self.address.evm);
+            // Commit the code hash upon deployment
+            // of a new account, in all cases.
+            // Retrieved in `fetch_or_create` in the next transaction.
+            IAccount.set_code_hash(starknet_address, [self.code_hash]);
             tempvar syscall_ptr = syscall_ptr;
             tempvar pedersen_ptr = pedersen_ptr;
             tempvar range_check_ptr = range_check_ptr;
@@ -201,7 +205,6 @@ namespace Internals {
 
         let has_code_or_nonce = Account.has_code_or_nonce(self);
         if (has_code_or_nonce == FALSE) {
-            // Nothing to commit
             return ();
         }
 


### PR DESCRIPTION
Fixes the codehash assigned to an account upon deployment as per https://github.com/code-423n4/2024-09-kakarot-findings/issues/10

- In any case, the codehash of an account is keccak(code_bytes)
- IF that account has no code, nonce nor balance, then `extcodehash` opcode returns 0.

As such, upon deploying the starknet contract corresponding to an account, we should _always_ set the codehash to `self.code_hash`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1566)
<!-- Reviewable:end -->
