### PR TITLE
docs: Fix typos in documentation: local_state.md and machine.md

### DIFF
--- a/cairo/kakarot-ssj/docs/general/local_state.md
+++ b/cairo/kakarot-ssj/docs/general/local_state.md
@@ -19,7 +19,7 @@ from using dicts in self-referring data structures, instead of having one state
 per execution context that we could merge into the parent state if the context
 exits successfully or discard if the context reverts, we have one global `State`
 structs that achieves the same behavior by tracking transactional changes, which
-refers to the changes made inside the current transaction as a whole, and a
+refers to the changes made inside the current transaction as a whole, and 
 contextual changes, which refers to changes made inside the current execution
 context.
 

--- a/cairo/kakarot-ssj/docs/general/machine.md
+++ b/cairo/kakarot-ssj/docs/general/machine.md
@@ -4,7 +4,7 @@ The EVM is a stack-based computer responsible for the execution of EVM bytecode.
 It has two context-bound data structures: the stack and the memory. The stack is
 a 256bit-words based data structure used to store and retrieve intermediate
 values during the execution of opcodes. The memory is a byte-addressable data
-structure organized into 32-byte words used a volatile space to store data
+structure organized into 32-byte words used volatile space to store data
 during execution. Both the stack and the memory are initialized empty at the
 start of a call context, and destroyed when a call context ends.
 


### PR DESCRIPTION
## Description

I noticed a couple of minor typos that could cause confusion:  

1. **File:** `docs/general/local_state.md`  
   **Original:** "a contextually changes, which refers to changes made inside the current execution context."  
   **Fixed:** Removed the unnecessary "a" to make it: "contextual changes, which refers to changes made inside the current execution context."  

2. **File:** `docs/general/machine.md`  
   **Original:** "used a volatile space to store data during execution."  
   **Fixed:** Adjusted for grammatical correctness by changing it to: "used as volatile space to store data during execution."  

Time spent on this PR: 17 mins

## Pull request type

Please check the type of change your PR introduces:

- [x] Documentation content changes

