### PR TITLE
fix: revert tx if multicall input is incoherent

### DIFF
--- a/cairo_zero/kakarot/precompiles/kakarot_precompiles.cairo
+++ b/cairo_zero/kakarot/precompiles/kakarot_precompiles.cairo
@@ -150,10 +150,9 @@ namespace KakarotPrecompiles {
         ) = Internals.execute_multiple_cairo_calls(caller_address, calls_len, calls_ptr, 0);
 
         if (reverted == FALSE and nb_executed_calls != number_of_calls) {
-            let (revert_reason_len, revert_reason) = Errors.precompileInputError();
-            return (
-                revert_reason_len, revert_reason, CAIRO_PRECOMPILE_GAS, Errors.EXCEPTIONAL_HALT
-            );
+            with_attr error_message("Number of executed calls does not match precompile input") {
+                assert nb_executed_calls = number_of_calls;
+            }
         }
 
         return (output_len, output, gas_cost, reverted);

--- a/tests/end_to_end/CairoPrecompiles/test_multicall_cairo_precompile.py
+++ b/tests/end_to_end/CairoPrecompiles/test_multicall_cairo_precompile.py
@@ -5,7 +5,6 @@ import pytest_asyncio
 from eth_abi import encode
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
-from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
 
 from kakarot_scripts.utils.kakarot import deploy, eth_send_transaction
 from kakarot_scripts.utils.starknet import get_contract, invoke
@@ -94,7 +93,7 @@ class TestCairoPrecompiles:
             expected_count = new_counter + 1
             assert new_count == expected_count
 
-        @given(wrong_nb_calls=st.integers(min_value=0, max_value=DEFAULT_PRIME - 1))
+        @given(wrong_nb_calls=st.integers(min_value=0, max_value=2**8 - 1))
         async def test_should_fail_when_number_of_calls_mismatch_actual_calls(
             self, cairo_counter, owner, wrong_nb_calls
         ):
@@ -112,7 +111,7 @@ class TestCairoPrecompiles:
             ):
                 await eth_send_transaction(
                     to=f"0x{0x75003:040x}",
-                    gas=21000 + 20000 * (len(calls)),
+                    gas=21000 + 20000 * max(wrong_nb_calls, len(calls)),
                     data=tx_data,
                     value=0,
                     caller_eoa=owner.starknet_contract,

--- a/tests/end_to_end/CairoPrecompiles/test_multicall_cairo_precompile.py
+++ b/tests/end_to_end/CairoPrecompiles/test_multicall_cairo_precompile.py
@@ -107,7 +107,9 @@ class TestCairoPrecompiles:
             # modify the number of calls to be different than the actual calls
             tx_data = f"{wrong_nb_calls:064x}" + tx_data[64:]
 
-            with cairo_error("Number of executed calls does not match precompile input"):
+            with cairo_error(
+                "Number of executed calls does not match precompile input"
+            ):
                 await eth_send_transaction(
                     to=f"0x{0x75003:040x}",
                     gas=21000 + 20000 * (len(calls)),


### PR DESCRIPTION
The fix made previously in #1647 did not take into account that the starknet state might have been changed.

If we ever encounter a case where the multicall payload was wrongly formed and the number of executed calls doesn't match the input, we should revert the tx immediately.