### PR TITLE
docs: Correct grammar in account information storage description

### DIFF
--- a/cairo/kakarot-ssj/docs/general/contract_storage.md
+++ b/cairo/kakarot-ssj/docs/general/contract_storage.md
@@ -15,7 +15,7 @@ _Account state associated to an Ethereum address. Source:
 [EVM Illustrated](https://takenobu-hs.github.io/downloads/ethereum_evm_illustrated.pdf)_
 
 In traditional EVM clients, like Geth, the _world state_ is stored as a _trie_,
-and information about accounts are stored in the world state trie and can be
+and information about accounts is stored in the world state trie and can be
 retrieved through queries. Each account in the world state trie is associated
 with an account storage trie, which stores all of the information related to the
 account. When Geth updates the storage of a contract by executing the SSTORE


### PR DESCRIPTION
### Description

While reviewing the documentation, I noticed a grammatical error in the sentence "information about accounts are stored." Since "information" is an uncountable noun, it should be followed by a singular verb.

I've corrected it to "information about accounts **is** stored" for clarity and accuracy.  

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):