### PR TITLE
[KGA-89] dev: remove useless computation in uint256_fast_exp"

### DIFF
--- a/cairo_zero/utils/uint256.cairo
+++ b/cairo_zero/utils/uint256.cairo
@@ -366,7 +366,6 @@ func uint256_fast_exp{range_check_ptr}(value: Uint256, exponent: Uint256) -> Uin
         return res;
     }
 
-    let pow = uint256_fast_exp(value, half_exponent);
     let (res, _) = uint256_mul(pow, pow);
     return res;
 }


### PR DESCRIPTION
removes a useless line that compute `uint256_fast_exp` one too many times.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1603)
<!-- Reviewable:end -->
