### PR TITLE
Correct AWS Route53 patterns module name in CDK configuration

### DIFF
--- a/aws_lambda/fee_balancer/cdk.json
+++ b/aws_lambda/fee_balancer/cdk.json
@@ -30,7 +30,7 @@
     "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
     "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
     "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
-    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/aws-route53-patterns:useCertificate": true,
     "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
     "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
     "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,


### PR DESCRIPTION

## Description
This PR fixes a typo in the AWS CDK configuration where "patterns" was incorrectly spelled as "patters".

### Changes Made
File: `aws_lambda/fee_balancer/cdk.json`

"@aws-cdk/aws-route53-patters:useCertificate": true,
"@aws-cdk/aws-route53-patterns:useCertificate": true,


### Why is this important?
This fix ensures proper configuration of the AWS Route53 patterns module. The incorrect spelling could lead to the certificate configuration being ignored, potentially affecting SSL/TLS certificate management in Route53.

### Screenshots
![image](https://github.com/user-attachments/assets/9cfdecfe-5a32-476e-b6f4-5dc7dd44dabf)
> Shows the incorrect spelling "patters" in the configuration

![image](https://github.com/user-attachments/assets/dfc20066-96fa-4e62-9cbf-f8a2153a73c2)
> Shows the corrected spelling "patterns" in the configuration

### Testing
- [ ] Verified CDK deployment works with the corrected configuration
- [ ] Route53 certificate functionality remains intact