### PR TITLE
feat: ProtocolHandler self management functions

### DIFF
--- a/cairo/protocol_handler/.gitignore
+++ b/cairo/protocol_handler/.gitignore
@@ -1,1 +1,4 @@
 target
+.snfoundry_versioned_programs/
+coverage/
+snfoundry_trace/

--- a/cairo/protocol_handler/Scarb.toml
+++ b/cairo/protocol_handler/Scarb.toml
@@ -12,6 +12,7 @@ openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", ta
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.31.0" }
 snforge_utils = { path = "../snforge_utils" }
+assert_macros = "2.8.2"
 
 [[target.starknet-contract]]
 casm = true
@@ -19,3 +20,9 @@ casm-add-pythonic-hints = true
 
 [scripts]
 test = "snforge test"
+test-coverage = "snforge test --coverage"
+
+[profile.dev.cairo]
+unstable-add-statements-code-locations-debug-info = true
+unstable-add-statements-functions-debug-info = true
+inlining-strategy = "avoid"

--- a/cairo/protocol_handler/tests/test_protocol_handler.cairo
+++ b/cairo/protocol_handler/tests/test_protocol_handler.cairo
@@ -656,13 +656,11 @@ fn test_protocol_handler_change_operator_should_pass() {
     let access_control_dispatcher = IAccessControlDispatcher {
         contract_address: protocol_handler.contract_address
     };
-    assert(
+    assert!(
         !access_control_dispatcher.has_role(ProtocolHandler::OPERATOR_ROLE, operator_mock()),
-        'Old operator not revoked'
     );
-    assert(
+    assert!(
         access_control_dispatcher.has_role(ProtocolHandler::OPERATOR_ROLE, new_operator),
-        'New operator not granted'
     );
 
     // Check the Access control related events are emitted
@@ -688,7 +686,7 @@ fn test_protocol_handler_change_operator_should_pass() {
 
     // Check the new operator is set in the contract state
     let loaded = load(protocol_handler.contract_address, selector!("operator"), 1);
-    assert_eq!(*loaded[0], new_operator.into(), "New operator not set");
+    assert_eq!(*loaded[0], new_operator.into());
 }
 
 

--- a/cairo/protocol_handler/tests/test_protocol_handler.cairo
+++ b/cairo/protocol_handler/tests/test_protocol_handler.cairo
@@ -1,6 +1,7 @@
 use snforge_std::{
     ContractClassTrait, ContractClass, declare, DeclareResultTrait, EventSpyTrait,
-    start_cheat_block_timestamp_global, start_cheat_caller_address, mock_call, spy_events, store
+    start_cheat_block_timestamp_global, start_cheat_caller_address, mock_call, spy_events, store,
+    load
 };
 use starknet::{ContractAddress, contract_address_const, get_block_timestamp};
 use starknet::account::Call;
@@ -12,6 +13,13 @@ use protocol_handler::{
 use snforge_utils::snforge_utils::{
     EventsFilterBuilderTrait, ContractEventsTrait, assert_called_with
 };
+
+use openzeppelin_access::accesscontrol::AccessControlComponent;
+use openzeppelin_access::accesscontrol::AccessControlComponent::{
+    InternalImpl, RoleGranted, RoleRevoked
+};
+use openzeppelin_access::accesscontrol::interface::IAccessControlDispatcher;
+use openzeppelin_access::accesscontrol::interface::IAccessControlDispatcherTrait;
 
 fn kakarot_mock() -> ContractAddress {
     contract_address_const::<'security_council_mock'>()
@@ -141,6 +149,7 @@ fn test_protocol_upgrade_fail_wrong_caller() {
     protocol_handler.upgrade(contract.class_hash);
 }
 
+#[test]
 fn test_protocol_upgrade_should_pass() {
     let (protocol_handler, contract) = setup_contracts_for_testing();
 
@@ -565,7 +574,6 @@ fn test_protocol_handler_execute_call_wrong_selector_should_fail() {
         }
 }
 
-
 #[test]
 fn test_protocol_handler_execute_call_should_pass() {
     let (protocol_handler, _) = setup_contracts_for_testing();
@@ -614,4 +622,314 @@ fn test_protocol_handler_execute_call_should_pass() {
                 .build();
             contract_events.assert_emitted(@expected);
         }
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_protocol_handler_change_operator_should_fail_wrong_caller() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to random caller address
+    let random_caller = contract_address_const::<'random_caller'>();
+    start_cheat_caller_address(protocol_handler.contract_address, random_caller);
+
+    // Call the protocol handler change_operator, should fail as caller is not security council
+    let new_operator = contract_address_const::<'new_operator'>();
+    protocol_handler.change_operator(new_operator);
+}
+
+#[test]
+fn test_protocol_handler_change_operator_should_pass() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to security council
+    start_cheat_caller_address(protocol_handler.contract_address, security_council_mock());
+
+    // Spy on the events
+    let mut spy = spy_events();
+
+    // Call the protocol handler change_operator
+    let new_operator = contract_address_const::<'new_operator'>();
+    protocol_handler.change_operator(new_operator);
+
+    // Check the old operator is revoked and the new operator is granted
+    let access_control_dispatcher = IAccessControlDispatcher {
+        contract_address: protocol_handler.contract_address
+    };
+    assert(
+        !access_control_dispatcher.has_role(ProtocolHandler::OPERATOR_ROLE, operator_mock()),
+        'Old operator not revoked'
+    );
+    assert(
+        access_control_dispatcher.has_role(ProtocolHandler::OPERATOR_ROLE, new_operator),
+        'New operator not granted'
+    );
+
+    // Check the Access control related events are emitted
+    let expected_revoked = AccessControlComponent::Event::RoleRevoked(
+        RoleRevoked {
+            role: ProtocolHandler::OPERATOR_ROLE,
+            account: operator_mock(),
+            sender: security_council_mock()
+        }
+    );
+    let expected_granted = AccessControlComponent::Event::RoleGranted(
+        RoleGranted {
+            role: ProtocolHandler::OPERATOR_ROLE,
+            account: new_operator,
+            sender: security_council_mock()
+        }
+    );
+    let contract_events = EventsFilterBuilderTrait::from_events(@spy.get_events())
+        .with_contract_address(protocol_handler.contract_address)
+        .build();
+    contract_events.assert_emitted(@expected_revoked);
+    contract_events.assert_emitted(@expected_granted);
+
+    // Check the new operator is set in the contract state
+    let loaded = load(protocol_handler.contract_address, selector!("operator"), 1);
+    assert_eq!(*loaded[0], new_operator.into(), "New operator not set");
+}
+
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_protocol_handler_change_security_council_should_fail_wrong_caller() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to random caller address
+    let random_caller = contract_address_const::<'random_caller'>();
+    start_cheat_caller_address(protocol_handler.contract_address, random_caller);
+
+    // Call the protocol handler change_security_council, should fail as caller is not security
+    // council
+    let new_security_council = contract_address_const::<'new_security_council'>();
+    protocol_handler.change_security_council(new_security_council);
+}
+
+#[test]
+fn test_protocol_handler_change_security_council_should_pass() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to security council
+    start_cheat_caller_address(protocol_handler.contract_address, security_council_mock());
+
+    // Spy on the events
+    let mut spy = spy_events();
+
+    // Call the protocol handler change_security_council
+    let new_security_council = contract_address_const::<'new_security_council'>();
+    protocol_handler.change_security_council(new_security_council);
+
+    // Check the old security council is revoked and the new security council is granted
+    let access_control_dispatcher = IAccessControlDispatcher {
+        contract_address: protocol_handler.contract_address
+    };
+    assert(
+        !access_control_dispatcher
+            .has_role(ProtocolHandler::SECURITY_COUNCIL_ROLE, security_council_mock()),
+        'Old SC not revoked'
+    );
+    assert(
+        access_control_dispatcher
+            .has_role(ProtocolHandler::SECURITY_COUNCIL_ROLE, new_security_council),
+        'New SC not granted'
+    );
+
+    // Check the Access control related events are emitted
+    let expected_revoked = AccessControlComponent::Event::RoleRevoked(
+        RoleRevoked {
+            role: ProtocolHandler::SECURITY_COUNCIL_ROLE,
+            account: security_council_mock(),
+            sender: security_council_mock()
+        }
+    );
+    let expected_granted = AccessControlComponent::Event::RoleGranted(
+        RoleGranted {
+            role: ProtocolHandler::SECURITY_COUNCIL_ROLE,
+            account: new_security_council,
+            sender: security_council_mock()
+        }
+    );
+    let contract_events = EventsFilterBuilderTrait::from_events(@spy.get_events())
+        .with_contract_address(protocol_handler.contract_address)
+        .build();
+    contract_events.assert_emitted(@expected_revoked);
+    contract_events.assert_emitted(@expected_granted);
+
+    // Check the new security council is set in the contract state
+    let loaded = load(protocol_handler.contract_address, selector!("security_council"), 1);
+    assert_eq!(*loaded[0], new_security_council.into(), "New SC not set");
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_protocol_handler_change_gas_price_admin_should_fail_wrong_caller() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to random caller address
+    let random_caller = contract_address_const::<'random_caller'>();
+    start_cheat_caller_address(protocol_handler.contract_address, random_caller);
+
+    // Call the protocol handler change_gas_price_admin, should fail as caller is not security
+    // council
+    let new_gas_price_admin = contract_address_const::<'new_gas_price_admin'>();
+    protocol_handler.change_gas_price_admin(new_gas_price_admin);
+}
+
+#[test]
+fn test_protocol_handler_change_gas_price_admin_should_pass() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to security council
+    start_cheat_caller_address(protocol_handler.contract_address, security_council_mock());
+
+    // Spy on the events
+    let mut spy = spy_events();
+
+    // Call the protocol handler change_gas_price_admin
+    let new_gas_price_admin = contract_address_const::<'new_gas_price_admin'>();
+    protocol_handler.change_gas_price_admin(new_gas_price_admin);
+
+    // Check the old gas price admin is revoked and the new gas price admin is granted
+    let access_control_dispatcher = IAccessControlDispatcher {
+        contract_address: protocol_handler.contract_address
+    };
+    assert(
+        !access_control_dispatcher
+            .has_role(ProtocolHandler::GAS_PRICE_ADMIN_ROLE, gas_price_admin_mock()),
+        'Old GPA not revoked'
+    );
+    assert(
+        access_control_dispatcher
+            .has_role(ProtocolHandler::GAS_PRICE_ADMIN_ROLE, new_gas_price_admin),
+        'New GPA not granted'
+    );
+
+    // Check the Access control related events are emitted
+    let expected_revoked = AccessControlComponent::Event::RoleRevoked(
+        RoleRevoked {
+            role: ProtocolHandler::GAS_PRICE_ADMIN_ROLE,
+            account: gas_price_admin_mock(),
+            sender: security_council_mock()
+        }
+    );
+    let expected_granted = AccessControlComponent::Event::RoleGranted(
+        RoleGranted {
+            role: ProtocolHandler::GAS_PRICE_ADMIN_ROLE,
+            account: new_gas_price_admin,
+            sender: security_council_mock()
+        }
+    );
+    let contract_events = EventsFilterBuilderTrait::from_events(@spy.get_events())
+        .with_contract_address(protocol_handler.contract_address)
+        .build();
+    contract_events.assert_emitted(@expected_revoked);
+    contract_events.assert_emitted(@expected_granted);
+
+    // Check the new  gas price admin is set in the contract state
+    let loaded = load(protocol_handler.contract_address, selector!("gas_price_admin"), 1);
+    assert_eq!(*loaded[0], new_gas_price_admin.into(), "New GPA not set");
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_protocol_handler_add_guardian_should_fail_wrong_caller() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to random caller address
+    let random_caller = contract_address_const::<'random_caller'>();
+    start_cheat_caller_address(protocol_handler.contract_address, random_caller);
+
+    // Call the protocol handler add_guardian, should fail as caller is not security council
+    let new_guardian = contract_address_const::<'new_guardian'>();
+    protocol_handler.add_guardian(new_guardian);
+}
+
+#[test]
+fn test_protocol_handler_add_guardian_should_pass() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to security council
+    start_cheat_caller_address(protocol_handler.contract_address, security_council_mock());
+
+    // Spy on the events
+    let mut spy = spy_events();
+
+    // Call the protocol handler add_guardian
+    let new_guardian = contract_address_const::<'new_guardian'>();
+    protocol_handler.add_guardian(new_guardian);
+
+    // Check the new guardian is granted
+    let access_control_dispatcher = IAccessControlDispatcher {
+        contract_address: protocol_handler.contract_address
+    };
+    assert(
+        access_control_dispatcher.has_role(ProtocolHandler::GUARDIAN_ROLE, new_guardian),
+        'New guardian not granted'
+    );
+
+    // Check the Access control related events are emitted
+    let expected_granted = AccessControlComponent::Event::RoleGranted(
+        RoleGranted {
+            role: ProtocolHandler::GUARDIAN_ROLE,
+            account: new_guardian,
+            sender: security_council_mock()
+        }
+    );
+    let contract_events = EventsFilterBuilderTrait::from_events(@spy.get_events())
+        .with_contract_address(protocol_handler.contract_address)
+        .build();
+    contract_events.assert_emitted(@expected_granted);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is missing role')]
+fn test_protocol_handler_remove_guardian_should_fail_wrong_caller() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to random caller address
+    let random_caller = contract_address_const::<'random_caller'>();
+    start_cheat_caller_address(protocol_handler.contract_address, random_caller);
+
+    // Call the protocol handler remove_guardian, should fail as caller is not security council
+    let guardian = guardians_mock()[0];
+    protocol_handler.remove_guardian(*guardian);
+}
+
+#[test]
+fn test_protocol_handler_remove_guardian_should_pass() {
+    let (protocol_handler, _) = setup_contracts_for_testing();
+
+    // Change caller to security council
+    start_cheat_caller_address(protocol_handler.contract_address, security_council_mock());
+
+    // Spy on the events
+    let mut spy = spy_events();
+
+    // Call the protocol handler remove_guardian
+    let guardian = guardians_mock()[0];
+    protocol_handler.remove_guardian(*guardian);
+
+    // Check the guardian is revoked
+    let access_control_dispatcher = IAccessControlDispatcher {
+        contract_address: protocol_handler.contract_address
+    };
+    assert(
+        !access_control_dispatcher.has_role(ProtocolHandler::GUARDIAN_ROLE, *guardian),
+        'Guardian not revoked'
+    );
+
+    // Check the Access control related events are emitted
+    let expected_revoked = AccessControlComponent::Event::RoleRevoked(
+        RoleRevoked {
+            role: ProtocolHandler::GUARDIAN_ROLE,
+            account: *guardian,
+            sender: security_council_mock()
+        }
+    );
+    let contract_events = EventsFilterBuilderTrait::from_events(@spy.get_events())
+        .with_contract_address(protocol_handler.contract_address)
+        .build();
+    contract_events.assert_emitted(@expected_revoked);
 }


### PR DESCRIPTION
## What is the new behavior?

- Add the self management function for the ProtocolHandler
- Introduces cairo-coverage for snfoundry and assert_macros
```rust
// Self management
* fn change_operator(new_address_operator: ContractAddress) SECURITY_COUNCIL
* fn change_security_council(new_security_council_address: ContractAddress) SECURITY_COUNCIL
* fn add_guardian(new_guardians_address: ContractAddress) SECURITY_COUNCIL
* fn remove_guardian(guardian_to_remove_address: ContractAddress) SECURITY_COUNCIL
* fn change_gas_price_admin(new_gas_price_admin: ContractAddres) SECURITY_COUNCIL
```
