### PR TITLE
[KGA-4] [KGA-118] [KGA-119] [KGA-127] [KGA-133] fix: reentrancy check in eth_call

### DIFF
--- a/cairo_zero/kakarot/accounts/account_contract.cairo
+++ b/cairo_zero/kakarot/accounts/account_contract.cairo
@@ -320,8 +320,6 @@ func set_authorized_pre_eip155_tx{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
 
 // @notice Execute a starknet call.
 // @dev Used when executing a Cairo Precompile. Used to preserve the caller address.
-// Reentrancy check is done, only `get_starknet_address` is allowed for Solidity contracts
-//      to be able to get the corresponding Starknet address in their calldata.
 // @param to The address to call.
 // @param function_selector The function selector to call.
 // @param calldata_len The length of the calldata array.
@@ -334,16 +332,6 @@ func execute_starknet_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range
     to: felt, function_selector: felt, calldata_len: felt, calldata: felt*
 ) -> (retdata_len: felt, retdata: felt*, success: felt) {
     Ownable.assert_only_owner();
-    let (kakarot_address) = Ownable.owner();
-    let is_get_starknet_address = Helpers.is_zero(
-        GET_STARKNET_ADDRESS_SELECTOR - function_selector
-    );
-    let is_kakarot = Helpers.is_zero(kakarot_address - to);
-    tempvar is_forbidden = is_kakarot * (1 - is_get_starknet_address);
-    if (is_forbidden != FALSE) {
-        let (error_len, error) = Errors.kakarotReentrancy();
-        return (error_len, error, FALSE);
-    }
     let (retdata_len, retdata) = call_contract(to, function_selector, calldata_len, calldata);
     return (retdata_len, retdata, TRUE);
 }

--- a/cairo_zero/kakarot/library.cairo
+++ b/cairo_zero/kakarot/library.cairo
@@ -3,6 +3,7 @@
 %lang starknet
 
 from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.security.reentrancyguard.library import ReentrancyGuard
 from starkware.cairo.common.bool import FALSE, TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.starknet.common.syscalls import get_caller_address, get_tx_info
@@ -98,6 +99,9 @@ namespace Kakarot {
         access_list: felt*,
     ) -> (model.EVM*, model.State*, felt, felt) {
         alloc_locals;
+
+        ReentrancyGuard.start();
+
         let is_regular_tx = is_not_zero(to.is_some);
         let is_deploy_tx = 1 - is_regular_tx;
         let evm_contract_address = resolve_to(to, origin, nonce);
@@ -122,6 +126,8 @@ namespace Kakarot {
             access_list_len,
             access_list,
         );
+
+        ReentrancyGuard.end();
         return (evm, state, gas_used, required_gas);
     }
 

--- a/cairo_zero/tests/src/kakarot/accounts/test_account_contract.py
+++ b/cairo_zero/tests/src/kakarot/accounts/test_account_contract.py
@@ -262,18 +262,6 @@ class TestAccountContract:
                 )
 
         @SyscallHandler.patch("Ownable_owner", SyscallHandler.caller_address)
-        def test_should_fail_if_calling_kakarot(self, cairo_run):
-            function_selector = 0xBCD
-            with SyscallHandler.patch(function_selector, lambda addr, data: []):
-                return_data, success = cairo_run(
-                    "test__execute_starknet_call",
-                    called_address=SyscallHandler.caller_address,
-                    function_selector=function_selector,
-                    calldata=[],
-                )
-                assert success == 0
-
-        @SyscallHandler.patch("Ownable_owner", SyscallHandler.caller_address)
         def test_should_execute_starknet_call(self, cairo_run):
             called_address = 0xABCDEF1234567890
             function_selector = 0x0987654321FEDCBA

--- a/solidity_contracts/src/CairoPrecompiles/KakarotReentrancyTest.sol
+++ b/solidity_contracts/src/CairoPrecompiles/KakarotReentrancyTest.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import {WhitelistedCallCairoLib} from "./WhitelistedCallCairoLib.sol";
+import {CairoLib} from "kakarot-lib/CairoLib.sol";
+
+contract KakarotReentrancyTest {
+    uint256 immutable kakarot;
+
+    constructor(uint256 kakarotAddress_) {
+        kakarot = kakarotAddress_;
+    }
+
+    function whitelistedStaticcallKakarot(string memory functionName, uint256[] memory data) external view {
+        WhitelistedCallCairoLib.staticcallCairo(kakarot, functionName, data);
+    }
+
+    function staticcallKakarot(string memory functionName, uint256[] memory data) external view {
+        CairoLib.staticcallCairo(kakarot, functionName, data);
+    }
+}

--- a/tests/end_to_end/CairoPrecompiles/test_call_cairo_precompile.py
+++ b/tests/end_to_end/CairoPrecompiles/test_call_cairo_precompile.py
@@ -37,7 +37,7 @@ async def kakarot_reentrancy(kakarot):
 
 
 @pytest_asyncio.fixture(scope="module")
-async def eth_call_calldata_fixture(kakarot, new_eoa):
+async def eth_call_calldata(kakarot, new_eoa):
     eoa = await new_eoa()
     return (
         kakarot.functions["eth_call"]
@@ -107,15 +107,15 @@ class TestCairoPrecompiles:
 
     class TestReentrancyKakarot:
         async def test_should_fail_when_reentrancy_cairo_call(
-            self, kakarot, kakarot_reentrancy, new_eoa, eth_call_calldata_fixture
+            self, kakarot, kakarot_reentrancy, new_eoa, eth_call_calldata
         ):
             with cairo_error("ReentrancyGuard: reentrant call"):
                 await kakarot_reentrancy.staticcallKakarot(
-                    "eth_call", eth_call_calldata_fixture
+                    "eth_call", eth_call_calldata
                 )
 
         async def test_should_fail_when_reentrancy_cairo_call_whitelisted(
-            self, kakarot, kakarot_reentrancy, new_eoa, eth_call_calldata_fixture
+            self, kakarot, kakarot_reentrancy, new_eoa, eth_call_calldata
         ):
             # Setup for whitelisted precompile
             await invoke(
@@ -127,7 +127,7 @@ class TestCairoPrecompiles:
 
             with cairo_error("ReentrancyGuard: reentrant call"):
                 await kakarot_reentrancy.whitelistedStaticcallKakarot(
-                    "eth_call", eth_call_calldata_fixture
+                    "eth_call", eth_call_calldata
                 )
 
             # TearDown


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Reentrancy check is moved at Kakarot level in eth_call

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1582)
<!-- Reviewable:end -->
