### PR TITLE
[KGA-64] dev: remove dead code in exec_create

### DIFF
--- a/cairo_zero/kakarot/instructions/system_operations.cairo
+++ b/cairo_zero/kakarot/instructions/system_operations.cairo
@@ -190,11 +190,9 @@ namespace SystemOperations {
         State.update_account(target_account);
 
         let transfer = model.Transfer(evm.message.address, target_account.address, [value]);
-        let success = State.add_transfer(transfer);
-        if (success == 0) {
-            Stack.push_uint128(0);
-            return child_evm;
-        }
+
+        // @dev: This transfer cannot fail, as the balance was checked before.
+        let _success = State.add_transfer(transfer);
 
         return child_evm;
     }


### PR DESCRIPTION
Removes a portion of dead code that cheks the return value of the `add_transfer` function in `exec_create`. Because the case where the sender doesn't have enough balance is manually handled before, this branch can not be executed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1611)
<!-- Reviewable:end -->
