### PR TITLE
dev: initialize chain-id after upgrade

### DIFF
--- a/kakarot_scripts/deployment/kakarot_deployment.py
+++ b/kakarot_scripts/deployment/kakarot_deployment.py
@@ -12,6 +12,7 @@ from kakarot_scripts.constants import (
     RPC_CLIENT,
     NetworkType,
 )
+from kakarot_scripts.utils.kakarot import eth_chain_id
 from kakarot_scripts.utils.starknet import deploy as deploy_starknet
 from kakarot_scripts.utils.starknet import (
     dump_deployments,
@@ -52,6 +53,11 @@ async def deploy_or_upgrade_kakarot(owner):
                 "set_cairo1_helpers_class_hash",
                 class_hash["Cairo1Helpers"],
             )
+
+        # Initialize the chain_id if it's value is not set
+        if await eth_chain_id() == 0:
+            await invoke("kakarot", "initialize_chain_id", NETWORK["chain_id"])
+
         else:
             logger.info("✅ Kakarot already up to date.")
     else:

--- a/kakarot_scripts/utils/kakarot.py
+++ b/kakarot_scripts/utils/kakarot.py
@@ -700,7 +700,7 @@ async def eth_send_transaction(
 
     payload = {
         "type": 0x1,
-        "chainId": await eth_chain_id(),
+        "chainId": NETWORK["chain_id"],
         "nonce": nonce,
         "gas": gas,
         "gasPrice": gas_price,


### PR DESCRIPTION
Initializes the chain_id after upgrading kakarot if it's unset
Fixes an issue where eth_send_transaction would use the `eth_chain_id()` of the network instead of the one that is defined in the constants, leading to tests passing even though the onchain `chain_id` was not correct

Closes #1629