### PR TITLE
changes

### DIFF
--- a/cairo_zero/kakarot/instructions/block_information.cairo
+++ b/cairo_zero/kakarot/instructions/block_information.cairo
@@ -17,7 +17,7 @@ from kakarot.stack import Stack
 from kakarot.state import State
 from utils.utils import Helpers
 
-// @title BlockInformation information opcodes.
+// @title BlockInformation opcodes.
 // @notice This file contains the functions to execute for block information opcodes.
 namespace BlockInformation {
     func exec_block_information{

--- a/cairo_zero/kakarot/instructions/stop_and_math_operations.cairo
+++ b/cairo_zero/kakarot/instructions/stop_and_math_operations.cairo
@@ -79,7 +79,7 @@ namespace StopAndMathOperations {
 
         // To cast the codeoffset opcodes_label to a model.Opcode*, we need to use it to offset
         // the current pc. We get the pc from the `get_fp_and_pc` util and assign a codeoffset (pc_label) to it.
-        // In short, this boilds down to: opcode = pc + offset - pc = offset
+        // In short, this boils down to: opcode = pc + offset - pc = offset
         let (_, pc) = get_fp_and_pc();
 
         pc_label:
@@ -91,7 +91,7 @@ namespace StopAndMathOperations {
         local stack: model.Stack* = stack;
 
         // offset is 1 (new line) + 2 (jmp + label) per opcode
-        // opcode is offset from by 0x1 (index of the first opcode)
+        // opcode is offset by 0x1 (index of the first opcode)
         tempvar offset = 2 * (opcode_number - 0x01) + 1;
 
         tempvar range_check_ptr = range_check_ptr;

--- a/cairo_zero/kakarot/instructions/system_operations.cairo
+++ b/cairo_zero/kakarot/instructions/system_operations.cairo
@@ -1010,7 +1010,7 @@ namespace CallHelper {
         }
 
         if (evm.reverted == Errors.EXCEPTIONAL_HALT) {
-            // If the call has halted exceptionnaly, the return_data is empty
+            // If the call has halted exceptionally, the return_data is empty
             // and nothing is copied to memory, and the gas is not returned;
             tempvar evm = new model.EVM(
                 message=message,


### PR DESCRIPTION

## Changes Made

1. cairo_zero/kakarot/instructions/block_information.cairo:
- // @title BlockInformation information opcodes.
+ // @title BlockInformation opcodes.

2. cairo_zero/kakarot/instructions/stop_and_math_operations.cairo:
- // In short, this boilds down to: opcode = pc + offset - pc = offset
+ // In short, this boils down to: opcode = pc + offset - pc = offset

3. cairo_zero/kakarot/instructions/system_operations.cairo:
- // If the call has halted exceptionaly, the return_data is empty
+ // If the call has halted exceptionally, the return_data is empty


