### PR TITLE
fix: fixed foundry version to a working one

### DIFF
--- a/.github/workflows/cairo-zero-ci.yml
+++ b/.github/workflows/cairo-zero-ci.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-a79dfaed6fc6f88cda5f314a25d1b484d9d8c051
       - name: Run tests
         env:
           HYPOTHESIS_PROFILE: ci
@@ -138,7 +138,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-a79dfaed6fc6f88cda5f314a25d1b484d9d8c051
       - uses: asdf-vm/actions/install@v3
       - name: Load cached katana
         id: cached-katana
@@ -163,7 +163,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-a79dfaed6fc6f88cda5f314a25d1b484d9d8c051
       - name: Install deps
         run: forge install
       - name: Run tests

--- a/.github/workflows/cairo-zero-nightly-fuzzing.yml
+++ b/.github/workflows/cairo-zero-nightly-fuzzing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-a79dfaed6fc6f88cda5f314a25d1b484d9d8c051
       - name: Run tests
         run: |
           make setup-ci

--- a/kakarot_scripts/setup/setup.py
+++ b/kakarot_scripts/setup/setup.py
@@ -103,7 +103,7 @@ def setup_local() -> None:
 
     install_dependency(
         "foundry",
-        "curl -L https://foundry.paradigm.xyz | bash && exec $SHELL && foundryup",
+        "curl -L https://foundry.paradigm.xyz | bash && exec $SHELL && foundryup -v nightly-a79dfaed6fc6f88cda5f314a25d1b484d9d8c051",
         "forge",
     )
 


### PR DESCRIPTION
Latest foundry nightly is bugged with WETH9. Fix the version to the latest working one.