### PR TITLE
[KGA-72] fix: return uncapped return_data_len from execute_from_outside

### DIFF
--- a/cairo_zero/kakarot/accounts/library.cairo
+++ b/cairo_zero/kakarot/accounts/library.cairo
@@ -223,11 +223,16 @@ namespace AccountContract {
         // See 300 max data_len for events
         // https://github.com/starkware-libs/blockifier/blob/9bfb3d4c8bf1b68a0c744d1249b32747c75a4d87/crates/blockifier/resources/versioned_constants.json
         // The whole data_len should be less than 300, so it's the return_data should be less than 297 (+3 for return_data_len, success, gas_used)
-        tempvar return_data_len = is_nn(297 - return_data_len) * (return_data_len - 297) + 297;
+        tempvar capped_return_data_len = is_nn(297 - return_data_len) * (return_data_len - 297) +
+            297;
         transaction_executed.emit(
-            response_len=return_data_len, response=return_data, success=success, gas_used=gas_used
+            response_len=capped_return_data_len,
+            response=return_data,
+            success=success,
+            gas_used=gas_used,
         );
 
+        // Return the unmodified return_data_len.
         return (response_len=return_data_len, response=return_data);
     }
 


### PR DESCRIPTION
The event is emitted with at most 297 felts of response_len, but the function returns the full data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot/1612)
<!-- Reviewable:end -->
