### PR TITLE
[KGA-25] [KGA-73] fix: set code_address of the deployment code to the created address

### DIFF
--- a/cairo_zero/kakarot/instructions/system_operations.cairo
+++ b/cairo_zero/kakarot/instructions/system_operations.cairo
@@ -163,7 +163,6 @@ namespace SystemOperations {
         let (valid_jumpdests_start, valid_jumpdests) = Helpers.initialize_jumpdests(
             bytecode_len=size.low, bytecode=bytecode
         );
-        tempvar address_zero = new model.Address(starknet=0, evm=0);
         tempvar message = new model.Message(
             bytecode=bytecode,
             bytecode_len=size.low,
@@ -175,7 +174,7 @@ namespace SystemOperations {
             caller=evm.message.address.evm,
             parent=parent,
             address=target_account.address,
-            code_address=address_zero,
+            code_address=target_account.address,
             read_only=FALSE,
             is_create=TRUE,
             depth=evm.message.depth + 1,

--- a/cairo_zero/kakarot/interpreter.cairo
+++ b/cairo_zero/kakarot/interpreter.cairo
@@ -859,7 +859,7 @@ namespace Interpreter {
         local bytecode: felt*;
         local calldata: felt*;
         local intrinsic_gas: felt;
-        local code_address: model.Address*;
+        let code_address = address;
         if (is_deploy_tx != FALSE) {
             let (empty: felt*) = alloc();
             let (init_code_words, _) = unsigned_div_rem(bytecode_len + 31, 32);
@@ -867,7 +867,6 @@ namespace Interpreter {
             assert bytecode = tmp_calldata;
             assert calldata = empty;
             assert intrinsic_gas = tmp_intrinsic_gas + Gas.CREATE + init_code_gas;
-            assert code_address = new model.Address(starknet=0, evm=0);
             let (valid_jumpdests_start, valid_jumpdests) = Helpers.initialize_jumpdests(
                 bytecode_len=bytecode_len, bytecode=bytecode
             );
@@ -878,7 +877,6 @@ namespace Interpreter {
             assert bytecode = tmp_bytecode;
             assert calldata = tmp_calldata;
             assert intrinsic_gas = tmp_intrinsic_gas;
-            assert code_address = address;
 
             let (new_dict) = default_dict_new(0);
             tempvar range_check_ptr = range_check_ptr;

--- a/tests/end_to_end/test_kakarot.py
+++ b/tests/end_to_end/test_kakarot.py
@@ -130,6 +130,26 @@ class TestKakarot:
                     if event.from_address != eth.address
                 ] == events
 
+        # https://github.com/code-423n4/2024-09-kakarot-findings/issues/44
+        async def test_execute_jump_creation_code(self, evm: Contract, origin):
+            params = {
+                "value": 0,
+                "code": "605f5f53605660015360025f5ff0",
+                "calldata": "",
+                "stack": "0000000000000000000000000000000000000000000000000000000000000000",
+                "memory": "",
+                "return_data": "",
+                "success": 1,
+            }
+            result = await evm.functions["evm_call"].call(
+                origin=origin,
+                value=int(params["value"]),
+                bytecode=hex_string_to_bytes_array(params["code"]),
+                calldata=hex_string_to_bytes_array(params["calldata"]),
+                access_list=[],
+            )
+            assert result.success == params["success"]
+
     class TestGetStarknetAddress:
         async def test_should_return_same_as_deployed_address(self, new_eoa):
             eoa = await new_eoa()

--- a/tests/end_to_end/test_kakarot.py
+++ b/tests/end_to_end/test_kakarot.py
@@ -247,6 +247,24 @@ class TestKakarot:
             assert result.return_data == []
             assert result.gas_used == 21_000
 
+    class TestEthCallJumpCreationCodeDeployTx:
+        async def test_eth_call_jump_creation_code_deploy_tx_should_succeed(
+            self, kakarot, new_eoa
+        ):
+            eoa = await new_eoa()
+            result = await kakarot.functions["eth_call"].call(
+                nonce=0,
+                origin=int(eoa.address, 16),
+                to={"is_some": 0, "value": 0},
+                gas_limit=TRANSACTION_GAS_LIMIT,
+                gas_price=1_000,
+                value=0,
+                data=bytes.fromhex("605f5f53605660015360025f5ff0"),
+                access_list=[],
+            )
+
+            assert result.success == 1
+
         async def test_eth_call_should_handle_uninitialized_class_update(
             self, kakarot, new_eoa, class_hashes
         ):


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Set code_address of the deployment code to the created address. 
[ src/ethereum/cancun/utils/message.py](https://github.com/ethereum/execution-specs/blob/07f5747a43d62ef7f203d41d77005cb15ca5e434/src/ethereum/cancun/utils/message.py#L89-L90)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1587)
<!-- Reviewable:end -->
