### PR TITLE
Fix assignment syntax for native_token_address in Cairo code

### DIFF
--- a/cairo_zero/backend/starknet.cairo
+++ b/cairo_zero/backend/starknet.cairo
@@ -43,7 +43,7 @@ namespace Starknet {
         self: model.State*
     ) {
         alloc_locals;
-        let (native_token_address) = Kakarot_native_token_address.read();
+        let native_token_address = Kakarot_native_token_address.read();
 
         // Accounts
         Internals._commit_accounts{state=self}(


### PR DESCRIPTION
In the original code, the assignment for `native_token_address` was written as:

```python
let (native_token_address) = Kakarot_native_token_address.read();
```

This included unnecessary parentheses, which is incorrect in Cairo syntax. The correct assignment should be:

```python
let native_token_address = Kakarot_native_token_address.read();
```

The fix is important because using parentheses in this context would cause a syntax error or unexpected behavior in the Cairo language, preventing the code from compiling or running correctly. Removing the parentheses ensures the proper assignment syntax and maintains the correctness of the code.

This update resolves the issue and improves the overall stability and readability of the code.

## Pull request type

Please check the type of change your PR introduces:

- [x] Code style update (formatting, renaming)