### PR TITLE
[KGA-49]: fix OOB read in parse_storage_keys on malformed inputs

### DIFF
--- a/cairo_zero/utils/eth_transaction.cairo
+++ b/cairo_zero/utils/eth_transaction.cairo
@@ -290,6 +290,10 @@ namespace EthTransaction {
 
         // Address
         let address_item = cast(access_list.data, RLP.Item*);
+        with_attr error_message("Invalid address length") {
+            assert [range_check_ptr] = address_item.data_len - 20;
+        }
+        let range_check_ptr = range_check_ptr + 1;
         let address = Helpers.bytes20_to_felt(address_item.data);
 
         // List<StorageKeys>
@@ -322,6 +326,11 @@ namespace EthTransaction {
         if (keys_list_len == 0) {
             return ();
         }
+
+        with_attr error_message("Invalid storage key length") {
+            assert [range_check_ptr] = keys_list.data_len - 32;
+        }
+        let range_check_ptr = range_check_ptr + 1;
 
         let key = Helpers.bytes32_to_uint256(keys_list.data);
         assert [parsed_keys] = key.low;

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -42,6 +42,25 @@ ZERO_ADDRESS = "0x" + 40 * "0"
 BLOCK_NUMBER = 0x42
 BLOCK_TIMESTAMP = int(time())
 
+ACCESS_LIST_TRANSACTION = {
+    "type": 1,
+    "gas": 100_000,
+    "gasPrice": 1_000_000_000,
+    "data": "0x616263646566",
+    "nonce": 34,
+    "to": "0x09616C3d61b3331fc4109a9E41a8BDB7d9776609",
+    "value": 0x5AF3107A4000,
+    "accessList": (
+        {
+            "address": "0x0000000000000000000000000000000000000001",
+            "storageKeys": (
+                "0x0100000000000000000000000000000000000000000000000000000000000000",
+            ),
+        },
+    ),
+    "chainId": CHAIN_ID,
+}
+
 # Taken from eth_account.account.Account.sign_transaction docstring
 # https://eth-account.readthedocs.io/en/stable/eth_account.html?highlight=sign_transaction#eth_account.account.Account.sign_transaction
 TRANSACTIONS = [
@@ -54,24 +73,7 @@ TRANSACTIONS = [
         "chainId": CHAIN_ID,
         "data": b"",
     },
-    {
-        "type": 1,
-        "gas": 100_000,
-        "gasPrice": 1_000_000_000,
-        "data": "0x616263646566",
-        "nonce": 34,
-        "to": "0x09616C3d61b3331fc4109a9E41a8BDB7d9776609",
-        "value": 0x5AF3107A4000,
-        "accessList": (
-            {
-                "address": "0x0000000000000000000000000000000000000001",
-                "storageKeys": (
-                    "0x0100000000000000000000000000000000000000000000000000000000000000",
-                ),
-            },
-        ),
-        "chainId": CHAIN_ID,
-    },
+    ACCESS_LIST_TRANSACTION,
     # Access list with two addresses
     {
         "type": 1,


### PR DESCRIPTION
Fixes an [issue](https://github.com/code-423n4/2024-09-kakarot-findings/issues/81) where parsing malformed access lists could have undefined behavior due to OOB reads. This had no impact on the protocol whatsoever and could only discard the benefits from eip2930

