### PR TITLE
docs: typo fix Update cairo_precompiles.md

### DIFF
--- a/docs/general/cairo_precompiles.md
+++ b/docs/general/cairo_precompiles.md
@@ -22,7 +22,7 @@ precompile will never cause the transaction to revert, meaning that:
 
 - The target Cairo addresses should always correspond to a deployed contract
 - The selector of the Cairo function being called should always be present in
-  the contract called
+  the called contract
 - The Cairo contract called should never _panic_
 
 From these principles, we can derive the following design.


### PR DESCRIPTION
## Description

I noticed a small grammatical issue in the documentation regarding the Cairo precompiles section. The sentence:

> "The selector of the Cairo function being called should always be present in the contract called."

was a bit awkward and not quite in line with proper English syntax. It should read:

> "The selector of the Cairo function being called should always be present in the called contract."

**The change was made to correct the word order and ensure clarity.**

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):
