### PR TITLE
ci: disable cairo-native

### DIFF
--- a/.github/workflows/ssj-ef-tests.yml
+++ b/.github/workflows/ssj-ef-tests.yml
@@ -34,21 +34,6 @@ jobs:
       - name: Make setup script executable
         run: chmod +x ./cairo/kakarot-ssj/scripts/setup_cairo_native.sh
 
-      - name: Setup Cairo Native
-        run: |
-          if [[ "${{ steps.cache-cairo-native.outputs.cache-hit }}" == 'true' ]]; then
-            sudo ./cairo/kakarot-ssj/scripts/setup_cairo_native.sh -s
-          else
-            sudo ./cairo/kakarot-ssj/scripts/setup_cairo_native.sh
-          fi
-
-      - name: Set Environment Variables
-        run: |
-          echo "MLIR_SYS_190_PREFIX=/usr/lib/llvm-19/" >> $GITHUB_ENV
-          echo "LLVM_SYS_191_PREFIX=/usr/lib/llvm-19/" >> $GITHUB_ENV
-          echo "TABLEGEN_190_PREFIX=/usr/lib/llvm-19/" >> $GITHUB_ENV
-          echo "CAIRO_NATIVE_RUNTIME_LIBRARY=$(pwd)/libcairo_native_runtime.a" >> $GITHUB_ENV
-
       - name: Checkout ef-tests
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ssj-ef-tests.yml
+++ b/.github/workflows/ssj-ef-tests.yml
@@ -86,7 +86,7 @@ jobs:
         working-directory: ef-tests
         run: |
           set -o pipefail
-          RUST_MIN_STACK=1342177280 make ef-test-v1-native | tee test_v1.out
+          RUST_BACKTRACE=1 RUST_MIN_STACK=1342177280 make ef-test-v1-native | tee test_v1.out
           set +o pipefail
 
       - name: Retrieve ef-tests execution resources

--- a/.github/workflows/ssj-ef-tests.yml
+++ b/.github/workflows/ssj-ef-tests.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           repository: kkrt-labs/ef-tests
           path: ef-tests # Check out to a subdirectory to avoid cleaning the kakarot-ssj directory
-          ref: ci/add-native-runtime-env
 
       - name: Checkout local skip file
         uses: actions/checkout@v4
@@ -85,9 +84,11 @@ jobs:
 
       - name: Run tests
         working-directory: ef-tests
+        # If we want to enable native mode:
+        # RUST_MIN_STACK=1342177280 make ef-test-v1-native | tee test_v1.out
         run: |
           set -o pipefail
-          RUST_BACKTRACE=1 RUST_MIN_STACK=1342177280 make ef-test-v1-native | tee test_v1.out
+          make ef-test-v1 | tee test_v1.out
           set +o pipefail
 
       - name: Retrieve ef-tests execution resources

--- a/.github/workflows/ssj-ef-tests.yml
+++ b/.github/workflows/ssj-ef-tests.yml
@@ -11,28 +11,30 @@ permissions: read-all
 
 jobs:
   ef-tests:
+    env:
+      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
+      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
+      TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Cache cairo-native setup
-        id: cache-cairo-native
-        uses: actions/cache@v3
+      - name: add llvm deb repository
+        uses: myci-actions/add-deb-repo@11
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            cairo/kakarot-ssj/target/
-            ./libcairo_native_runtime.a
-          key:
-            ${{ runner.os }}-cairo-native-${{ hashFiles('**/Cargo.lock',
-            'scripts/setup_cairo_native.sh') }}
-
-      - name: Make setup script executable
-        run: chmod +x ./cairo/kakarot-ssj/scripts/setup_cairo_native.sh
+          repo: deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+          repo-name: llvm-repo
+          keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+      - name: Update and upgrade APT
+        shell: bash
+        run: sudo apt-get update && sudo apt-get upgrade -y
+      - name: Install LLVM
+        run:
+          sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19
+          clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
+          libgmp3-dev libzstd-dev lld libssl-dev zstd
+      - name: Add llvm bin to PATH
+        run: echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
 
       - name: Checkout ef-tests
         uses: actions/checkout@v4

--- a/.github/workflows/ssj-ef-tests.yml
+++ b/.github/workflows/ssj-ef-tests.yml
@@ -53,7 +53,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kkrt-labs/ef-tests
-          ref: feat/cairo-native
           path: ef-tests # Check out to a subdirectory to avoid cleaning the kakarot-ssj directory
 
       - name: Checkout local skip file

--- a/.github/workflows/ssj-ef-tests.yml
+++ b/.github/workflows/ssj-ef-tests.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           repository: kkrt-labs/ef-tests
           path: ef-tests # Check out to a subdirectory to avoid cleaning the kakarot-ssj directory
+          ref: ci/add-native-runtime-env
 
       - name: Checkout local skip file
         uses: actions/checkout@v4

