### PR TITLE
# **Fix Dockerfile: Sort package names alphanumerically**

### DIFF
--- a/docker/deployer/Dockerfile
+++ b/docker/deployer/Dockerfile
@@ -40,15 +40,15 @@ RUN curl -L https://foundry.paradigm.xyz -o foundry.sh \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
+    build-essential \
     ca-certificates \
-    wget \
-    tar \
-    unzip \
-    jq \
     gcc \
+    jq \
     libgmp-dev \
     python3-dev \
-    build-essential \
+    tar \
+    unzip \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 ARG GITHUB_TOKEN


### PR DESCRIPTION
# **Fix Dockerfile: Sort package names alphanumerically**

## **Description**
This pull request fixes the ordering of package names in the `Dockerfile` to follow alphanumeric sorting, as per best practices and linting guidelines.

## **Changes Made**
- Sorted the package names in the `apt-get install` command alphanumerically.

## **Reason for Change**
- Improve readability and maintainability of the `Dockerfile`.
- Ensure compliance with code style guidelines.

## **Checklist**
- [x] Package names sorted correctly.
- [x] Dockerfile builds successfully.

## **Related Issues**
N/A

-
-
-
