### PR TITLE
fix: typos in documentation files

### DIFF
--- a/cairo/kakarot-ssj/crates/evm/src/stack.cairo
+++ b/cairo/kakarot-ssj/crates/evm/src/stack.cairo
@@ -205,7 +205,7 @@ impl StackImpl of StackTrait {
     ///
     /// # Errors
     ///
-    /// If the stack length is less than than N, returns with a StackUnderflow error.
+    /// If the stack length is less than N, returns with a StackUnderflow error.
     fn pop_n(ref self: Stack, mut n: usize) -> Result<Array<u256>, EVMError> {
         ensure(!(n > self.len()), EVMError::StackUnderflow)?;
         let mut popped_items = ArrayTrait::<u256>::new();

--- a/cairo_zero/tests/src/kakarot/test_gas.py
+++ b/cairo_zero/tests/src/kakarot/test_gas.py
@@ -65,7 +65,7 @@ class TestGas:
             )
 
             # If the memory expansion is greater than 2**27 words of 32 bytes
-            # We saturate it to the hardcoded value corresponding the the gas cost of a 2**32 memory size
+            # We saturate it to the hardcoded value corresponding the gas cost of a 2**32 memory size
             expected_saturated = (
                 memory_cost_u32
                 if (words_len * 32 + expansion.expand_by) >= 2**32


### PR DESCRIPTION
Corrected `less than than N` to `less than N`
Corrected `corresponding the the gas` to `corresponding the gas`