### PR TITLE
Fix Typos

### DIFF
--- a/cairo/kakarot-ssj/README.md
+++ b/cairo/kakarot-ssj/README.md
@@ -48,7 +48,7 @@
 
 ## About
 
-Kakarot is an (zk)-Ethereum Virtual Machine implementation written in Cairo.
+Kakarot is a (zk)-Ethereum Virtual Machine implementation written in Cairo.
 Kakarot is Ethereum compatible, i.e. all existing smart contracts, developer
 tools and wallets work out-of-the-box on Kakarot. It's been open source from day
 one. Soon available on Starknet L2 and Appchains.

--- a/docs/general/cairo_precompiles.md
+++ b/docs/general/cairo_precompiles.md
@@ -367,7 +367,7 @@ smaller than the field element size, and the resulting `data` array is of
 size 2.
 
 Similarly, the return data of the Cairo contract is deserialized into a
-`uint256[]` where each returned felt has been cast to a uint256.
+`uint256[]` where each returned felt has been cast to an uint256.
 
 > Note: It is left to the responsibility of the wrapper contract developer to
 > ensure that the calldata is correctly serialized to match the Cairo contract's


### PR DESCRIPTION
This pull request addresses minor typos in the documentation for better readability and consistency.  

**Changes Made:**  
1. **README.md:**  
   - Corrected the article from "(zk)-Ethereum" to "a (zk)-Ethereum" for grammatical accuracy.  

2. **cairo_precompiles.md:**  
   - Replaced "a uint256" with "an uint256" to reflect proper article usage based on pronunciation.  

### Time Spent  
Approximately 0.25 days.  

### Pull Request Type  
- [x] Documentation content changes  

### Current Behavior  
The documentation contained minor grammatical errors that could potentially cause confusion or reduce the professionalism of the text.  

### New Behavior  
The updated text improves grammatical accuracy and clarity without changing the technical content.  

### Breaking Changes  
- [ ] Yes  
- [x] No  
