### PR TITLE
[KGA-87] fix: high offset memory expansion computations

### DIFF
--- a/cairo_zero/tests/src/kakarot/test_gas.cairo
+++ b/cairo_zero/tests/src/kakarot/test_gas.cairo
@@ -36,14 +36,14 @@ func test__max_memory_expansion_cost{range_check_ptr}() -> felt {
     local size_2: Uint256;
     %{
         ids.words_len = program_input["words_len"];
-        ids.offset_1.low = program_input["offset_1"];
-        ids.offset_1.high = 0;
-        ids.size_1.low = program_input["size_1"];
-        ids.size_1.high = 0;
-        ids.offset_2.low = program_input["offset_2"];
-        ids.offset_2.high = 0;
-        ids.size_2.low = program_input["size_2"];
-        ids.size_2.high = 0;
+        ids.offset_1.low = program_input["offset_1"][0]
+        ids.offset_1.high = program_input["offset_1"][1]
+        ids.size_1.low = program_input["size_1"][0]
+        ids.size_1.high = program_input["size_1"][1]
+        ids.offset_2.low = program_input["offset_2"][0]
+        ids.offset_2.high = program_input["offset_2"][1]
+        ids.size_2.low = program_input["size_2"][0]
+        ids.size_2.high = program_input["size_2"][1]
     %}
     let memory_expansion = Gas.max_memory_expansion_cost(
         words_len, &offset_1, &size_1, &offset_2, &size_2
@@ -74,9 +74,9 @@ func test__compute_message_call_gas{range_check_ptr}() -> felt {
     tempvar gas_param: Uint256;
     tempvar gas_left: felt;
     %{
-        ids.gas_param.low = program_input["gas_param"];
-        ids.gas_param.high = 0;
-        ids.gas_left = program_input["gas_left"];
+        ids.gas_param.low = program_input["gas_param"][0]
+        ids.gas_param.high = program_input["gas_param"][1]
+        ids.gas_left = program_input["gas_left"]
     %}
     let gas = Gas.compute_message_call_gas(gas_param, gas_left);
 

--- a/cairo_zero/tests/src/kakarot/test_gas.py
+++ b/cairo_zero/tests/src/kakarot/test_gas.py
@@ -6,6 +6,9 @@ from ethereum.shanghai.vm.gas import (
 from hypothesis import given
 from hypothesis.strategies import integers
 
+from kakarot_scripts.utils.uint256 import int_to_uint256
+from tests.utils.constants import FELT_252_PRIME
+
 
 class TestGas:
     class TestCost:
@@ -33,32 +36,37 @@ class TestGas:
             assert diff == output
 
         @given(
-            offset_1=integers(min_value=0, max_value=0xFFFFF),
-            size_1=integers(min_value=0, max_value=0xFFFFF),
-            offset_2=integers(min_value=0, max_value=0xFFFFF),
-            size_2=integers(min_value=0, max_value=0xFFFFF),
+            offset_1=integers(min_value=0, max_value=FELT_252_PRIME - 1),
+            size_1=integers(min_value=0, max_value=FELT_252_PRIME - 1),
+            offset_2=integers(min_value=0, max_value=FELT_252_PRIME - 1),
+            size_2=integers(min_value=0, max_value=FELT_252_PRIME - 1),
         )
         def test_should_return_max_expansion_cost(
             self, cairo_run, offset_1, size_1, offset_2, size_2
         ):
+            MEMORY_COST_U32 = 0x200018000000
             output = cairo_run(
                 "test__max_memory_expansion_cost",
                 words_len=0,
-                offset_1=offset_1,
-                size_1=size_1,
-                offset_2=offset_2,
-                size_2=size_2,
+                offset_1=int_to_uint256(offset_1),
+                size_1=int_to_uint256(size_1),
+                offset_2=int_to_uint256(offset_2),
+                size_2=int_to_uint256(size_2),
             )
-            assert (
-                output
-                == calculate_gas_extend_memory(
-                    b"",
-                    [
-                        (offset_1, size_1),
-                        (offset_2, size_2),
-                    ],
-                ).cost
+            expansion = calculate_gas_extend_memory(
+                b"",
+                [
+                    (offset_1, size_1),
+                    (offset_2, size_2),
+                ],
             )
+
+            # If the memory expansion is greater than 2**27 words of 32 bytes
+            # We saturate it to the hardcoded value corresponding the the gas cost of a 2**32 memory size
+            expected_saturated = (
+                MEMORY_COST_U32 if expansion.expand_by > 2**32 else expansion.cost
+            )
+            assert output == expected_saturated
 
         @given(
             offset=integers(min_value=0, max_value=2**256 - 1),
@@ -94,6 +102,8 @@ class TestGas:
             self, cairo_run, gas_param, gas_left, expected
         ):
             output = cairo_run(
-                "test__compute_message_call_gas", gas_param=gas_param, gas_left=gas_left
+                "test__compute_message_call_gas",
+                gas_param=int_to_uint256(gas_param),
+                gas_left=gas_left,
             )
             assert output == expected

--- a/cairo_zero/tests/src/kakarot/test_gas.py
+++ b/cairo_zero/tests/src/kakarot/test_gas.py
@@ -5,9 +5,9 @@ from ethereum.shanghai.vm.gas import (
 )
 from hypothesis import given
 from hypothesis.strategies import integers
+from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
 from kakarot_scripts.utils.uint256 import int_to_uint256
-from tests.utils.constants import FELT_252_PRIME
 
 
 class TestGas:
@@ -36,10 +36,10 @@ class TestGas:
             assert diff == output
 
         @given(
-            offset_1=integers(min_value=0, max_value=FELT_252_PRIME - 1),
-            size_1=integers(min_value=0, max_value=FELT_252_PRIME - 1),
-            offset_2=integers(min_value=0, max_value=FELT_252_PRIME - 1),
-            size_2=integers(min_value=0, max_value=FELT_252_PRIME - 1),
+            offset_1=integers(min_value=0, max_value=DEFAULT_PRIME - 1),
+            size_1=integers(min_value=0, max_value=DEFAULT_PRIME - 1),
+            offset_2=integers(min_value=0, max_value=DEFAULT_PRIME - 1),
+            size_2=integers(min_value=0, max_value=DEFAULT_PRIME - 1),
         )
         def test_should_return_max_expansion_cost(
             self, cairo_run, offset_1, size_1, offset_2, size_2

--- a/cairo_zero/tests/src/kakarot/test_gas.py
+++ b/cairo_zero/tests/src/kakarot/test_gas.py
@@ -44,7 +44,7 @@ class TestGas:
         def test_should_return_max_expansion_cost(
             self, cairo_run, offset_1, size_1, offset_2, size_2
         ):
-            MEMORY_COST_U32 = 0x200018000000
+            memory_cost_u32 = calculate_memory_gas_cost(2**32 - 1)
             output = cairo_run(
                 "test__max_memory_expansion_cost",
                 words_len=0,
@@ -64,7 +64,7 @@ class TestGas:
             # If the memory expansion is greater than 2**27 words of 32 bytes
             # We saturate it to the hardcoded value corresponding the the gas cost of a 2**32 memory size
             expected_saturated = (
-                MEMORY_COST_U32 if expansion.expand_by > 2**32 else expansion.cost
+                memory_cost_u32 if expansion.expand_by >= 2**32 else expansion.cost
             )
             assert output == expected_saturated
 

--- a/cairo_zero/tests/src/utils/test_bytes.py
+++ b/cairo_zero/tests/src/utils/test_bytes.py
@@ -5,10 +5,9 @@ from hypothesis import given
 from hypothesis.strategies import integers
 
 from kakarot_scripts.utils.uint256 import int_to_uint256
+from tests.utils.constants import FELT_252_PRIME
 from tests.utils.errors import cairo_error
 from tests.utils.hints import patch_hint
-
-PRIME = 0x800000000000011000000000000000000000000000000000000000000000001
 
 
 class TestBytes:
@@ -29,7 +28,7 @@ class TestBytes:
             )
             assert expected == bytes(output)
 
-        @given(n=integers(min_value=2**248, max_value=PRIME - 1))
+        @given(n=integers(min_value=2**248, max_value=FELT_252_PRIME - 1))
         def test_should_raise_when_value_sup_31_bytes(self, cairo_run, n):
             with cairo_error(message="felt_to_bytes_little: value >= 2**248"):
                 cairo_run("test__felt_to_bytes_little", n=n)
@@ -100,14 +99,16 @@ class TestBytes:
             assert bytes.fromhex(f"{n:x}".rjust(len(res) * 2, "0")) == res
 
     class TestFeltToBytes20:
-        @pytest.mark.parametrize("n", [0, 10, 1234, 0xFFFFFF, 2**128, PRIME - 1])
+        @pytest.mark.parametrize(
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1]
+        )
         def test_should_return_bytes20(self, cairo_run, n):
             output = cairo_run("test__felt_to_bytes20", n=n)
             assert f"{n:064x}"[-40:] == bytes(output).hex()
 
     class TestUint256ToBytesLittle:
         @pytest.mark.parametrize(
-            "n", [0, 10, 1234, 0xFFFFFF, 2**128, PRIME - 1, 2**256 - 1]
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1, 2**256 - 1]
         )
         def test_should_return_bytes(self, cairo_run, n):
             output = cairo_run("test__uint256_to_bytes_little", n=int_to_uint256(n))
@@ -116,7 +117,7 @@ class TestBytes:
 
     class TestUint256ToBytes:
         @pytest.mark.parametrize(
-            "n", [0, 10, 1234, 0xFFFFFF, 2**128, PRIME - 1, 2**256 - 1]
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1, 2**256 - 1]
         )
         def test_should_return_bytes(self, cairo_run, n):
             output = cairo_run("test__uint256_to_bytes", n=int_to_uint256(n))
@@ -125,7 +126,7 @@ class TestBytes:
 
     class TestUint256ToBytes32:
         @pytest.mark.parametrize(
-            "n", [0, 10, 1234, 0xFFFFFF, 2**128, PRIME - 1, 2**256 - 1]
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1, 2**256 - 1]
         )
         def test_should_return_bytes(self, cairo_run, n):
             output = cairo_run("test__uint256_to_bytes32", n=int_to_uint256(n))

--- a/cairo_zero/tests/src/utils/test_bytes.py
+++ b/cairo_zero/tests/src/utils/test_bytes.py
@@ -3,9 +3,9 @@ import os
 import pytest
 from hypothesis import given
 from hypothesis.strategies import integers
+from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
 from kakarot_scripts.utils.uint256 import int_to_uint256
-from tests.utils.constants import FELT_252_PRIME
 from tests.utils.errors import cairo_error
 from tests.utils.hints import patch_hint
 
@@ -28,7 +28,7 @@ class TestBytes:
             )
             assert expected == bytes(output)
 
-        @given(n=integers(min_value=2**248, max_value=FELT_252_PRIME - 1))
+        @given(n=integers(min_value=2**248, max_value=DEFAULT_PRIME - 1))
         def test_should_raise_when_value_sup_31_bytes(self, cairo_run, n):
             with cairo_error(message="felt_to_bytes_little: value >= 2**248"):
                 cairo_run("test__felt_to_bytes_little", n=n)
@@ -100,7 +100,7 @@ class TestBytes:
 
     class TestFeltToBytes20:
         @pytest.mark.parametrize(
-            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1]
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, DEFAULT_PRIME - 1]
         )
         def test_should_return_bytes20(self, cairo_run, n):
             output = cairo_run("test__felt_to_bytes20", n=n)
