### PR TITLE
[KGA-34] feat: update base fee starting from next block only

### DIFF
--- a/.github/workflows/cairo-zero-ci.yml
+++ b/.github/workflows/cairo-zero-ci.yml
@@ -180,6 +180,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kkrt-labs/ef-tests
+          ref: feat/update-base-fee-state
       - name: Checkout local skip file
         uses: actions/checkout@v4
         with:

--- a/cairo_zero/backend/starknet.cairo
+++ b/cairo_zero/backend/starknet.cairo
@@ -146,19 +146,15 @@ namespace Starknet {
         let (block_number) = get_block_number();
         let is_next_fee_ready = is_le(next_start_block_number, block_number);
 
-        let (res_current_block) = Kakarot_base_fee.read('current_block');
-        let current_base_fee = res_current_block[0];
-        let current_start_block_number = res_current_block[1];
-        let is_already_updated = Helpers.is_zero(
-            current_start_block_number - next_start_block_number
-        );
-
-        if (is_already_updated == FALSE and is_next_fee_ready != FALSE) {
-            Kakarot_base_fee.write('current_block', (next_base_fee, next_start_block_number));
+        if (next_start_block_number != 0 and is_next_fee_ready != FALSE) {
+            // update current_block storage and return next_block value
+            Kakarot_base_fee.write('current_block', (next_base_fee, block_number));
+            Kakarot_base_fee.write('next_block', (0, 0));
             return (next_base_fee,);
         }
 
-        return (current_base_fee,);
+        let (res_current_block) = Kakarot_base_fee.read('current_block');
+        return (res_current_block[0],);
     }
 }
 

--- a/cairo_zero/kakarot/library.cairo
+++ b/cairo_zero/kakarot/library.cairo
@@ -179,7 +179,7 @@ namespace Kakarot {
             return ();
         }
 
-        Kakarot_base_fee.write('current_block', (base_fee, starting_block));
+        Kakarot_base_fee.write('current_block', (next_base_fee, starting_block));
         return ();
     }
 