--- a/cairo/kakarot-ssj/blockchain-tests-skip.yml
+++ b/cairo/kakarot-ssj/blockchain-tests-skip.yml
@@ -44,6 +44,12 @@ testname:
   initcode:
     - contract_creating_tx__fork_Cancun_minus_blockchain_test_minus_over_limit_ones
     - contract_creating_tx__fork_Cancun_minus_blockchain_test_minus_over_limit_zeros
+    - create_opcode_initcode__fork_Cancun_minus_blockchain_test_minus_create2_minus_49120_bytes #RunResources error
+    - create_opcode_initcode__fork_Cancun_minus_blockchain_test_minus_create2_minus_49121_bytes #RunResources error
+    - create_opcode_initcode__fork_Cancun_minus_blockchain_test_minus_create2_minus_max_size_ones #RunResources error
+    - create_opcode_initcode__fork_Cancun_minus_blockchain_test_minus_create2_minus_max_size_zeros #RunResources error
+    - create_opcode_initcode__fork_Cancun_minus_blockchain_test_minus_create2_minus_over_limit_ones #RunResources error
+    - create_opcode_initcode__fork_Cancun_minus_blockchain_test_minus_create2_minus_over_limit_zeros #RunResources error
   stEIP3651-warmcoinbase:
     - coinbaseWarmAccountCallGasFail_d0g0v0_Cancun
   vmIOandFlowOperations:
@@ -201,6 +207,8 @@ testname:
     - createInitFailStackSizeLargerThan1024_d0g0v0_Cancun
     - Call1024PreCalls_d0g0v0_Cancun
     - Call1024PreCalls_d0g1v0_Cancun
+  vmArithmeticTest:
+    - twoOps_d0g0v0_Cancun #RunResources error
   stCreate2:
     - Create2OnDepth1023_d0g0v0_Cancun
     - Create2OnDepth1024_d0g0v0_Cancun
@@ -213,6 +221,9 @@ testname:
     - CreateOOGafterMaxCodesize_d2g0v0_Cancun
     - CreateOOGafterMaxCodesize_d3g0v0_Cancun
     - CreateOOGafterMaxCodesize_d5g0v0_Cancun
+    - CREATE_ContractRETURNBigOffset_d3g0v0_Cancun #RunResources error
+    - CreateOOGafterMaxCodesize_d0g0v0_Cancun #RunResources error
+    - CreateOOGafterMaxCodesize_d1g0v0_Cancun #RunResources error
   stEIP150Specific:
     - Transaction64Rule_integerBoundaries_d0g0v0_Cancun
     - Transaction64Rule_integerBoundaries_d10g0v0_Cancun
@@ -241,6 +252,47 @@ testname:
   stEIP1559:
     - baseFeeDiffPlaces_d34g0v0_Cancun
     - gasPriceDiffPlaces_d34g0v0_Cancun
+    - baseFeeDiffPlaces_d0g0v0_Cancun
+    - baseFeeDiffPlaces_d10g0v0_Cancun
+    - baseFeeDiffPlaces_d11g0v0_Cancun
+    - baseFeeDiffPlaces_d12g0v0_Cancun
+    - baseFeeDiffPlaces_d13g0v0_Cancun
+    - baseFeeDiffPlaces_d14g0v0_Cancun
+    - baseFeeDiffPlaces_d15g0v0_Cancun
+    - baseFeeDiffPlaces_d16g0v0_Cancun
+    - baseFeeDiffPlaces_d17g0v0_Cancun
+    - baseFeeDiffPlaces_d18g0v0_Cancun
+    - baseFeeDiffPlaces_d19g0v0_Cancun
+    - baseFeeDiffPlaces_d1g0v0_Cancun
+    - baseFeeDiffPlaces_d20g0v0_Cancun
+    - baseFeeDiffPlaces_d21g0v0_Cancun
+    - baseFeeDiffPlaces_d22g0v0_Cancun
+    - baseFeeDiffPlaces_d23g0v0_Cancun
+    - baseFeeDiffPlaces_d24g0v0_Cancun
+    - baseFeeDiffPlaces_d25g0v0_Cancun
+    - baseFeeDiffPlaces_d26g0v0_Cancun
+    - baseFeeDiffPlaces_d27g0v0_Cancun
+    - baseFeeDiffPlaces_d28g0v0_Cancun
+    - baseFeeDiffPlaces_d29g0v0_Cancun
+    - baseFeeDiffPlaces_d2g0v0_Cancun
+    - baseFeeDiffPlaces_d30g0v0_Cancun
+    - baseFeeDiffPlaces_d31g0v0_Cancun
+    - baseFeeDiffPlaces_d32g0v0_Cancun
+    - baseFeeDiffPlaces_d33g0v0_Cancun
+    - baseFeeDiffPlaces_d3g0v0_Cancun
+    - baseFeeDiffPlaces_d4g0v0_Cancun
+    - baseFeeDiffPlaces_d5g0v0_Cancun
+    - baseFeeDiffPlaces_d6g0v0_Cancun
+    - baseFeeDiffPlaces_d7g0v0_Cancun
+    - baseFeeDiffPlaces_d8g0v0_Cancun
+    - baseFeeDiffPlaces_d9g0v0_Cancun
+    - lowFeeCap_d0g0v0_Cancun
+    - lowGasPriceOldTypes_d0g0v0_Cancun
+    - lowGasPriceOldTypes_d1g0v0_Cancun
+    - senderBalance_d0g0v0_Cancun
+  stExample:
+    - eip1559_d0g0v0_Cancun
+    - mergeTest_d0g0v0_Cancun
   stExtCodeHash:
     - extCodeHashDynamicArgument_d1g0v0_Cancun
     - dynamicAccountOverwriteEmpty_Paris_d0g0v0_Cancun