@@ -108,7 +108,7 @@ class TestBytes:
 
     class TestUint256ToBytesLittle:
         @pytest.mark.parametrize(
-            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1, 2**256 - 1]
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, DEFAULT_PRIME - 1, 2**256 - 1]
         )
         def test_should_return_bytes(self, cairo_run, n):
             output = cairo_run("test__uint256_to_bytes_little", n=int_to_uint256(n))
@@ -117,7 +117,7 @@ class TestBytes:
 
     class TestUint256ToBytes:
         @pytest.mark.parametrize(
-            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1, 2**256 - 1]
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, DEFAULT_PRIME - 1, 2**256 - 1]
         )
         def test_should_return_bytes(self, cairo_run, n):
             output = cairo_run("test__uint256_to_bytes", n=int_to_uint256(n))
@@ -126,7 +126,7 @@ class TestBytes:
 
     class TestUint256ToBytes32:
         @pytest.mark.parametrize(
-            "n", [0, 10, 1234, 0xFFFFFF, 2**128, FELT_252_PRIME - 1, 2**256 - 1]
+            "n", [0, 10, 1234, 0xFFFFFF, 2**128, DEFAULT_PRIME - 1, 2**256 - 1]
         )
         def test_should_return_bytes(self, cairo_run, n):
             output = cairo_run("test__uint256_to_bytes32", n=int_to_uint256(n))

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -48,8 +48,6 @@ ZERO_ADDRESS = "0x" + 40 * "0"
 BLOCK_NUMBER = 0x42
 BLOCK_TIMESTAMP = int(time())
 
-FELT_252_PRIME = 0x800000000000011000000000000000000000000000000000000000000000001
-
 # Taken from eth_account.account.Account.sign_transaction docstring
 # https://eth-account.readthedocs.io/en/stable/eth_account.html?highlight=sign_transaction#eth_account.account.Account.sign_transaction
 TRANSACTIONS = [

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -48,6 +48,8 @@ ZERO_ADDRESS = "0x" + 40 * "0"
 BLOCK_NUMBER = 0x42
 BLOCK_TIMESTAMP = int(time())
 
+FELT_252_PRIME = 0x800000000000011000000000000000000000000000000000000000000000001
+
 # Taken from eth_account.account.Account.sign_transaction docstring
 # https://eth-account.readthedocs.io/en/stable/eth_account.html?highlight=sign_transaction#eth_account.account.Account.sign_transaction
 TRANSACTIONS = [


### PR DESCRIPTION
Fixes computation on high memory offsets.
The remediation proposed by the audit finding was not sufficient enough. This one looks fine, although a bit more costly (even though uint256_add is not that computationally intensive)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1604)
<!-- Reviewable:end -->