--- a/cairo_zero/kakarot/storages.cairo
+++ b/cairo_zero/kakarot/storages.cairo
@@ -28,8 +28,12 @@ func Kakarot_evm_to_starknet_address(evm_address: felt) -> (starknet_address: fe
 func Kakarot_coinbase() -> (res: felt) {
 }
 
+// @notice The base fee set for kakarot
+// @dev There can only be one base fee for a given block. Thus, we use an index to manage two different base fees:
+// - The base fee to use for the current block (index: 'current_block')
+// - The base fee to applicable starting next block (index: 'next_block')
 @storage_var
-func Kakarot_base_fee() -> (res: felt) {
+func Kakarot_base_fee(index: felt) -> ((base_fee: felt, block_number: felt),) {
 }
 
 @storage_var

--- a/cairo_zero/tests/src/kakarot/test_kakarot.cairo
+++ b/cairo_zero/tests/src/kakarot/test_kakarot.cairo
@@ -162,6 +162,11 @@ func test__set_base_fee{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
     return ();
 }
 
+func test__get_base_fee{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+    let (base_fee) = Kakarot.get_base_fee();
+    return base_fee;
+}
+
 func test__set_prev_randao{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
     tempvar prev_randao;
 

--- a/cairo_zero/tests/src/kakarot/test_kakarot.py
+++ b/cairo_zero/tests/src/kakarot/test_kakarot.py
@@ -276,21 +276,6 @@ class TestKakarot:
             base_fee = cairo_run("test__get_base_fee")
             assert base_fee == 2
 
-            # Should read the value from next_block
-            SyscallHandler.mock_storage.assert_any_call(
-                address=get_storage_var_address(
-                    "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
-                ),
-                value=base_fee,
-            )
-            SyscallHandler.mock_storage.assert_any_call(
-                address=get_storage_var_address(
-                    "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
-                )
-                + 1,
-                value=0x101,
-            )
-
             # Should update current block base fee
             SyscallHandler.mock_storage.assert_any_call(
                 address=get_storage_var_address(
@@ -304,6 +289,21 @@ class TestKakarot:
                 )
                 + 1,
                 value=0x101,
+            )
+
+            # Should nullify the value from next_block
+            SyscallHandler.mock_storage.assert_any_call(
+                address=get_storage_var_address(
+                    "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
+                ),
+                value=0,
+            )
+            SyscallHandler.mock_storage.assert_any_call(
+                address=get_storage_var_address(
+                    "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
+                )
+                + 1,
+                value=0,
             )
 
     class TestCoinbase:

--- a/cairo_zero/tests/src/kakarot/test_kakarot.py
+++ b/cairo_zero/tests/src/kakarot/test_kakarot.py
@@ -833,6 +833,19 @@ class TestKakarot:
                 )
 
         @SyscallHandler.patch("Kakarot_block_gas_limit", TRANSACTION_GAS_LIMIT)
+        @SyscallHandler.patch(
+            get_storage_var_address(
+                "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
+            ),
+            value=TRANSACTION_GAS_LIMIT * 10**10,
+        )
+        @SyscallHandler.patch(
+            get_storage_var_address(
+                "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
+            )
+            + 1,
+            value=0x100,
+        )
         @SyscallHandler.patch("Kakarot_base_fee", TRANSACTION_GAS_LIMIT * 10**10)
         @SyscallHandler.patch("Kakarot_chain_id", CHAIN_ID)
         @pytest.mark.parametrize("tx", TRANSACTIONS)

--- a/cairo_zero/tests/src/kakarot/test_kakarot.py
+++ b/cairo_zero/tests/src/kakarot/test_kakarot.py
@@ -165,14 +165,7 @@ class TestKakarot:
             get_storage_var_address(
                 "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
             ),
-            value=1,
-        )
-        @SyscallHandler.patch(
-            get_storage_var_address(
-                "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
-            )
-            + 1,
-            value=0x101,
+            value=[1, 0x101],
         )
         @patch.object(SyscallHandler, "block_number", 0x102)
         def test_set_base_fee_should_overwrite_current_block_fee_if_next_block_is_applicable(
@@ -213,27 +206,13 @@ class TestKakarot:
             get_storage_var_address(
                 "Kakarot_base_fee", int.from_bytes(b"current_block", "big")
             ),
-            value=1,
-        )
-        @SyscallHandler.patch(
-            get_storage_var_address(
-                "Kakarot_base_fee", int.from_bytes(b"current_block", "big")
-            )
-            + 1,
-            value=0x100,
+            value=[1, 0x100],
         )
         @SyscallHandler.patch(
             get_storage_var_address(
                 "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
             ),
-            value=2,
-        )
-        @SyscallHandler.patch(
-            get_storage_var_address(
-                "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
-            )
-            + 1,
-            value=0x101,
+            value=[2, 0x101],
         )
         @patch.object(SyscallHandler, "block_number", 0x100)
         def test_get_base_fee_should_return_current_block_fee_if_next_block_is_not_applicable(
@@ -247,27 +226,13 @@ class TestKakarot:
             get_storage_var_address(
                 "Kakarot_base_fee", int.from_bytes(b"current_block", "big")
             ),
-            value=1,
-        )
-        @SyscallHandler.patch(
-            get_storage_var_address(
-                "Kakarot_base_fee", int.from_bytes(b"current_block", "big")
-            )
-            + 1,
-            value=0x100,
+            value=[1, 0x100],
         )
         @SyscallHandler.patch(
             get_storage_var_address(
                 "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
             ),
-            value=2,
-        )
-        @SyscallHandler.patch(
-            get_storage_var_address(
-                "Kakarot_base_fee", int.from_bytes(b"next_block", "big")
-            )
-            + 1,
-            value=0x101,
+            value=[2, 0x101],
         )
         @patch.object(SyscallHandler, "block_number", 0x101)
         def test_get_base_fee_should_return_next_block_fee_if_applicable_and_update_current_block(

--- a/tests/utils/syscall_handler.py
+++ b/tests/utils/syscall_handler.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import Optional, Union
+from typing import Iterable, Optional, Union
 from unittest import mock
 
 import ecdsa
@@ -609,7 +609,13 @@ class SyscallHandler:
                 selector_if_storage = get_storage_var_address(target, *args)
             else:
                 selector_if_storage = target
-            cls.patches[selector_if_storage] = value
+
+            if isinstance(value, Iterable):
+                for i, v in enumerate(value):
+                    cls.patches[selector_if_storage + i] = v
+            else:
+                cls.patches[selector_if_storage] = value
+
         except AssertionError:
             pass
 


### PR DESCRIPTION
Updates the base fee mechanism.

In the EVM there can only be one base fee for a given block.
Thus, we use an index to manage two different base fees:
     - The base fee to use for the current block (index: 'current_block')
     - The base fee to use for the next block (index: 'next_block')
     
The startegy is:
- when getting the base fee, check if you can get the one from the 'next_block' (if block_number > next_fee_start_block_number)
- if yes, then update the value in `current_block` and return the new value
- otherwise, return the value from `current_block`     

When setting the base_fee, it will be applicable starting from `block_number + 1`.

Note: for tests we have to manually patch both `addr` and `addr+1` as we'restoring two values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1606)
<!-- Reviewable:end -->
