### PR TITLE
Update Twitter Link and Test Gas Documentation

### DIFF
--- a/cairo/kakarot-ssj/README.md
+++ b/cairo/kakarot-ssj/README.md
@@ -145,7 +145,7 @@ Reach out to the maintainer at one of the following places:
 If you want to say **thank you** or/and support active development of Kakarot:
 
 - Add a [GitHub Star](https://github.com/kkrt-labs/kakarot-ssj) to the project.
-- Tweet about [Kakarot](https://twitter.com/KakarotZkEvm).
+- Tweet about [Kakarot](https://x.com/KakarotZkEvm).
 - Write interesting articles about the project on [Dev.to](https://dev.to/),
   [Medium](https://medium.com/), [Mirror](https://mirror.xyz/) or your personal
   blog.

--- a/cairo_zero/tests/src/kakarot/test_gas.py
+++ b/cairo_zero/tests/src/kakarot/test_gas.py
@@ -65,7 +65,7 @@ class TestGas:
             )
 
             # If the memory expansion is greater than 2**27 words of 32 bytes
-            # We saturate it to the hardcoded value corresponding the the gas cost of a 2**32 memory size
+            # We saturate it to the hardcoded value corresponding the gas cost of a 2**32 memory size
             expected_saturated = (
                 memory_cost_u32
                 if (words_len * 32 + expansion.expand_by) >= 2**32


### PR DESCRIPTION

Changes Made:

1. File: cairo/kakarot-ss1/README.md
- Old: https://twitter.com/kakarotEvmm
- New: x.com/kakarotEvmm
Reason: Updated to reflect Twitter's rebranding to X

2. File: cairo_zero/tests/src/kakarot/test_gas.py 
- Old: # We saturate it to the hardcoded value corresponding the the gas cost
- New: # We saturate it to the hardcoded value corresponding the gas cost
Reason: Fixed grammatical error by removing duplicate "the"

These changes improve documentation accuracy and readability while keeping external links current.
