### PR TITLE
fix: typos in documentation files

### DIFF
--- a/cairo/kakarot-ssj/docs/general/contract_storage.md
+++ b/cairo/kakarot-ssj/docs/general/contract_storage.md
@@ -15,7 +15,7 @@ _Account state associated to an Ethereum address. Source:
 [EVM Illustrated](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 In traditional EVM clients, like Geth, the _world state_ is stored as a _trie_,
-and information about account are stored in the world state trie and can be
+and information about accounts are stored in the world state trie and can be
 retrieved through queries. Each account in the world state trie is associated
 with an account storage trie, which stores all of the information related to the
 account. When Geth updates the storage of a contract by executing the SSTORE


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "account" to "accounts", because it is necessary to use "accounts" in the plural, as we are talking about a collection of accounts

Please review the changes and let me know if any additional changes are needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1602)
<!-- Reviewable:end -->
