### PR TITLE
dev: load previous db when testing with katana

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+katana-db/ filter=lfs diff=lfs merge=lfs -text
+katana-db/db.version filter=lfs diff=lfs merge=lfs -text
+katana-db/mdbx.dat filter=lfs diff=lfs merge=lfs -text
+katana-db/mdbx.lck filter=lfs diff=lfs merge=lfs -text

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build-sol:
 	forge build --names --force
 
 run-katana:
-	katana --chain-id test --validate-max-steps 1000000 --invoke-max-steps 9000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --seed 0
+	katana --chain-id test --validate-max-steps 1000000 --invoke-max-steps 9000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --seed 0 --db-dir ./katana-db
 
 run-anvil:
 	anvil --block-base-fee-per-gas 1
@@ -101,4 +101,4 @@ run-anvil:
 run-nodes:
 	@echo "Starting Anvil and Katana in messaging mode"
 	@anvil --block-base-fee-per-gas 1 &
-	@katana --chain-id test --validate-max-steps 1000000 --invoke-max-steps 9000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --messaging .katana/messaging_config.json --seed 0
+	@katana --chain-id test --validate-max-steps 1000000 --invoke-max-steps 9000000 --eth-gas-price 0 --strk-gas-price 0 --disable-fee --messaging .katana/messaging_config.json --seed 0 --db-dir ./katana-db

--- a/kakarot_scripts/deployment/kakarot_deployment.py
+++ b/kakarot_scripts/deployment/kakarot_deployment.py
@@ -34,8 +34,18 @@ async def deploy_or_upgrade_kakarot(owner):
     class_hash = get_declarations()
     starknet_deployments = get_deployments()
 
+    if starknet_deployments.get("kakarot"):
+        try:
+            deployed_class_hash = await RPC_CLIENT.get_class_hash_at(
+                starknet_deployments["kakarot"]
+            )
+        except Exception:
+            deployed_class_hash = None
+    else:
+        deployed_class_hash = None
+
     # Deploy or upgrade Kakarot
-    if starknet_deployments.get("kakarot") and NETWORK["type"] is not NetworkType.DEV:
+    if deployed_class_hash:
         logger.info("ℹ️  Kakarot already deployed, checking version.")
         deployed_class_hash = await RPC_CLIENT.get_class_hash_at(
             starknet_deployments["kakarot"]

--- a/kakarot_scripts/deployment/kakarot_deployment.py
+++ b/kakarot_scripts/deployment/kakarot_deployment.py
@@ -10,7 +10,6 @@ from kakarot_scripts.constants import (
     EVM_ADDRESS,
     NETWORK,
     RPC_CLIENT,
-    NetworkType,
 )
 from kakarot_scripts.utils.starknet import deploy as deploy_starknet
 from kakarot_scripts.utils.starknet import (

--- a/katana-db/db.version
+++ b/katana-db/db.version
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b40711a88c7039756fb8a73827eabe2c0fe5a0346ca7e0a104adc0fc764f528d
+size 4

--- a/katana-db/mdbx.dat
+++ b/katana-db/mdbx.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71e8172d048b333594096bb94df215dbf8395e064c56a11585f9cf91dff3ffc9
+size 4294967296

--- a/katana-db/mdbx.lck
+++ b/katana-db/mdbx.lck
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0679e4ebe120eae7b043304ca2405d833eea627acbb40db86ea3ab5b2bd8a503
+size 1032192


### PR DESCRIPTION
Use `git lfs` to track a `katana-db` that contains the previous committed state for a Katana instance.

This ensures that e2e tests are ran against a katana version that has an already existing kakarot, and upgrades go well. For example, it helped notice that https://github.com/kkrt-labs/kakarot/pull/1631 didn't update an existing deployment's chain_id automatically.