### PR TITLE
fix: remove unnecessary tx version check

### DIFF
--- a/cairo_zero/kakarot/accounts/account_contract.cairo
+++ b/cairo_zero/kakarot/accounts/account_contract.cairo
@@ -9,7 +9,6 @@ from starkware.cairo.common.math import assert_le, assert_not_zero, assert_le_fe
 from starkware.cairo.common.math_cmp import is_nn
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import (
-    get_tx_info,
     get_caller_address,
     get_block_timestamp,
     call_contract,
@@ -108,11 +107,6 @@ func execute_from_outside{
     let (caller) = get_caller_address();
     with_attr error_message("EOA: multicall not supported") {
         assert call_array_len = 1;
-    }
-    let (tx_info) = get_tx_info();
-    let version = tx_info.version;
-    with_attr error_message("Deprecated tx version: 0") {
-        assert_le(1, version);
     }
 
     // EOA validation

--- a/cairo_zero/tests/src/kakarot/accounts/test_account_contract.py
+++ b/cairo_zero/tests/src/kakarot/accounts/test_account_contract.py
@@ -579,25 +579,6 @@ class TestAccountContract:
                     signature=[],
                 )
 
-        @patch.dict(SyscallHandler.tx_info, {"version": 0})
-        def test_should_raise_when_tx_version_is_zero(self, cairo_run):
-            with cairo_error(message="Deprecated tx version: 0"):
-                cairo_run(
-                    "test__execute_from_outside_entrypoint",
-                    outside_execution={
-                        "caller": SyscallHandler.caller_address,
-                        "nonce": 0,
-                        "execute_after": 0,
-                        "execute_before": SyscallHandler.block_timestamp + 1,
-                    },
-                    call_array=[
-                        {"to": 0, "selector": 0, "data_offset": 0, "data_len": 0},
-                    ],
-                    calldata=[],
-                    calldata_len=0,
-                    signature=[],
-                )
-
         @SyscallHandler.patch("Account_bytecode_len", 1)
         def test_should_raise_when_eoa_has_code(self, cairo_run):
             with cairo_error(message="EOAs cannot have code"):


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): unnecessary check

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #<Issue number>

## What is the new behavior?

The  __execute__ function assumes that the signature validation was finished on the __validate__ function but version zero transactions can invoke any function as entrypoint without executing the validation function. The execute_from_outside function does not assume that the validation is already finished but properly performs the signature
validation in its library function