@@ -255,6 +307,10 @@ testname:
     - stackLimitPush32_1024_d0g0v0_Cancun
     - stackLimitPush32_1025_d0g0v0_Cancun
   stPreCompiledContracts2:
+    - CALLCODEIdentity_5_d0g0v0_Cancun #RunResources error
+    - CALLCODESha256_5_d0g0v0_Cancun #RunResources error
+    - CallIdentity_5_d0g0v0_Cancun #RunResources error
+    - CallSha256_5_d0g0v0_Cancun #RunResources error
     - CALLCODERipemd160_0_d0g0v0_Cancun
     - CALLCODERipemd160_1_d0g0v0_Cancun
     - CALLCODERipemd160_2_d0g0v0_Cancun
@@ -360,6 +416,8 @@ testname:
     - modexp_d30g2v0_Cancun
     - modexp_d30g3v0_Cancun
   stQuadraticComplexityTest:
+    - Call50000_d0g0v0_Cancun #RunResources error
+    - Callcode50000_d0g0v0_Cancun #RunResources error
     - Call20KbytesContract50_1_d0g0v0_Cancun
     - Call20KbytesContract50_2_d0g0v0_Cancun
     - Call20KbytesContract50_3_d0g0v0_Cancun
@@ -381,6 +439,10 @@ testname:
     - Return50000_d0g0v0_Cancun
     - Return50000_d0g1v0_Cancun
   stRandom2:
+    - randomStatetest448_d0g0v0_Cancun #RunResources error
+    - randomStatetest456_d0g0v0_Cancun #RunResources error
+    - randomStatetest589_d0g0v0_Cancun #RunResources error
+    - randomStatetest643_d0g0v0_Cancun #RunResources error
     - randomStatetest415_d0g0v0_Cancun
     - randomStatetest418_d0g0v0_Cancun
     - randomStatetest433_d0g0v0_Cancun
@@ -398,6 +460,10 @@ testname:
     - randomStatetest476_d0g0v0_Cancun
     - randomStatetest650_d0g0v0_Cancun
   stRandom:
+    - randomStatetest151_d0g0v0_Cancun #RunResources error
+    - randomStatetest205_d0g0v0_Cancun #RunResources error
+    - randomStatetest341_d0g0v0_Cancun #RunResources error
+    - randomStatetest53_d0g0v0_Cancun #RunResources error
     - randomStatetest111_d0g0v0_Cancun
     - randomStatetest14_d0g0v0_Cancun
     - randomStatetest150_d0g0v0_Cancun
@@ -519,6 +585,11 @@ testname:
     - shiftCombinations_d0g0v0_Cancun
     - shiftSignedCombinations_d0g0v0_Cancun
   stStaticCall:
+    - static_Call10_d0g0v0_Cancun #RunResources error
+    - static_Call10_d1g0v0_Cancun #RunResources error
+    - static_Call1MB1024Calldepth_d0g0v0_Cancun #RunResources error
+    - static_CallIdentity_5_d0g0v0_Cancun #RunResources error
+    - static_CallSha256_5_d0g0v0_Cancun #RunResources error
     - static_Call1024BalanceTooLow2_d1g0v0_Cancun
     - static_Call1024BalanceTooLow_d1g0v0_Cancun
     - static_Call1024PreCalls2_d0g0v0_Cancun
@@ -590,6 +661,9 @@ testname:
     - static_LoopCallsThenRevert_d0g1v0_Cancun
     - static_Return50000_2_d0g0v0_Cancun
   stSystemOperationsTest:
+    - Call10_d0g0v0_Cancun #RunResources error
+    - CallRecursiveBombLog2_d0g0v0_Cancun #RunResources error
+    - CallRecursiveBombLog_d0g0v0_Cancun #RunResources error
     - CallRecursiveBomb0_OOG_atMaxCallDepth_d0g0v0_Cancun
   stZeroKnowledge:
     - ecpairing_bad_length_191_d0g0v0_Cancun

--- a/cairo/kakarot-ssj/crates/contracts/Scarb.toml
+++ b/cairo/kakarot-ssj/crates/contracts/Scarb.toml
@@ -3,8 +3,6 @@ name = "contracts"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet.workspace = true
 evm = { path = "../evm" }


### PR DESCRIPTION
- Ensured that we could run the CI in native mode by having the right llvm deps installed
HOWEVER
- Disabled Cairo Native as the run was taking an overly long time.
- updated SSJ skipfile because some tests are now Out Of Resources.