### PR TITLE
fix: do not store code hash for EOAs

### DIFF
--- a/cairo_zero/backend/starknet.cairo
+++ b/cairo_zero/backend/starknet.cairo
@@ -205,10 +205,6 @@ namespace Internals {
         if (starknet_account_exists == 0) {
             // Deploy account
             Starknet.deploy(self.address.evm);
-            // Commit the code hash upon deployment
-            // of a new account, in all cases.
-            // Retrieved in `fetch_or_create` in the next transaction.
-            IAccount.set_code_hash(starknet_address, [self.code_hash]);
             tempvar syscall_ptr = syscall_ptr;
             tempvar pedersen_ptr = pedersen_ptr;
             tempvar range_check_ptr = range_check_ptr;

--- a/cairo_zero/kakarot/account.cairo
+++ b/cairo_zero/kakarot/account.cairo
@@ -123,10 +123,7 @@ namespace Account {
             tempvar address = new model.Address(starknet=starknet_address, evm=evm_address);
             let balance = fetch_balance(address);
             assert balance_ptr = new Uint256(balance.low, balance.high);
-            // empty code hash see https://eips.ethereum.org/EIPS/eip-1052
-            tempvar code_hash_ptr = new Uint256(
-                low=Constants.EMPTY_CODE_HASH_LOW, high=Constants.EMPTY_CODE_HASH_HIGH
-            );
+            tempvar code_hash_ptr = new Uint256(0, 0);
             let account = Account.init(
                 address=address,
                 code_len=0,

--- a/cairo_zero/kakarot/account.cairo
+++ b/cairo_zero/kakarot/account.cairo
@@ -123,12 +123,11 @@ namespace Account {
             tempvar address = new model.Address(starknet=starknet_address, evm=evm_address);
             let balance = fetch_balance(address);
             assert balance_ptr = new Uint256(balance.low, balance.high);
-            tempvar code_hash_ptr = new Uint256(0, 0);
             let account = Account.init(
                 address=address,
                 code_len=0,
                 code=bytecode,
-                code_hash=code_hash_ptr,
+                code_hash=cast(0, Uint256*),
                 nonce=0,
                 balance=balance_ptr,
             );

--- a/cairo_zero/kakarot/instructions/environmental_information.cairo
+++ b/cairo_zero/kakarot/instructions/environmental_information.cairo
@@ -11,6 +11,7 @@ from starkware.cairo.common.math_cmp import is_not_zero, is_nn
 from starkware.cairo.common.uint256 import Uint256, uint256_le
 
 from kakarot.account import Account
+from kakarot.constants import Constants
 
 from kakarot.evm import EVM
 from kakarot.errors import Errors
@@ -478,18 +479,27 @@ namespace EnvironmentalInformation {
             return evm;
         }
 
-        let account = State.get_account(evm_address);
-        let has_code_or_nonce = Account.has_code_or_nonce(account);
-        let account_exists = has_code_or_nonce + account.balance.low + account.balance.high;
         // Relevant cases:
         // https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L392
-        if (account_exists == FALSE) {
-            Stack.push_uint128(0);
+        let account = State.get_account(evm_address);
+
+        // If the account has code, return the code_hash stored in the account storage.
+        if (account.code_len != 0) {
+            Stack.push_uint256([account.code_hash]);
             return evm;
         }
 
-        Stack.push_uint256([account.code_hash]);
+        // If the account has no code but a balance or nonce, return the hash of the empty code hash.
+        if (account.nonce + account.balance.low + account.balance.high != 0) {
+            let empty_code_hash = Uint256(
+                low=Constants.EMPTY_CODE_HASH_LOW, high=Constants.EMPTY_CODE_HASH_HIGH
+            );
+            Stack.push_uint256(empty_code_hash);
+            return evm;
+        }
 
+        // Account is empty (EIP-161), return 0
+        Stack.push_uint128(0);
         return evm;
     }
 }

--- a/cairo_zero/tests/src/kakarot/test_account.cairo
+++ b/cairo_zero/tests/src/kakarot/test_account.cairo
@@ -174,7 +174,7 @@ func test__fetch_original_storage__state_modified{
     let starknet_address = Account.compute_starknet_address(evm_address);
     tempvar address = new model.Address(starknet_address, evm_address);
     let (local code: felt*) = alloc();
-    tempvar code_hash = new Uint256(Constants.EMPTY_CODE_HASH_LOW, Constants.EMPTY_CODE_HASH_HIGH);
+    tempvar code_hash = new Uint256(0, 0);
     tempvar balance = new Uint256(0, 0);
     let account = Account.init(address, 0, code, code_hash, 0, balance);
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

Code hash for eoa cannot be stored as they can change. Put the logic of 0 or empty code hash in function.
