### PR TITLE
fix: broken links README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ future of zero-knowledge.
 ## Supported opcodes
 
 We support 100% of EVM opcodes and
-[9 out of 10 precompiles](https://docs.kakarot.org/starknet/architecture/differences).
+[9 out of 10 precompiles](https://docs.kakarot.org/starknet/architecture/cairo-precompiles).
 
 ## Documentation
 
@@ -176,7 +176,7 @@ required. Actually, for tests requiring a Starknet devnet, prefer end-to-end
 relying only on a RPC endpoint and currently running on Katana.
 
 For an example of the cairo test runner, see for example
-[the RLP library tests](tests/src/utils/test_rlp.py). Especially, the cairo
+[the RLP library tests](./cairo_zero/tests/src/utils/test_rlp.py). Especially, the cairo
 runner uses hints to communicate values and return outputs:
 
 - `kwargs` of `cairo_run` are available in the `program_input` variable
@@ -240,7 +240,7 @@ Note that the chosen `chain_id` when deploying is important:
 - To be compatible with ledger the chain id needs to be inferior to 4 bytes see
   https://github.com/kkrt-labs/kakarot/issues/1530
 
-The [deploy script](./kakarot_scripts/deploy_kakarot.py) relies on some env
+The [deploy script](./kakarot_scripts/deployment/kakarot_deployment.py) relies on some env
 variables defined in a `.env` file located at the root of the project and loaded
 in the [constant file](./kakarot_scripts/constants.py). To get started, just
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ required. Actually, for tests requiring a Starknet devnet, prefer end-to-end
 relying only on a RPC endpoint and currently running on Katana.
 
 For an example of the cairo test runner, see for example
-[the RLP library tests](./cairo_zero/tests/src/utils/test_rlp.py). Especially, the cairo
-runner uses hints to communicate values and return outputs:
+[the RLP library tests](./cairo_zero/tests/src/utils/test_rlp.py). Especially,
+the cairo runner uses hints to communicate values and return outputs:
 
 - `kwargs` of `cairo_run` are available in the `program_input` variable
 - values written in the `output_ptr` segment are returned, e.g.
@@ -240,9 +240,10 @@ Note that the chosen `chain_id` when deploying is important:
 - To be compatible with ledger the chain id needs to be inferior to 4 bytes see
   https://github.com/kkrt-labs/kakarot/issues/1530
 
-The [deploy script](./kakarot_scripts/deployment/kakarot_deployment.py) relies on some env
-variables defined in a `.env` file located at the root of the project and loaded
-in the [constant file](./kakarot_scripts/constants.py). To get started, just
+The [deploy script](./kakarot_scripts/deployment/kakarot_deployment.py) relies
+on some env variables defined in a `.env` file located at the root of the
+project and loaded in the [constant file](./kakarot_scripts/constants.py). To
+get started, just
 
 ```bash
 cp .env.example .env


### PR DESCRIPTION
## Description
This PR fixes broken links in the `README.md` file to ensure all references point to the correct resources.

## Time spent on this PR
0.2 days

## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Current behavior
Currently, some links in the `README.md` are outdated or broken, causing navigation issues for readers.

Resolves: No linked issue

## New behavior
- Updated the precompiles link to point to the correct `cairo-precompiles` page.
- Fixed the test RLP library link to use the correct relative path.
- Updated the deploy script link to point to the correct file location.
